### PR TITLE
📜 0.2.4 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## Unreleased
+
 ## 0.2.4 (2021-09-08)
 
 - Improved error messages when a file could not be read. ([#70](https://github.com/fastly/Viceroy/pull/70))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
-## Unreleased
+## 0.2.4 (2021-09-08)
+
+- Improved error messages when a file could not be read. ([#70](https://github.com/fastly/Viceroy/pull/70))
+- Fixed a bug for dictionary lookups that returned and error rather than `None`. ([#69](https://github.com/fastly/Viceroy/pull/69))
 
 ## 0.2.3 (2021-08-23)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2064,7 +2064,7 @@ checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
 
 [[package]]
 name = "viceroy"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "anyhow",
  "futures",
@@ -2084,7 +2084,7 @@ dependencies = [
 
 [[package]]
 name = "viceroy-lib"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "anyhow",
  "bytes",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "viceroy"
 description = "Viceroy is a local testing daemon for Compute@Edge."
-version = "0.2.4"
+version = "0.2.5"
 authors = ["Fastly"]
 edition = "2018"
 license = "Apache-2.0 WITH LLVM-exception"

--- a/cli/tests/trap-test/Cargo.lock
+++ b/cli/tests/trap-test/Cargo.lock
@@ -1861,7 +1861,7 @@ checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
 
 [[package]]
 name = "viceroy-lib"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "anyhow",
  "bytes",

--- a/doc/RELEASING.md
+++ b/doc/RELEASING.md
@@ -7,6 +7,9 @@ Below are the steps needed to do a Viceroy release:
 1. Update the Changelog so that it contains all of the updates since the previous version as it's own commit
 1. Push a branch in the form `release-x.y.z` where `x`, `y`, and `z` are the major, minor, and patch versions of Viceroy and have the tip of the branch contain the Changelog commit.
 1. Run `make ci` locally to make sure that everything will pass before pushing the branch and opening up a PR
+1. Publish each crate in the workspace. Note that we must do this in order of dependencies. So,
+  1. `cd lib && cargo publish`
+  1. `cd cli && cargo publish`
 1. When you get approval run `git tag vx.y.z HEAD && git push origin --tags` on the branch where `x`, `y`, and `z` again correspond to the Viceroy version to kick off the build for all of the artifacts.
 1. When that is good and completes, push a commit to the branch that bumps Viceroy to the next patch version (so `z + 1`) and updates all the lockfiles again
 1. Get approval again and merge when CI passes

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "viceroy-lib"
-version = "0.2.4"
+version = "0.2.5"
 description = "Viceroy implementation details."
 authors = ["Fastly"]
 edition = "2018"


### PR DESCRIPTION
this branch intends to release a new version of Viceroy.

since our last version, we have merged #69 and #70. the former is a bug-fix worth releasing soon, so let's get it out there!

i'm following the instructions added [here](https://github.com/fastly/Viceroy/blob/main/doc/RELEASING.md), so upon approval I'll push a tag and publish the crates.