### PR TITLE
Use wasmtime-wasi in async mode

### DIFF
--- a/cli/tests/sleep.rs
+++ b/cli/tests/sleep.rs
@@ -18,5 +18,3 @@ async fn empty_ok_response_by_default_after_sleep() -> TestResult {
 
     Ok(())
 }
-
-

--- a/cli/tests/sleep.rs
+++ b/cli/tests/sleep.rs
@@ -1,0 +1,22 @@
+mod common;
+use common::{Test, TestResult};
+use hyper::{body::to_bytes, StatusCode};
+/// Run a program that only sleeps. This exercises async functionality in wasi.
+/// Check that an empty response is sent downstream by default.
+///
+/// `sleep.wasm` is a guest program which sleeps for 100 milliseconds,then returns.
+#[tokio::test(flavor = "multi_thread")]
+async fn empty_ok_response_by_default_after_sleep() -> TestResult {
+    let resp = Test::using_fixture("sleep.wasm").against_empty().await;
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    assert!(to_bytes(resp.into_body())
+        .await
+        .expect("can read body")
+        .to_vec()
+        .is_empty());
+
+    Ok(())
+}
+
+

--- a/lib/src/linking.rs
+++ b/lib/src/linking.rs
@@ -79,7 +79,7 @@ fn make_wasi_ctx(ctx: &ExecuteCtx, session: &Session) -> Result<WasiCtx, anyhow:
 }
 
 pub fn link_host_functions(linker: &mut Linker<WasmCtx>) -> Result<(), Error> {
-    wasmtime_wasi::add_to_linker(linker, WasmCtx::wasi)?;
+    wasmtime_wasi::tokio::add_to_linker(linker, WasmCtx::wasi)?;
     wiggle_abi::fastly_abi::add_to_linker(linker, WasmCtx::session)?;
     wiggle_abi::fastly_dictionary::add_to_linker(linker, WasmCtx::session)?;
     wiggle_abi::fastly_geo::add_to_linker(linker, WasmCtx::session)?;

--- a/test-fixtures/src/bin/sleep.rs
+++ b/test-fixtures/src/bin/sleep.rs
@@ -1,0 +1,3 @@
+fn main() {
+    std::thread::sleep(std::time::Duration::from_millis(100))
+}


### PR DESCRIPTION
Previously, we linked with the synchronous version of the Wasi import functions, but used the tokio implementations inside them. This led to crashes in wiggle's "dummy executor", which shouldn't be in the picture.

Now we link import functions with `wasmtime_wasi::tokio`'s implementation, which defers to the underlying async engine. And, a test is added to show that this fixes the issue.