### PR TITLE
Make URI and Host header semantics more explicit

### DIFF
--- a/lib/src/wiggle_abi/req_impl.rs
+++ b/lib/src/wiggle_abi/req_impl.rs
@@ -346,7 +346,7 @@ impl FastlyHttpReq for Session {
             .ok_or_else(|| Error::UnknownBackend(backend_name.to_owned()))?;
 
         // synchronously send the request
-        let resp = upstream::send_request(req, backend)?.await?;
+        let resp = upstream::send_request(req, backend).await?;
         Ok(self.insert_response(resp))
     }
 
@@ -368,7 +368,7 @@ impl FastlyHttpReq for Session {
             .ok_or_else(|| Error::UnknownBackend(backend_name.to_owned()))?;
 
         // asynchronously send the request
-        let pending_req = PendingRequest::spawn(upstream::send_request(req, backend)?);
+        let pending_req = PendingRequest::spawn(upstream::send_request(req, backend));
 
         // return a handle to the pending request
         Ok(self.insert_pending_request(pending_req))
@@ -392,7 +392,7 @@ impl FastlyHttpReq for Session {
             .ok_or_else(|| Error::UnknownBackend(backend_name.to_owned()))?;
 
         // asynchronously send the request
-        let pending_req = PendingRequest::spawn(upstream::send_request(req, backend)?);
+        let pending_req = PendingRequest::spawn(upstream::send_request(req, backend));
 
         // return a handle to the pending request
         Ok(self.insert_pending_request(pending_req))


### PR DESCRIPTION
Previously, we were relying on subtleties of Hyper's behavior to determine the final URI and Host header for outbound requests. Unfortunately, that behavior is sensitive to a number of factors, e.g. whether we happen to be sending a request via an HTTP2 connection.

This commit changes Viceroy to canonicalize the request URI and Host header before it ever reaches Hyper. In most cases this behavior will match what Hyper would do anyway.

Fixes #89