### PR TITLE
Default to `./fastly.toml` when config file not specified

### DIFF
--- a/cli/src/opts.rs
+++ b/cli/src/opts.rs
@@ -57,8 +57,10 @@ impl Opts {
     }
 
     /// The path to a `local_server` configuration file.
-    pub fn config_path(&self) -> Option<&Path> {
-        self.config_path.as_deref()
+    pub fn config_path(&self) -> &Path {
+        self.config_path
+            .as_deref()
+            .unwrap_or_else(|| Path::new("./fastly.toml"))
     }
 
     /// Whether to treat stdout as a logging entpoint


### PR DESCRIPTION
This closes #42 