### PR TITLE
Add long config flag to Viceroy

### DIFF
--- a/cli/src/opts.rs
+++ b/cli/src/opts.rs
@@ -30,7 +30,7 @@ pub struct Opts {
     )]
     input: PathBuf,
     /// The path to a TOML file containing `local_server` configuration.
-    #[structopt(short = "C")]
+    #[structopt(short = "C", long = "config")]
     config_path: Option<PathBuf>,
     /// Whether to treat stdout as a logging endpoint
     // NB: struct_opt won't let us use `default_value` here, but the default is `false`


### PR DESCRIPTION
We only had the short `-C` flag to pass in a config for Viceroy, but
some people would prefer a longer `--config`. This is also useful for
those learning how to use Viceroy to know what the flags mean, rather
than their shorthand version.

Closes #3