### PR TITLE
add initial work for dictionary support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2112,6 +2112,7 @@ dependencies = [
  "hyper-tls",
  "itertools",
  "lazy_static",
+ "once_cell",
  "regex",
  "semver 0.10.0",
  "serde",

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -43,10 +43,12 @@ pub async fn serve(opts: Opts) -> Result<(), Error> {
     if let Some(config_path) = opts.config_path() {
         let config = FastlyConfig::from_file(config_path)?;
         let backends = config.backends();
+        let dictionaries = config.dictionaries();
         let backend_names = itertools::join(backends.keys(), ", ");
 
         ctx = ctx
             .with_backends(backends.clone())
+            .with_dictionaries(dictionaries.clone())
             .with_config_path(config_path.into());
 
         if backend_names.is_empty() {

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -26,6 +26,7 @@ hyper = {version = "0.14.0", features = ["full"]}
 hyper-tls = "0.5.0"
 itertools = "0.10.1"
 lazy_static = "1.4.0"
+once_cell = "1.8.0"
 regex = "1.3.9"
 semver = "0.10.0"
 serde = "1.0.114"

--- a/lib/src/config/dictionaries.rs
+++ b/lib/src/config/dictionaries.rs
@@ -1,0 +1,105 @@
+use {
+    std::{collections::HashMap, sync::{Arc, Mutex}},
+};
+
+use once_cell::sync::OnceCell;
+
+static INSTANCE: OnceCell<Mutex<u32>> = OnceCell::new();
+
+/// A single backend definition.
+///
+/// Currently, a backend only consists of a [`Uri`], but more fields may be added in the future.
+#[derive(Clone, Debug)]
+pub struct Dictionary {
+    pub name: String,
+    pub id: u32,
+}
+
+/// A map of [`Backend`] definitions, keyed by their name.
+#[derive(Clone, Debug, Default)]
+pub struct DictionariesConfig(pub HashMap<String, Arc<Dictionary>>);
+
+/// This module contains [`TryFrom`] implementations used when deserializing a `fastly.toml`.
+///
+/// These implementations are called indirectly by [`FastlyConfig::from_file`][super::FastlyConfig],
+/// and help validate that we have been given an appropriate TOML schema. If the configuration is
+/// not valid, a [`FastlyConfigError`] will be returned.
+mod deserialization {
+    use {
+        super::{Dictionary, DictionariesConfig, INSTANCE},
+        crate::error::{DictionaryConfigError, FastlyConfigError},
+        std::{convert::TryFrom, sync::{Arc, Mutex}},
+        toml::value::{Table, Value},
+    };
+
+    /// Helper function for converting a TOML [`Value`] into a [`Table`].
+    ///
+    /// This function checks that a value is a [`Value::Table`] variant and returns the underlying
+    /// [`Table`], or returns an error if the given value was not of the right type — e.g., a
+    /// [`Boolean`][Value::Boolean] or a [`String`][Value::String]).
+    fn into_table(value: Value) -> Result<Table, DictionaryConfigError> {
+        match value {
+            Value::Table(table) => Ok(table),
+            _ => Err(DictionaryConfigError::InvalidEntryType),
+        }
+    }
+
+    /// Return an [`DictionaryConfigError::UnrecognizedKey`] error if any unrecognized keys are found.
+    ///
+    /// This should be called after we have removed and validated the keys we expect in a [`Table`].
+    fn check_for_unrecognized_keys(table: &Table) -> Result<(), DictionaryConfigError> {
+        if let Some(key) = table.keys().next() {
+            // While other keys might still exist, we can at least return a helpful error including
+            // the name of *one* unrecognized keys we found.
+            Err(DictionaryConfigError::UnrecognizedKey(key.to_owned()))
+        } else {
+            Ok(())
+        }
+    }
+
+    impl TryFrom<Table> for DictionariesConfig {
+        type Error = FastlyConfigError;
+        fn try_from(toml: Table) -> Result<Self, Self::Error> {
+            /// Process a backend's definitions, or return a [`FastlyConfigError`].
+            fn process_entry(
+                (name, defs): (String, Value),
+            ) -> Result<(String, Arc<Dictionary>), FastlyConfigError> {
+                into_table(defs)
+                    .and_then(Dictionary::try_from)
+                    .map_err(|err| FastlyConfigError::InvalidDictionaryDefinition {
+                        name: name.clone(),
+                        err,
+                    })
+                    .map(|def| (name, Arc::new(def)))
+            }
+
+            toml.into_iter()
+                .map(process_entry)
+                .collect::<Result<_, _>>()
+                .map(Self)
+        }
+    }
+
+    impl TryFrom<Table> for Dictionary {
+        type Error = DictionaryConfigError;
+        fn try_from(mut toml: Table) -> Result<Self, Self::Error> {
+            let name = toml
+                .remove("name")
+                .ok_or(DictionaryConfigError::MissingName)
+                .and_then(|name| match name {
+                    // Value::String(name) => url.parse::<Uri>().map_err(DictionaryConfigError::from),
+                    Value::String(name) => Ok(name),
+                    _ => Err(DictionaryConfigError::InvalidNameEntry),
+                })?;
+            check_for_unrecognized_keys(&toml)?;
+
+            let counter = INSTANCE.get_or_init(|| {
+                Mutex::new(0_u32)
+            });
+            let id = *counter.lock().unwrap() + 1_u32;
+            INSTANCE.set(Mutex::new(id)).unwrap();
+
+            Ok(Self { name, id: id})
+        }
+    }
+}

--- a/lib/src/error.rs
+++ b/lib/src/error.rs
@@ -80,6 +80,9 @@ pub enum Error {
     #[error("Unknown backend: {0}")]
     UnknownBackend(String),
 
+    #[error("Unknown dictionary: {0}")]
+    UnknownDictionary(String),
+
     #[error{"Expected UTF-8"}]
     Utf8Expected(#[from] std::str::Utf8Error),
 
@@ -209,6 +212,13 @@ pub enum FastlyConfigError {
         err: BackendConfigError,
     },
 
+    #[error("invalid configuration for '{name}': {err}")]
+    InvalidDictionaryDefinition {
+        name: String,
+        #[source]
+        err: DictionaryConfigError,
+    },
+
     /// An error that occurred while deserializing the file.
     ///
     /// This represents errors caused by syntactically invalid TOML data, missing fields, etc.
@@ -251,6 +261,28 @@ pub enum BackendConfigError {
 
     #[error("missing 'url' field")]
     MissingUrl,
+
+    #[error("unrecognized key '{0}'")]
+    UnrecognizedKey(String),
+}
+
+/// Errors that may occur while validating dictionary configurations.
+#[derive(Debug, thiserror::Error)]
+pub enum DictionaryConfigError {
+    #[error("definition was not provided as a TOML table")]
+    InvalidEntryType,
+
+    // #[error("invalid url: {0}")]
+    // InvalidUrl(#[from] http::uri::InvalidUri),
+
+    #[error("'name' field was not a string")]
+    InvalidNameEntry,
+
+    #[error("no default definition provided")]
+    MissingDefault,
+
+    #[error("missing 'name' field")]
+    MissingName,
 
     #[error("unrecognized key '{0}'")]
     UnrecognizedKey(String),

--- a/lib/src/execute.rs
+++ b/lib/src/execute.rs
@@ -1,5 +1,7 @@
 //! Guest code execution.
 
+use crate::config::Dictionaries;
+
 use {
     crate::{
         body::Body,
@@ -36,6 +38,8 @@ pub struct ExecuteCtx {
     instance_pre: Arc<InstancePre<WasmCtx>>,
     /// The backends for this execution.
     backends: Arc<Backends>,
+    /// The backends for this execution.
+    dictionaries: Arc<Dictionaries>,
     /// Path to the config, defaults to None
     config_path: Arc<Option<PathBuf>>,
     /// Whether to treat stdout as a logging endpoint
@@ -91,6 +95,7 @@ impl ExecuteCtx {
             engine,
             instance_pre: Arc::new(instance_pre),
             backends: Arc::new(Backends::default()),
+            dictionaries: Arc::new(Dictionaries::default()),
             config_path: Arc::new(None),
             log_stdout: false,
             log_stderr: false,
@@ -112,6 +117,19 @@ impl ExecuteCtx {
     pub fn with_backends(self, backends: Backends) -> Self {
         Self {
             backends: Arc::new(backends),
+            ..self
+        }
+    }
+
+    /// Get the dictionaries for this execution context.
+    pub fn dictionaries(&self) -> &Dictionaries {
+        &self.dictionaries
+    }
+
+    /// Set the dictionaries for this execution context.
+    pub fn with_dictionaries(self, dictionaries: Dictionaries) -> Self {
+        Self {
+            dictionaries: Arc::new(dictionaries),
             ..self
         }
     }
@@ -237,6 +255,7 @@ impl ExecuteCtx {
             sender,
             remote,
             self.backends.clone(),
+            self.dictionaries.clone(),
             self.config_path.clone(),
         );
         // We currently have to postpone linking and instantiation to the guest task

--- a/lib/src/session.rs
+++ b/lib/src/session.rs
@@ -7,7 +7,7 @@ use {
     self::{body_variant::BodyVariant, downstream::DownstreamResponse},
     crate::{
         body::Body,
-        config::{Backend, Backends},
+        config::{Backend, Backends, Dictionaries},
         error::{Error, HandleError},
         logging::LogEndpoint,
         streaming_body::StreamingBody,
@@ -67,6 +67,10 @@ pub struct Session {
     ///
     /// Populated prior to guest execution, and never modified.
     pub(crate) backends: Arc<Backends>,
+    /// The dictionaries configured for this execution.
+    ///
+    /// Populated prior to guest execution, and never modified.
+    pub(crate) dictionaries: Arc<Dictionaries>,
     /// The path to the configuration file used for this invocation of Viceroy.
     ///
     /// Created prior to guest execution, and never modified.
@@ -85,6 +89,7 @@ impl Session {
         resp_sender: Sender<Response<Body>>,
         client_ip: IpAddr,
         backends: Arc<Backends>,
+        dictionaries: Arc<Dictionaries>,
         config_path: Arc<Option<PathBuf>>,
     ) -> Session {
         let (parts, body) = req.into_parts();
@@ -108,6 +113,7 @@ impl Session {
             log_endpoints: PrimaryMap::new(),
             log_endpoints_by_name: HashMap::new(),
             backends,
+            dictionaries,
             config_path,
             pending_reqs: PrimaryMap::new(),
             req_id,
@@ -127,6 +133,7 @@ impl Session {
             Request::new(Body::empty()),
             sender,
             "0.0.0.0".parse().unwrap(),
+            Arc::new(HashMap::new()),
             Arc::new(HashMap::new()),
             Arc::new(None),
         )

--- a/lib/src/wiggle_abi/dictionary_impl.rs
+++ b/lib/src/wiggle_abi/dictionary_impl.rs
@@ -1,5 +1,9 @@
 //! fastly_dictionary` hostcall implementations.
 
+use cranelift_entity::PrimaryMap;
+
+use crate::config::{Dictionary, FastlyConfig};
+
 use {
     crate::{
         error::Error,
@@ -12,7 +16,16 @@ use {
 impl FastlyDictionary for Session {
     #[allow(unused_variables)] // FIXME: Remove this directive once implemented.
     fn open(&mut self, name: &GuestPtr<str>) -> Result<DictionaryHandle, Error> {
-        Err(Error::NotAvailable("Dictionary lookup"))
+        let dicts = self.dictionaries.as_ref();
+        let n = name.as_str().unwrap().to_owned();
+        match dicts.get(&n) {
+            Some(dict) => {
+                Ok(
+                    DictionaryHandle::from(dict.id)
+                )
+            },
+            None => Err(Error::UnknownDictionary(n.clone())),
+        }
     }
 
     #[allow(unused_variables)] // FIXME: Remove this directive once implemented.


### PR DESCRIPTION
- Done: Reading dictionaries from fasty.toml file
- Done: Construct Dictionary and DictionaryHandles
- Done: Implement Dictionary.open
- To do: Reading the dictionary items from fastly.toml file
- To do: Implement Dictionary.get

Feedback for Fastly so far:
It would be really useful to have a few more methods on Dictionary such as:
- `has` to check the existence of an key
- `forEach` to iterate over the items
- `getStream` to read the item value as a stream, this would be good to keep memory use low
