### PR TITLE
Allow more functions per wasm module

### DIFF
--- a/lib/src/execute.rs
+++ b/lib/src/execute.rs
@@ -68,6 +68,8 @@ impl ExecuteCtx {
             types: 200,
             // AssemblyScript applications tend to create a fair number of globals
             globals: 64,
+            // Some applications create a large number of functions, in particular in debug mode
+            functions: 20000,
             ..ModuleLimits::default()
         };
 


### PR DESCRIPTION
Some services can contain a very large number of functions, in particular when compiled in debug mode, so to debug them in Viceroy requires a higher limit