### PR TITLE
Log UnknownDictionaryItem errors using DEBUG

### DIFF
--- a/lib/src/wiggle_abi.rs
+++ b/lib/src/wiggle_abi.rs
@@ -134,6 +134,11 @@ impl UserErrorConversion for Session {
                     ),
                 }
             }
+            Error::DictionaryError(ref err) => match err {
+                DictionaryError::UnknownDictionaryItem(_) => {
+                    event!(Level::DEBUG, "Hostcall yielded an error: {}", err);
+                }
+            },
             _ => event!(Level::ERROR, "Hostcall yielded an error: {}", e),
         }
 


### PR DESCRIPTION
The output is still available running viceroy with -v (verbose logging).