### PR TITLE
🧹 Eliminate duplicate documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,77 +50,6 @@ be used to make requests to your Compute@Edge service locally. You can make requ
 by using [curl](https://curl.se/), or you can send a simple GET request by visiting
 the URL in your web browser.
 
-### Configuring backends
-
-Most Compute@Edge services need to make requests to named backends (origin
-servers), which are normally configured using the Fastly UI. For testing with
-Viceroy, you can specify backends in your `fastly.toml` file, which you
-provide to Viceroy using the `-C` flag:
-
-```
-viceroy bin/main.wasm -C fastly.toml
-```
-
-Backends are specified in the TOML file within a `local_server.backends`
-section:
-
-```toml
-[local_server.backends]
-
-[local_server.backends.origin]
-url = "http://localhost:8000"
-
-[local_server.backends.example]
-url = "http://example.com:80"
-```
-
-The host and port are used when routing requests to the named backends while
-testing your Compute@Edge service.
-
-#### Backend path prefixes
-
-Backend URLs can include a path, which will be used as a _prefix_ to the URL of
-any requests your service makes to the backend. Path prefixes are useful when
-simulating multiple backends with a single mock service.
-
-So, for example, you might use the following configuration:
-
-```toml
-[local_server.backends]
-
-[local_server.backends.main]
-url = "http://localhost:8000/main"
-
-[local_server.backends.secondary]
-url = "http://localhost:8000/secondary"
-```
-
-When your service makes a request against the `main` backend with URL
-`/index.html`, it will be routed to the http service on `localhost` at port
-`8000`, against the url `/main/index.html`. Similarly, the same requests
-against the `secondary` backend would route to `/secondary/index.html` on the
-same host.
-
-### Environment variables
-
-Viceroy offers a subset of the environment variables available in Compute@Edge:
-
-* `FASTLY_HOSTNAME`: in Viceroy, this is always set to `localhost`, which
-  provides an easy way for guest code to detect it is running within Viceroy.
-* `FASTLY_TRACE_ID`: in Viceroy, this is an ID starting from 0 and incrementing
-  with each incoming request, providing each guest instance with its own unique
-  ID.
-
-## Limitations
-
-At the moment, Viceroy does not support the full Compute@Edge API. In
-particular:
-
-* GeoIP is unsupported.
-* Dictionaries are unsupported.
-* Caching directives are ignored; no caching is ever performed.
-* Information about the TLS connection from the client is not available.
-
 ## Working with Viceroy's source
 
 Note that this repository uses Git submodules, so you will need to run
@@ -130,6 +59,15 @@ git submodule update --recursive --init
 ```
 
 to pull down or update submodules.
+
+## Documentation
+
+Since the Fastly CLI uses Viceroy under the hood, the two share documentation for
+everything other than CLI differences. You can find general documentation for
+local testing [here][cli], and documentation about configuring local testing
+[here][toml-docs]. Documentation for Viceroy's CLI can be found via `--help`.
+
+[toml-docs]: https://developer.fastly.com/reference/fastly-toml/#local-server
 
 ## Colophon
 


### PR DESCRIPTION
The README was duplicating some of the contents of the official CLI docs. This PR replaces that material with pointers to the devhub docs.