### PR TITLE
🌦 Allow partial CA store to be loaded

### DIFF
--- a/lib/src/execute.rs
+++ b/lib/src/execute.rs
@@ -324,7 +324,7 @@ fn configure_tls() -> Result<rustls::ClientConfig, Error> {
     config.root_store = match rustls_native_certs::load_native_certs() {
         Ok(store) => store,
         Err((Some(store), err)) => {
-            warn!("some certificates could not be loaded: {}", err);
+            warn!(%err, "some certificates could not be loaded");
             store
         }
         Err((None, err)) => return Err(Error::BadCerts(err)),


### PR DESCRIPTION
This change more closely mimics the setup we previously had with hyper_rustls, and allows Viceroy to be used even if only some root certificates could be loaded.

I believe this change will address #103, but we will have to test it to be sure.