### PR TITLE
Add a Code of Conduct to Viceroy and Contributing file

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,134 @@
+
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+[oss@fastly.com](mailto:oss@fastly.com).
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series
+of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or
+permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior,  harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.0, available at
+[https://www.contributor-covenant.org/version/2/0/code_of_conduct.html][v2.0].
+
+Community Impact Guidelines were inspired by 
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available 
+at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.0]: https://www.contributor-covenant.org/version/2/0/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,70 @@
+# Contributing to Viceroy
+
+First off thank you for wanting to contribute to making Viceroy better! We
+appreciate you taking time to improve the Compute@Edge experience for developers
+everywhere. There are many ways you can contribute that include but aren't
+limited to documentation, opening issues, issue triage, and code contributions.
+We'll cover some of the ways you can contribute below, but if you don't see
+instructions for what you want to do, open up an issue and ask us!
+
+## Table of Contents
+1. Documentation
+1. Feature Requests
+1. Bugs
+1. Issue Triage
+1. Code Contributions
+
+## Documentation
+
+Was something in our documentation unclear? Does something have no documentation,
+but should? This is a perfect way to make an easy contribution to Viceroy. If
+you're not sure what the documentation should contain, please open up an issue!
+We're happy to guide you with the correct information needed or if you already
+know what needs to be done, open up a PR and we'll review it for you before
+merging your changes.
+
+## Feature Requests
+
+Do you think there's something Viceroy should have that would make the
+experience better? Feature requests are a great way to let us know. Before
+opening up a feature request on the issue tracker first make sure that there is
+no currently open issue asking for the same thing. If there's not, open up an
+issue asking for what you want and the motivation behind the change.
+
+## Bugs
+
+Sometimes you run into issues and the code is not working properly. If you do
+run into a bug and you can't figure it out or if you do figure out the bug, open
+up an issue on the issue tracker. Just make sure it's not already an issue that
+has been filed yet. If you do open up an issue let us know what you expected to
+happen, what actually happened, what your operating system is, as well as a case
+we can use to reproduce the issue if you have one!
+
+## Issue Triage
+
+Sometimes issues get stale and are no longer an issue, need to be updated, or
+have been fixed by a PR and were never closed. While we try to stay on top of
+issues and keep the backlog groomed, we are only human and can miss out on
+things. If you find that an issue can be closed,
+
+## Code Contributions
+
+If you want to contribute code to Viceroy thank you! A few things before you do
+get started adding a change and open up a PR
+
+1. Make sure there's a tracking issue for your code change. We don't want you to
+   do a lot of work only for us to reject the PR because it's a feature change
+   we won't accept for instance.
+1. Before opening your PR make sure you have tests and things working locally.
+   You can run `make ci` in order to run the tests we run on CI which includes
+   the test suite, `clippy`, and a `cargo fmt` check
+
+It also helps to understand how we structure Viceroy. Under `cli` is the code
+related to setting up and running the Viceroy CLI tool. This includes things
+like argument parsing, setting up logging, and reading in options. It's fairly
+small on purpose as most of the actual logic that runs Viceroy is found under
+`lib`. This contains all the logic for how Viceroy works. You'll most likely
+make changes here to fix an issue or add functionality!
+
+Thanks again for contributing to Viceroy. We really do appreciate you wanting to
+help out and make it better!


### PR DESCRIPTION
Each of these commits has there own commit that expands upon why each file was added and are worth reading on their own if one wants. Mainly this PR adds these 2 files as was laid out in #25.
Closes #25 