### PR TITLE
✨ tests: install a pretty tracing subscriber

### DIFF
--- a/cli/tests/common.rs
+++ b/cli/tests/common.rs
@@ -123,7 +123,10 @@ impl Test {
             )
             .pretty()
             .with_test_writer()
-            .init();
+            // `try_init` returns an `Err` if the initialization was unsuccessful, likely because a
+            // global subscriber was already installed. we will ignore this error if it happens.
+            .try_init()
+            .ok();
 
         let mut module_path = PathBuf::from(FIXTURE_PATH);
         module_path.push(&self.fixture);

--- a/cli/tests/trap-test/Cargo.lock
+++ b/cli/tests/trap-test/Cargo.lock
@@ -33,6 +33,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec8ad6edb4840b78c5c3d88de606b22252d552b55f3a4699fbb10fc070ec3049"
 
 [[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -213,6 +222,18 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "chrono"
+version = "0.4.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
+dependencies = [
+ "libc",
+ "num-integer",
+ "num-traits",
+ "winapi",
+]
 
 [[package]]
 name = "core-foundation"
@@ -914,6 +935,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f099785f7595cc4b4553a174ce30dd7589ef93391ff414dbb67f62392b9e0ce1"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "matches"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -985,6 +1015,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
+dependencies = [
+ "autocfg",
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -1281,6 +1330,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax",
+]
+
+[[package]]
 name = "regex-syntax"
 version = "0.6.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1500,6 +1558,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shellexpand"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1612,6 +1679,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8018d24e04c95ac8790716a5987d0fec4f8b27249ffa0f7d33f1369bdfb88cbd"
+dependencies = [
+ "once_cell",
 ]
 
 [[package]]
@@ -1744,6 +1820,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-log"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6923477a48e41c1951f1999ef8bb5a3023eb723ceadafe78ffb65dc366761e3"
+dependencies = [
+ "lazy_static",
+ "log",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-serde"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb65ea441fbb84f9f6748fd496cf7f63ec9af5bca94dd86456978d055e8eb28b"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e0d2eaa99c3c2e41547cfa109e910a68ea03823cccad4a0525dcbc9b01e8c71"
+dependencies = [
+ "ansi_term",
+ "chrono",
+ "lazy_static",
+ "matchers",
+ "regex",
+ "serde",
+ "serde_json",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-serde",
+]
+
+[[package]]
 name = "trap-test"
 version = "0.1.0"
 dependencies = [
@@ -1752,6 +1871,7 @@ dependencies = [
  "http",
  "hyper",
  "tokio",
+ "tracing-subscriber",
  "viceroy-lib",
 ]
 

--- a/cli/tests/trap-test/Cargo.toml
+++ b/cli/tests/trap-test/Cargo.toml
@@ -8,12 +8,13 @@ license = "Apache-2.0 WITH LLVM-exception"
 publish = false
 
 [dependencies]
-viceroy-lib = { path = "../../../lib", features = ["test-fatalerror-config"] }
 anyhow = "1.0.31"
+futures = "0.3.0"
 http = "0.2.1"
 hyper = "0.14.0"
 tokio = { version = "1.2", features = ["full"] }
-futures = "0.3.0"
+tracing-subscriber = "0.2.19"
+viceroy-lib = { path = "../../../lib", features = ["test-fatalerror-config"] }
 
 # To indicate to cargo that this trap-test is not a member of the testing workspace specified by
 # ~/cli/tests/fixtures/Cargo.toml, place an empty workspace specification here.


### PR DESCRIPTION
**n.b.** this branch is based on #105.

this adds a few lines to `viceroy_cli::tests::common::Test::against`,
which is used to run test fixtures.

this initializes and installs a tracing subscriber for use in tests,
configured to record any events (i.e., filtering at the `trace` level)
that occur in `viceroy-lib`.

because the `with_test_writer` method is used, the subscriber will use a
writer that is compatible with `cargo test`'s input capturing, and these
verbose logs will not be seen if a test finishes successfully.

an example snippet of this output is shown below:

```
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
test example_test_case ... FAILED

failures:

---- example_test_case stdout ----
  Dec 16 10:39:25.802  INFO viceroy_lib::execute: handling request GET http://127.0.0.1/
    at lib/src/execute.rs:252
    in viceroy_lib::execute::request with id: 0

  Dec 16 10:39:25.804 TRACE viceroy_lib::wiggle_abi::fastly_abi: abi_version: 1
    at lib/src/wiggle_abi.rs:59
    in viceroy_lib::wiggle_abi::fastly_abi::wiggle abi with module: "fastly_abi", function: "init"
    in viceroy_lib::execute::request with id: 0

  Dec 16 10:39:25.804 TRACE viceroy_lib::wiggle_abi::fastly_abi: result: Ok(())
    at lib/src/wiggle_abi.rs:59
    in viceroy_lib::wiggle_abi::fastly_abi::wiggle abi with module: "fastly_abi", function: "init"
    in viceroy_lib::execute::request with id: 0
```