### PR TITLE
Allow host overrides in TOML configuration

### DIFF
--- a/cli/tests/common.rs
+++ b/cli/tests/common.rs
@@ -57,9 +57,11 @@ impl Test {
     }
 
     /// Add a backend definition to this test.
-    pub fn backend(mut self, name: &str, url: &str) -> Self {
+    pub fn backend(mut self, name: &str, url: &str, override_host: Option<&str>) -> Self {
         let backend = Backend {
             uri: url.parse().expect("invalid backend URL"),
+            override_host: override_host
+                .and_then(|s| Some(s.parse().expect("can parse override_host"))),
         };
         self.backends.insert(name.to_owned(), Arc::new(backend));
         self

--- a/cli/tests/http-semantics.rs
+++ b/cli/tests/http-semantics.rs
@@ -12,7 +12,7 @@ async fn framing_headers_are_overridden() -> TestResult {
     // Set up the test harness
     let test = Test::using_fixture("bad-framing-headers.wasm")
         // The "TheOrigin" backend checks framing headers on the request and then echos its body.
-        .backend("TheOrigin", "http://127.0.0.1:9000/")
+        .backend("TheOrigin", "http://127.0.0.1:9000/", None)
         .host(9000, |req| {
             assert!(!req.headers().contains_key(header::TRANSFER_ENCODING));
             assert_eq!(
@@ -47,7 +47,7 @@ async fn content_length_is_computed_correctly() -> TestResult {
     // Set up the test harness
     let test = Test::using_fixture("content-length.wasm")
         // The "TheOrigin" backend supplies a fixed-size body.
-        .backend("TheOrigin", "http://127.0.0.1:9000/")
+        .backend("TheOrigin", "http://127.0.0.1:9000/", None)
         .host(9000, |_| {
             Response::new(Vec::from(&b"ABCDEFGHIJKLMNOPQRST"[..]))
         });

--- a/cli/tests/upstream-async.rs
+++ b/cli/tests/upstream-async.rs
@@ -10,7 +10,7 @@ async fn upstream_async_methods() -> TestResult {
     // Set up the test harness
     let test = Test::using_fixture("upstream-async.wasm")
         // Set up the backends, which just return responses with an identifying header
-        .backend("backend1", "http://127.0.0.1:9000/")
+        .backend("backend1", "http://127.0.0.1:9000/", None)
         .host(9000, |_| {
             Response::builder()
                 .header("Backend-1-Response", "")
@@ -18,7 +18,7 @@ async fn upstream_async_methods() -> TestResult {
                 .body(vec![])
                 .unwrap()
         })
-        .backend("backend2", "http://127.0.0.1:9001/")
+        .backend("backend2", "http://127.0.0.1:9001/", None)
         .host(9001, |_| {
             Response::builder()
                 .header("Backend-2-Response", "")

--- a/cli/tests/upstream-streaming.rs
+++ b/cli/tests/upstream-streaming.rs
@@ -11,7 +11,7 @@ async fn upstream_streaming() -> TestResult {
     // Set up the test harness
     let test = Test::using_fixture("upstream-streaming.wasm")
         // The "origin" backend simply echos the request body
-        .backend("origin", "http://127.0.0.1:9000/")
+        .backend("origin", "http://127.0.0.1:9000/", None)
         .host(9000, |req| Response::new(req.into_body()));
 
     // Test with an empty request

--- a/cli/tests/upstream.rs
+++ b/cli/tests/upstream.rs
@@ -2,7 +2,10 @@ mod common;
 
 use {
     common::{Test, TestResult},
-    hyper::{header, Request, Response, StatusCode},
+    hyper::{
+        header::{self, HeaderValue},
+        Request, Response, StatusCode,
+    },
 };
 
 #[tokio::test(flavor = "multi_thread")]
@@ -129,7 +132,7 @@ async fn override_host_works() -> TestResult {
         .host(9000, |req| {
             assert_eq!(
                 req.headers().get(header::HOST),
-                Some(&hyper::header::HeaderValue::from_static("otherhost.com"))
+                Some(&HeaderValue::from_static("otherhost.com"))
             );
             Response::new(vec![])
         });

--- a/lib/src/error.rs
+++ b/lib/src/error.rs
@@ -231,6 +231,15 @@ pub enum BackendConfigError {
     #[error("definition was not provided as a TOML table")]
     InvalidEntryType,
 
+    #[error("invalid override_host: {0}")]
+    InvalidOverrideHost(#[from] http::header::InvalidHeaderValue),
+
+    #[error("'override_host' field is empty")]
+    EmptyOverrideHost,
+
+    #[error("'override_host' field was not a string")]
+    InvalidOverrideHostEntry,
+
     #[error("invalid url: {0}")]
     InvalidUrl(#[from] http::uri::InvalidUri),
 

--- a/lib/src/upstream.rs
+++ b/lib/src/upstream.rs
@@ -86,6 +86,12 @@ pub fn send_request(
         req = Request::from_parts(req_parts, req_body);
     }
 
+    // if requested override the host header
+    if let Some(override_host) = &backend.override_host {
+        req.headers_mut()
+            .insert(hyper::header::HOST, override_host.clone());
+    }
+
     filter_outgoing_headers(req.headers_mut());
 
     Ok(async move {


### PR DESCRIPTION
This adds a new field to the backend definition, override_host,
allowing to override the Host header that will be sent to the
backend.

Addresses #9.