### PR TITLE
Catch Interrupt

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -111,11 +111,17 @@ pub async fn main() -> Result<(), Error> {
 
     install_tracing_subscriber(&opts);
 
-    if let Err(e) = serve(opts).await {
-        event!(Level::ERROR, "{}", e);
+    tokio::select! {
+        _ = tokio::signal::ctrl_c() => {
+            Ok(())
+        }
+        res = serve(opts) => {
+            if let Err(ref e) = res {
+                event!(Level::ERROR, "{}", e);
+            }
+            res
+        }
     }
-
-    Ok(())
 }
 
 fn install_tracing_subscriber(opts: &Opts) {


### PR DESCRIPTION
This patch catches the interrupt signal and returns a zero exit code. I created a test WASM script from [this](https://github.com/fastly/compute-starter-kit-rust-default) repository and checked the status code after adding this patch.

If you feel like this is an acceptable PR, could you please add a `hacktoberfest-accepted` label?

Closes #73