### PR TITLE
GitHub Actions: add aarch64 tarballs for linux and macOS

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,24 +3,34 @@ name: Main
 on:
   push:
     tags:
-      - 'v*.*.*'
+      - "v*.*.*"
 
 jobs:
   build:
     strategy:
       matrix:
         rust-toolchain: [stable]
-        os: [ubuntu-latest, macos-latest, windows-latest]
-        arch: [amd64]
+        os: [ubuntu-latest, macos-11, windows-latest]
+        arch: [amd64, arm64]
+        exclude:
+          - os: windows-latest
+            arch: arm64
         include:
           - os: ubuntu-latest
             name: linux
-          - os: macos-latest
+            rust_abi: unknown-linux-gnu
+          - os: macos-11
             name: darwin
-            rust-target: x86_64-apple-darwin
+            rust_abi: apple-darwin
           - os: windows-latest
             name: windows
+            rust_abi: pc-windows-msvc
             extension: .exe
+          - arch: arm64
+            rust_arch: aarch64
+          - arch: amd64
+            rust_arch: x86_64
+
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
@@ -32,28 +42,46 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           toolchain: ${{ matrix.rust-toolchain }}
-          target: ${{ matrix.rust-target }}
+          target: ${{ matrix.rust_arch }}-${{ matrix.rust_abi }}
           default: true
           override: true
+
+      - name: Install C cross-compilation toolchain
+        if: ${{ matrix.name == 'linux' && matrix.arch != 'amd64' }}
+        run: |
+          sudo apt install -f -y gcc-${{ matrix.rust_arch }}-linux-gnu
+          echo CC=${{ matrix.rust_arch }}-linux-gnu-gcc >> $GITHUB_ENV
+          echo RUSTFLAGS='-C linker=${{ matrix.rust_arch }}-linux-gnu-gcc' >> $GITHUB_ENV
 
       - name: Extract tag name
         uses: olegtarasov/get-tag@v2.1
         id: tagName
 
       - name: Build
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --release --all --locked --target=${{ matrix.rust_arch }}-${{ matrix.rust_abi }}
+
+      - name: Strip symbols (linux)
+        if: ${{ matrix.name == 'linux' }}
         run: |
-          cargo build --all --release --locked
+          ${{ matrix.rust_arch }}-linux-gnu-strip target/${{ matrix.rust_arch }}-${{ matrix.rust_abi }}/release/viceroy${{ matrix.extension }}
+
+      - name: Strip symbols (non-linux)
+        if: ${{ matrix.name != 'linux' }}
+        run: |
+          strip target/${{ matrix.rust_arch }}-${{ matrix.rust_abi }}/release/viceroy${{ matrix.extension }}
 
       - name: Package
         run: |
-          cd target/release
-          strip viceroy${{ matrix.extension }}
+          cd target/${{ matrix.rust_arch }}-${{ matrix.rust_abi }}/release
           tar czf viceroy_${{ steps.tagName.outputs.tag }}_${{ matrix.name }}-${{ matrix.arch }}.tar.gz viceroy${{ matrix.extension }}
 
       - name: Release
         uses: softprops/action-gh-release@v1
         with:
           files: |
-            target/release/viceroy_${{ steps.tagName.outputs.tag }}_${{ matrix.name }}-${{ matrix.arch }}.tar.gz
+            target/${{ matrix.rust_arch }}-${{ matrix.rust_abi }}/release/viceroy_${{ steps.tagName.outputs.tag }}_${{ matrix.name }}-${{ matrix.arch }}.tar.gz
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Fixes #87 and Fixes https://github.com/fastly/cli/issues/458

Note that `macos-11` is not the same as `macos-latest`, and is required to get a recent Xcode version.