### PR TITLE
🐦 update crates to new development version (0.2.2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2079,7 +2079,7 @@ checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
 
 [[package]]
 name = "viceroy-cli"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "futures",
@@ -2097,7 +2097,7 @@ dependencies = [
 
 [[package]]
 name = "viceroy-lib"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "bytes",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "viceroy-cli"
 description = "Viceroy is a local testing daemon for Compute@Edge."
-version = "0.2.1"
+version = "0.2.2"
 authors = ["Fastly"]
 edition = "2018"
 license = "Apache-2.0 WITH LLVM-exception"
@@ -14,7 +14,7 @@ path = "src/main.rs"
 itertools = "0.10.0"
 structopt = "0.3.21"
 tokio = {version = "1.2", features = ["full"]}
-viceroy-lib = {path = "../lib", version = "^0.2.1"}
+viceroy-lib = {path = "../lib", version = "^0.2.2"}
 tracing = "0.1.26"
 tracing-subscriber = "0.2.19"
 tracing-futures = "0.2.5"

--- a/cli/tests/trap-test/Cargo.lock
+++ b/cli/tests/trap-test/Cargo.lock
@@ -1967,7 +1967,7 @@ checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
 
 [[package]]
 name = "viceroy-lib"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "bytes 1.0.1",

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "viceroy-lib"
-version = "0.2.1"
+version = "0.2.2"
 description = "Viceroy implementation details."
 authors = ["Fastly"]
 edition = "2018"


### PR DESCRIPTION
Follow-up to #28, bumps our in-tree versions so that they reflect what the next release will be.