### PR TITLE
🧹 Tidy up logging and error output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,6 +130,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b700ce4376041dcd0a327fd0097c41095743c4c8af8887265942faf1100bd040"
 
 [[package]]
+name = "bytesize"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81a18687293a1546b67c246452202bbbf143d239cb43494cc163da14979082da"
+
+[[package]]
 name = "cap-fs-ext"
 version = "0.13.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2102,6 +2108,7 @@ version = "0.2.2"
 dependencies = [
  "anyhow",
  "bytes",
+ "bytesize",
  "cfg-if",
  "cranelift-entity 0.65.0",
  "fastly-shared",

--- a/cli/src/opts.rs
+++ b/cli/src/opts.rs
@@ -175,7 +175,11 @@ mod opts_tests {
                 kind: ErrorKind::ValueValidation,
                 message,
                 ..
-            }) if message.contains("No such file or directory") => Ok(()),
+            }) if message.contains("No such file or directory")
+                || message.contains("cannot find the path specified") =>
+            {
+                Ok(())
+            }
             res => panic!("unexpected result: {:?}", res),
         }
     }

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -15,6 +15,7 @@ include = [
 [dependencies]
 anyhow = "1.0.31"
 bytes = "1.0.0"
+bytesize = "1.0.0"
 cfg-if = "1.0"
 cranelift-entity = "0.65.0"
 fastly-shared = "0.3.2"

--- a/lib/src/error.rs
+++ b/lib/src/error.rs
@@ -5,7 +5,7 @@ use {crate::wiggle_abi::types::FastlyStatus, url::Url, wiggle::GuestError};
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
     /// Thrown by hostcalls when a buffer is larger than its `*_len` limit.
-    #[error("BufferLengthError: {buf} too long to fit in {len}")]
+    #[error("Buffer length error: {buf} too long to fit in {len}")]
     BufferLengthError {
         buf: &'static str,
         len: &'static str,
@@ -17,7 +17,7 @@ pub enum Error {
     FatalError(String),
 
     /// Error when viceroy has been given an invalid file.
-    #[error("expected a valid Wasm file")]
+    #[error("Expected a valid Wasm file")]
     FileFormat,
 
     #[error(transparent)]
@@ -88,6 +88,9 @@ pub enum Error {
 
     #[error(transparent)]
     DownstreamRequestError(#[from] DownstreamRequestError),
+
+    #[error("{0} is not currently supported for local testing")]
+    NotAvailable(&'static str),
 }
 
 impl Error {

--- a/lib/src/execute.rs
+++ b/lib/src/execute.rs
@@ -19,7 +19,7 @@ use {
         sync::Arc,
     },
     tokio::sync::oneshot::{self, Sender},
-    tracing::{event, info_span, Instrument, Level},
+    tracing::{event, info, info_span, Instrument, Level},
     wasmtime::{Engine, InstancePre, Linker, Module},
 };
 
@@ -229,12 +229,7 @@ impl ExecuteCtx {
         sender: Sender<Response<Body>>,
         remote: IpAddr,
     ) -> Result<(), ExecutionError> {
-        event!(
-            Level::INFO,
-            "handling request {} {}",
-            req.method(),
-            req.uri()
-        );
+        info!("handling request {} {}", req.method(), req.uri());
 
         let session = Session::new(
             req_id,
@@ -281,9 +276,8 @@ impl ExecuteCtx {
             .expect("`memory` is exported")
             .size(&store);
 
-        event!(
-            Level::INFO,
-            "Request completed, using {} bytes of wasm heap",
+        info!(
+            "request completed using {} bytes of WebAssembly heap",
             heap_pages * 64 * 1024
         );
 

--- a/lib/src/execute.rs
+++ b/lib/src/execute.rs
@@ -277,8 +277,8 @@ impl ExecuteCtx {
             .size(&store);
 
         info!(
-            "request completed using {} bytes of WebAssembly heap",
-            heap_pages * 64 * 1024
+            "request completed using {} of WebAssembly heap",
+            bytesize::ByteSize::kib(heap_pages as u64 * 64)
         );
 
         outcome

--- a/lib/src/wiggle_abi/dictionary_impl.rs
+++ b/lib/src/wiggle_abi/dictionary_impl.rs
@@ -12,7 +12,7 @@ use {
 impl FastlyDictionary for Session {
     #[allow(unused_variables)] // FIXME: Remove this directive once implemented.
     fn open(&mut self, name: &GuestPtr<str>) -> Result<DictionaryHandle, Error> {
-        todo!()
+        Err(Error::NotAvailable("Dictionary lookup"))
     }
 
     #[allow(unused_variables)] // FIXME: Remove this directive once implemented.
@@ -23,6 +23,6 @@ impl FastlyDictionary for Session {
         buf: &GuestPtr<u8>,
         buf_len: u32,
     ) -> Result<u32, Error> {
-        todo!()
+        Err(Error::NotAvailable("Dictionary lookup"))
     }
 }

--- a/lib/src/wiggle_abi/geo_impl.rs
+++ b/lib/src/wiggle_abi/geo_impl.rs
@@ -15,6 +15,6 @@ impl FastlyGeo for Session {
         buf_len: u32,
         nwritten_out: &GuestPtr<u32>,
     ) -> Result<(), Error> {
-        todo!()
+        Err(Error::NotAvailable("GeoIP"))
     }
 }

--- a/lib/src/wiggle_abi/req_impl.rs
+++ b/lib/src/wiggle_abi/req_impl.rs
@@ -90,7 +90,7 @@ impl FastlyHttpReq for Session {
         cipher_max_len: u32,
         nwritten_out: &GuestPtr<u32>,
     ) -> Result<(), Error> {
-        todo!()
+        Err(Error::NotAvailable("Client TLS data"))
     }
 
     #[allow(unused_variables)] // FIXME KTM 2020-06-25: Remove this directive once implemented.
@@ -100,7 +100,7 @@ impl FastlyHttpReq for Session {
         protocol_max_len: u32,
         nwritten_out: &GuestPtr<u32>,
     ) -> Result<(), Error> {
-        todo!()
+        Err(Error::NotAvailable("Client TLS data"))
     }
 
     #[allow(unused_variables)] // FIXME KTM 2020-06-25: Remove this directive once implemented.
@@ -110,7 +110,7 @@ impl FastlyHttpReq for Session {
         chello_max_len: u32,
         nwritten_out: &GuestPtr<u32>,
     ) -> Result<(), Error> {
-        todo!()
+        Err(Error::NotAvailable("Client TLS data"))
     }
 
     fn new(&mut self) -> Result<RequestHandle, Error> {

--- a/lib/src/wiggle_abi/uap_impl.rs
+++ b/lib/src/wiggle_abi/uap_impl.rs
@@ -23,6 +23,6 @@ impl FastlyUap for Session {
         patch_len: u32,
         patch_nwritten_out: &GuestPtr<'a, u32>,
     ) -> Result<(), Error> {
-        todo!()
+        Err(Error::NotAvailable("Useragent parsing"))
     }
 }


### PR DESCRIPTION
This PR addresses a few minor UI nits (reported on Slack), as well as a more significant issue: rather than panicking when an unimplemented hostcall is used, we instead yield an error back to the guest. The error reporting infrastructure will print a friendly message, though in most cases the SDK will subsequently panic.