### PR TITLE
Fix local dictionary lookups

### DIFF
--- a/lib/src/wiggle_abi/dictionary_impl.rs
+++ b/lib/src/wiggle_abi/dictionary_impl.rs
@@ -54,7 +54,13 @@ impl FastlyDictionary for Session {
         let file = dict.file.clone();
         let obj = read_json_file(file);
         let item = obj
-            .get(key)
+            .get("item_key")
+            .and_then(|item_key| {
+                if item_key == key {
+                    return obj.get("item_value");
+                }
+                None
+            })
             .ok_or_else(|| DictionaryError::UnknownDictionaryItem(key.to_owned()))?;
         let item = item.as_str().unwrap();
         let item_bytes = item.as_bytes();


### PR DESCRIPTION
Right now when running locally with `fastly compute serve`, we're doing look ups against the fastly API dictionary schema instead of the edge dict's key, e.g:
```toml
# given this dictionary settings in fastly.toml, a dict with key "foo" and value "bar"
[local_server.dictionaries.edge_dict]
file = "./dict.json"
format = "json"
```
```rust
// panics locally, works on compute@edge
let _ = fastly::Dictionary::open("edge_dict")
    .get("foo")
    .unwrap();
// works locally, panics on compute@edge
let _ = fastly::Dictionary::open("edge_dict")
    .get("item_key")
    .unwrap();
```

sample project for a quick repro: https://github.com/thiagopnts/fastly-dict-lookup-bug