### PR TITLE
Make GH Actions also run on MacOS and Windows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ jobs:
     strategy:
       matrix:
         rust-toolchain: [1.52.1]
-        platform: [ubuntu-latest]
+        platform: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.platform }}
     steps:
     - name: Checkout code


### PR DESCRIPTION
We support all Tier 1 platforms that Rust uses, but we have not been
testing that they also build on other platforms besides Linux. With this
change CI will also make sure that a build will work on these platforms
as well, letting us catch any OS specific breakages that we might not
catch developing Viceroy on our own machines.

Closes #6 