### PR TITLE
🌸 Cherry-pick `trap-test` lockfile update

### DIFF
--- a/cli/tests/trap-test/Cargo.lock
+++ b/cli/tests/trap-test/Cargo.lock
@@ -1855,7 +1855,7 @@ checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
 
 [[package]]
 name = "viceroy-lib"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "bytes",


### PR DESCRIPTION
@fgsch reported this morning that builds on `main`  are currently broken. This was observed in #48, specifically in [this](https://github.com/fastly/Viceroy/runs/3103246326) CI run:

```
cd cli/tests/trap-test && cargo test fatal_error_traps --locked -- --nocapture
error: the lock file /home/runner/work/Viceroy/Viceroy/cli/tests/trap-test/Cargo.lock needs to be updated but --locked was passed to prevent this
```

### Why? How? :woman_shrugging: 

Unfortunate! So, quoth the git log:

```
; git log --oneline --graph -6
*   28e4078 (HEAD -> main, origin/main) Merge pull request #45 from fastly/ajt/release-0.2.2
|\  
| * 3ab0e95 Bump crates to 0.2.3
| * a851065 Update changelog for 0.2.2
* |   e41296d Merge pull request #38 from fastly/mgattozzi/lock-it-down
|\ \  
| |/  
|/|   
| * 72ffecd Have CI use --locked flag for cargo commands
|/  
*   6615217 (tag: v0.2.2) Merge pull request #41 from fastly/ajt/more-release-prep
```

#38 updated CI to use the `--locked` flag on cargo commands, so that we enforce our lockfiles. At the same time, we released `0.2.2` and updated our in-tree `version` in #45 (_See 3ab0e95 in particular_) but left the lockfile in `cli/tests/trap-test` un-touched.

This branch cherry-picks @fgsch's commit to update that lockfile, no more and no less.