### PR TITLE
Support Windows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         rust-toolchain: [stable]
         os: [ubuntu-latest, macos-latest, windows-latest]
-        arch: [amd64, arm64]
+        arch: amd64
         include:
           - os: ubuntu-latest
             name: linux


### PR DESCRIPTION
**NOTE**: I also refactored the workflow to use a 'matrix' so `build-linux` and `build-mac` becomes `build`.