### PR TITLE
🎚 Use rustls for https directly, for more control

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2088,7 +2088,6 @@ dependencies = [
  "anyhow",
  "futures",
  "hyper",
- "hyper-rustls",
  "itertools",
  "serde_json",
  "structopt",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -458,15 +458,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ct-logs"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1a816186fa68d9e426e3cb4ae4dff1fcd8e4a2c34b781bf7a822574a0d0aac8"
-dependencies = [
- "sct",
-]
-
-[[package]]
 name = "digest"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -839,23 +830,6 @@ dependencies = [
  "tower-service",
  "tracing",
  "want",
-]
-
-[[package]]
-name = "hyper-rustls"
-version = "0.22.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f9f7a97316d44c0af9b0301e65010573a853a9fc97046d7331d7f6bc0fd5a64"
-dependencies = [
- "ct-logs",
- "futures-util",
- "hyper",
- "log",
- "rustls",
- "rustls-native-certs",
- "tokio",
- "tokio-rustls",
- "webpki",
 ]
 
 [[package]]
@@ -2114,10 +2088,11 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
- "hyper-rustls",
  "itertools",
  "lazy_static",
  "regex",
+ "rustls",
+ "rustls-native-certs",
  "semver 0.10.0",
  "serde",
  "serde_derive",
@@ -2125,6 +2100,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio",
+ "tokio-rustls",
  "toml",
  "tracing",
  "tracing-futures",
@@ -2132,6 +2108,7 @@ dependencies = [
  "wasi-common",
  "wasmtime",
  "wasmtime-wasi",
+ "webpki",
  "wiggle",
 ]
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -19,7 +19,6 @@ tracing = "0.1.26"
 tracing-subscriber = "0.2.19"
 tracing-futures = "0.2.5"
 hyper = {version = "0.14.0", features = ["full"]}
-hyper-rustls = "0.22.1"
 wat = "1.0.38"
 serde_json = "1.0.66"
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -59,7 +59,8 @@ pub async fn serve(opts: Opts) -> Result<(), Error> {
         }
 
         for (name, backend) in backends.iter() {
-            let client = Client::builder().build(BackendConnector::new(backend));
+            let client =
+                Client::builder().build(BackendConnector::new(backend, ctx.tls_config().clone()));
             let req = Request::get(&backend.uri).body(Body::empty()).unwrap();
 
             event!(Level::INFO, "checking if backend '{}' is up", name);

--- a/cli/tests/trap-test/Cargo.lock
+++ b/cli/tests/trap-test/Cargo.lock
@@ -413,15 +413,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ct-logs"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1a816186fa68d9e426e3cb4ae4dff1fcd8e4a2c34b781bf7a822574a0d0aac8"
-dependencies = [
- "sct",
-]
-
-[[package]]
 name = "digest"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -788,23 +779,6 @@ dependencies = [
  "tower-service",
  "tracing",
  "want",
-]
-
-[[package]]
-name = "hyper-rustls"
-version = "0.22.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f9f7a97316d44c0af9b0301e65010573a853a9fc97046d7331d7f6bc0fd5a64"
-dependencies = [
- "ct-logs",
- "futures-util",
- "hyper",
- "log",
- "rustls",
- "rustls-native-certs",
- "tokio",
- "tokio-rustls",
- "webpki",
 ]
 
 [[package]]
@@ -1869,16 +1843,18 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
- "hyper-rustls",
  "itertools",
  "lazy_static",
  "regex",
+ "rustls",
+ "rustls-native-certs",
  "semver 0.10.0",
  "serde",
  "serde_derive",
  "serde_json",
  "thiserror",
  "tokio",
+ "tokio-rustls",
  "toml",
  "tracing",
  "tracing-futures",
@@ -1886,6 +1862,7 @@ dependencies = [
  "wasi-common",
  "wasmtime",
  "wasmtime-wasi",
+ "webpki",
  "wiggle",
 ]
 

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -23,16 +23,18 @@ futures = "0.3.5"
 http = "0.2.1"
 http-body = "0.4.0"
 hyper = {version = "0.14.0", features = ["full"]}
-hyper-rustls = "0.22.1"
 itertools = "0.10.1"
 lazy_static = "1.4.0"
 regex = "1.3.9"
+rustls = "0.19"
+rustls-native-certs = "0.5.0"
 semver = "0.10.0"
 serde = "1.0.114"
 serde_derive = "1.0.114"
 serde_json = "1.0.59"
 thiserror = "1.0.20"
 tokio = {version = "1.2", features = ["full"]}
+tokio-rustls = "0.22"
 toml = "0.5.6"
 tracing = "0.1.26"
 tracing-futures = "0.2.5"
@@ -40,6 +42,7 @@ url = "2.2.0"
 wasi-common = "0.29.0"
 wasmtime = "0.29.0"
 wasmtime-wasi = {version = "0.29.0", features = ["tokio"]}
+webpki = "0.21.0"
 wiggle = {version = "0.29.0", features = ["wasmtime_async"]}
 
 [dev-dependencies]

--- a/lib/src/error.rs
+++ b/lib/src/error.rs
@@ -94,6 +94,9 @@ pub enum Error {
 
     #[error("{0} is not currently supported for local testing")]
     NotAvailable(&'static str),
+
+    #[error("Could not load native certificates: {0}")]
+    BadCerts(std::io::Error),
 }
 
 impl Error {
@@ -122,6 +125,7 @@ impl Error {
             // All other hostcall errors map to a generic `ERROR` value.
             Error::AbiVersionMismatch
             | Error::BackendUrl(_)
+            | Error::BadCerts(_)
             | Error::DownstreamRequestError(_)
             | Error::DownstreamRespSending
             | Error::FastlyConfig(_)

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -28,4 +28,4 @@ mod streaming_body;
 mod upstream;
 mod wiggle_abi;
 
-pub use {error::Error, execute::ExecuteCtx, service::ViceroyService};
+pub use {error::Error, execute::ExecuteCtx, service::ViceroyService, upstream::BackendConnector};

--- a/lib/src/session.rs
+++ b/lib/src/session.rs
@@ -64,15 +64,15 @@ pub struct Session {
     /// The backends configured for this execution.
     ///
     /// Populated prior to guest execution, and never modified.
-    pub(crate) backends: Arc<Backends>,
+    backends: Arc<Backends>,
     /// The TLS configuration for this execution.
     ///
     /// Populated prior to guest execution, and never modified.
-    pub(crate) tls_config: Arc<rustls::ClientConfig>,
+    tls_config: Arc<rustls::ClientConfig>,
     /// The dictionaries configured for this execution.
     ///
     /// Populated prior to guest execution, and never modified.
-    pub(crate) dictionaries: Arc<Dictionaries>,
+    dictionaries: Arc<Dictionaries>,
     /// The dictionaries configured for this execution.
     ///
     /// Populated prior to guest execution, and never modified.
@@ -80,7 +80,7 @@ pub struct Session {
     /// The path to the configuration file used for this invocation of Viceroy.
     ///
     /// Created prior to guest execution, and never modified.
-    pub(crate) config_path: Arc<Option<PathBuf>>,
+    config_path: Arc<Option<PathBuf>>,
     /// The ID for the client request being processed.
     req_id: u64,
 }
@@ -520,9 +520,14 @@ impl Session {
         self.backends.get(name).map(std::ops::Deref::deref)
     }
 
+    /// Access the backend map.
+    pub fn backends(&self) -> &Arc<Backends> {
+        &self.backends
+    }
+
     // ----- TLS config -----
 
-    /// Reference the TLS configuration.
+    /// Access the TLS configuration.
     pub fn tls_config(&self) -> &Arc<rustls::ClientConfig> {
         &self.tls_config
     }
@@ -541,6 +546,11 @@ impl Session {
             .get(handle)
             .and_then(|name| self.dictionaries.get(name))
             .ok_or(HandleError::InvalidDictionaryHandle(handle))
+    }
+
+    /// Access the dictionary map.
+    pub fn dictionaries(&self) -> &Arc<Dictionaries> {
+        &self.dictionaries
     }
 
     // ----- Pending Requests API -----
@@ -640,6 +650,11 @@ impl Session {
     /// Returns the unique identifier for the request this session is processing.
     pub fn req_id(&self) -> u64 {
         self.req_id
+    }
+
+    /// Access the path to the configuration file for this invocation.
+    pub fn config_path(&self) -> &Arc<Option<PathBuf>> {
+        &self.config_path
     }
 }
 

--- a/lib/src/upstream.rs
+++ b/lib/src/upstream.rs
@@ -5,11 +5,20 @@ use crate::{
 use futures::Future;
 use http::{uri, HeaderValue};
 use hyper::{client::HttpConnector, Client, HeaderMap, Request, Response, Uri};
-use hyper_rustls::{HttpsConnector, MaybeHttpsStream};
-use std::pin::Pin;
-use std::str::FromStr;
-use std::task::{self, Poll};
-use tokio::{net::TcpStream, sync::oneshot};
+use std::{
+    io,
+    pin::Pin,
+    str::FromStr,
+    sync::Arc,
+    task::{self, Context, Poll},
+};
+use tokio::{
+    io::{AsyncRead, AsyncWrite, ReadBuf},
+    net::TcpStream,
+    sync::oneshot,
+};
+use tokio_rustls::{client::TlsStream, TlsConnector};
+use webpki::DNSNameRef;
 
 /// A custom Hyper client connector, which is needed to override Hyper's default behavior of
 /// connecting to host specified by the request's URI; we instead want to connect to the host
@@ -17,36 +26,63 @@ use tokio::{net::TcpStream, sync::oneshot};
 ///
 /// This connector internally wraps Hyper's TLS connector, automatically providing TLS-based
 /// connections when indicated by the backend URI's scheme.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct BackendConnector {
     backend_uri: Uri,
-    https: HttpsConnector<HttpConnector>,
+    http: HttpConnector,
+    tls_config: Arc<rustls::ClientConfig>,
 }
 
 impl BackendConnector {
-    pub fn new(backend: &Backend) -> Self {
+    pub fn new(backend: &Backend, tls_config: Arc<rustls::ClientConfig>) -> Self {
+        let mut http = HttpConnector::new();
+        http.enforce_http(false);
+
         Self {
             backend_uri: backend.uri.clone(),
-            https: HttpsConnector::with_native_roots(),
+            http,
+            tls_config,
         }
     }
 }
 
 type BoxError = Box<dyn std::error::Error + Send + Sync>;
 
+pub enum Connection {
+    Http(TcpStream),
+    Https(Box<TlsStream<TcpStream>>),
+}
+
 impl hyper::service::Service<Uri> for BackendConnector {
-    type Response = MaybeHttpsStream<TcpStream>;
+    type Response = Connection;
     type Error = BoxError;
     type Future = Pin<Box<dyn Future<Output = Result<Self::Response, BoxError>> + Send>>;
 
     fn poll_ready(&mut self, cx: &mut task::Context<'_>) -> Poll<Result<(), Self::Error>> {
-        self.https.poll_ready(cx)
+        self.http.poll_ready(cx).map_err(Into::into)
     }
 
+    // We ignore the URI argument and instead provide the backend's URI.
+    // NB this does _not_ affect the URI provided in the request itself.
     fn call(&mut self, _: Uri) -> Self::Future {
-        // here we ignore the URI argument and instead provide the backend's URI.
-        // NB this does _not_ affect the URI provided in the request itself.
-        self.https.call(self.backend_uri.clone())
+        let uri = self.backend_uri.clone();
+        let config = self.tls_config.clone();
+        let hostname = uri.host().unwrap_or_default().to_string();
+        let is_https = uri.scheme_str() == Some("https");
+
+        let connect_fut = self.http.call(uri);
+        Box::pin(async move {
+            let tcp = connect_fut.await.map_err(Box::new)?;
+
+            if is_https {
+                let connector = TlsConnector::from(config);
+                let dnsname = DNSNameRef::try_from_ascii_str(&hostname).map_err(Box::new)?;
+                let tls = connector.connect(dnsname, tcp).await.map_err(Box::new)?;
+                Ok(Connection::Https(Box::new(tls)))
+            } else {
+                Ok(Connection::Http(tcp))
+            }
+        })
     }
 }
 
@@ -117,8 +153,9 @@ fn canonical_uri(original_uri: &Uri, canonical_host: &str, backend: &Backend) ->
 pub fn send_request(
     mut req: Request<Body>,
     backend: &Backend,
+    tls_config: &Arc<rustls::ClientConfig>,
 ) -> impl Future<Output = Result<Response<Body>, Error>> {
-    let connector = BackendConnector::new(backend);
+    let connector = BackendConnector::new(backend, tls_config.clone());
 
     let host = canonical_host_header(req.headers(), req.uri(), backend);
     let uri = canonical_uri(
@@ -207,5 +244,53 @@ impl Future for SelectTarget {
         std::pin::Pin::new(&mut self.pending_req.receiver)
             .poll(cx)
             .map(|res| res.expect("Pending request receiver was dropped"))
+    }
+}
+
+// Boilerplate forwarding implementations for `Connection`:
+
+impl hyper::client::connect::Connection for Connection {
+    fn connected(&self) -> hyper::client::connect::Connected {
+        hyper::client::connect::Connected::new()
+    }
+}
+
+impl AsyncRead for Connection {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<Result<(), io::Error>> {
+        match Pin::get_mut(self) {
+            Connection::Http(s) => Pin::new(s).poll_read(cx, buf),
+            Connection::Https(s) => Pin::new(s).poll_read(cx, buf),
+        }
+    }
+}
+
+impl AsyncWrite for Connection {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<Result<usize, io::Error>> {
+        match Pin::get_mut(self) {
+            Connection::Http(s) => Pin::new(s).poll_write(cx, buf),
+            Connection::Https(s) => Pin::new(s).poll_write(cx, buf),
+        }
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
+        match Pin::get_mut(self) {
+            Connection::Http(s) => Pin::new(s).poll_flush(cx),
+            Connection::Https(s) => Pin::new(s).poll_flush(cx),
+        }
+    }
+
+    fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
+        match Pin::get_mut(self) {
+            Connection::Http(s) => Pin::new(s).poll_shutdown(cx),
+            Connection::Https(s) => Pin::new(s).poll_shutdown(cx),
+        }
     }
 }

--- a/lib/src/wiggle_abi.rs
+++ b/lib/src/wiggle_abi.rs
@@ -107,9 +107,9 @@ impl UserErrorConversion for Session {
     fn fastly_status_from_error(&mut self, e: Error) -> Result<FastlyStatus, wiggle::Trap> {
         match e {
             Error::UnknownBackend(ref backend) => {
-                let config_path = &self.config_path;
-                let backends_buffer = itertools::join(self.backends.keys(), ",");
-                let backends_len = self.backends.len();
+                let config_path = &self.config_path();
+                let backends_buffer = itertools::join(self.backends().keys(), ",");
+                let backends_len = self.backends().len();
 
                 match (backends_len, (**config_path).as_ref()) {
                     (_, None) => event!(

--- a/lib/src/wiggle_abi/req_impl.rs
+++ b/lib/src/wiggle_abi/req_impl.rs
@@ -346,7 +346,7 @@ impl FastlyHttpReq for Session {
             .ok_or_else(|| Error::UnknownBackend(backend_name.to_owned()))?;
 
         // synchronously send the request
-        let resp = upstream::send_request(req, backend).await?;
+        let resp = upstream::send_request(req, backend, self.tls_config()).await?;
         Ok(self.insert_response(resp))
     }
 
@@ -368,7 +368,8 @@ impl FastlyHttpReq for Session {
             .ok_or_else(|| Error::UnknownBackend(backend_name.to_owned()))?;
 
         // asynchronously send the request
-        let pending_req = PendingRequest::spawn(upstream::send_request(req, backend));
+        let pending_req =
+            PendingRequest::spawn(upstream::send_request(req, backend, self.tls_config()));
 
         // return a handle to the pending request
         Ok(self.insert_pending_request(pending_req))
@@ -392,7 +393,8 @@ impl FastlyHttpReq for Session {
             .ok_or_else(|| Error::UnknownBackend(backend_name.to_owned()))?;
 
         // asynchronously send the request
-        let pending_req = PendingRequest::spawn(upstream::send_request(req, backend));
+        let pending_req =
+            PendingRequest::spawn(upstream::send_request(req, backend, self.tls_config()));
 
         // return a handle to the pending request
         Ok(self.insert_pending_request(pending_req))


### PR DESCRIPTION
Previous work (#75) moved Viceroy to using rustls for TLS, with some good benefits. However, the hyper_rustls library bakes in a fair amount of TLS configuration that we need to control more directly.

Since hyper_rustls is a very thin library, and since we already need our own Hyper connector for other reasons, I opted to just use rustls directly within Viceroy, for maximum clarity/control. The main downside is that there's a bit of boilerplate around TCP/TLS streams.

Along the way, this PR also refactors the CLI backend health checks to use the Viceroy library, rather than connecting in its own way, which will help ensure we keep those in sync.

I've confirmed that this PR:

Fixes #91 
Fixes #96