### PR TITLE
Fix a few more warnings from clippy

### DIFF
--- a/cli/tests/common.rs
+++ b/cli/tests/common.rs
@@ -60,8 +60,7 @@ impl Test {
     pub fn backend(mut self, name: &str, url: &str, override_host: Option<&str>) -> Self {
         let backend = Backend {
             uri: url.parse().expect("invalid backend URL"),
-            override_host: override_host
-                .and_then(|s| Some(s.parse().expect("can parse override_host"))),
+            override_host: override_host.map(|s| s.parse().expect("can parse override_host")),
         };
         self.backends.insert(name.to_owned(), Arc::new(backend));
         self

--- a/cli/tests/logging.rs
+++ b/cli/tests/logging.rs
@@ -16,7 +16,7 @@ impl Write for LogWriter {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         match self.0.send(buf.to_owned()) {
             Ok(()) => Ok(buf.len()),
-            Err(_) => Err(io::ErrorKind::ConnectionReset)?,
+            Err(_) => Err(io::ErrorKind::ConnectionReset.into()),
         }
     }
 


### PR DESCRIPTION
Found by clippy when running with `--all-targets`.