### PR TITLE
Update ABI and stub out new function

### DIFF
--- a/lib/src/wiggle_abi/req_impl.rs
+++ b/lib/src/wiggle_abi/req_impl.rs
@@ -9,8 +9,8 @@ use {
             fastly_http_req::FastlyHttpReq,
             headers::HttpHeaders,
             types::{
-                BodyHandle, CacheOverrideTag, HttpVersion, MultiValueCursor,
-                MultiValueCursorResult, PendingRequestHandle, RequestHandle, ResponseHandle,ContentEncodings
+                BodyHandle, CacheOverrideTag, ContentEncodings, HttpVersion, MultiValueCursor,
+                MultiValueCursorResult, PendingRequestHandle, RequestHandle, ResponseHandle,
             },
         },
     },
@@ -468,7 +468,11 @@ impl FastlyHttpReq for Session {
         Ok(())
     }
 
-    fn auto_decompress_response_set(&mut self, _h: RequestHandle, _encodings: ContentEncodings) -> Result<(),Error> {
-      unimplemented!("auto_decompress_response_set has not yet been implemented in Viceroy");
+    fn auto_decompress_response_set(
+        &mut self,
+        _h: RequestHandle,
+        _encodings: ContentEncodings,
+    ) -> Result<(), Error> {
+        unimplemented!("auto_decompress_response_set has not yet been implemented in Viceroy");
     }
 }

--- a/lib/src/wiggle_abi/req_impl.rs
+++ b/lib/src/wiggle_abi/req_impl.rs
@@ -10,7 +10,7 @@ use {
             headers::HttpHeaders,
             types::{
                 BodyHandle, CacheOverrideTag, HttpVersion, MultiValueCursor,
-                MultiValueCursorResult, PendingRequestHandle, RequestHandle, ResponseHandle,
+                MultiValueCursorResult, PendingRequestHandle, RequestHandle, ResponseHandle,ContentEncodings
             },
         },
     },
@@ -466,5 +466,9 @@ impl FastlyHttpReq for Session {
         // the handle given doesn't exist
         self.take_request_parts(req_handle)?;
         Ok(())
+    }
+
+    fn auto_decompress_response_set(&mut self, _h: RequestHandle, _encodings: ContentEncodings) -> Result<(),Error> {
+      unimplemented!("auto_decompress_response_set has not yet been implemented in Viceroy");
     }
 }


### PR DESCRIPTION
This commit updates the ABI of C@E to the latest version so that v0.8.1
Rust SDK users will not have any crashes due to a function that does not
exist. While this hostcall exists on the fleet and had been updated
internally, we hadn't updated Viceroy to have access to it as well
through a public update. This commit brings Viceroy in line with the
current Rust SDK release and stubs out the
`auto_decompress_response_set` function for `Request` that can be
implemented for local testing in a commit. For now this will stop
clients from crashing when testing locally.

Fixes #110

In order to test I ran the sample program locally from the linked issue. Here's the output where Viceroy doesn't work vs the Viceroy from this commit:

```bash
src/fastly/fastly-test is 📦 v0.1.0 via 🦀 v1.57.0 on ☁️  mgattozzi@fastly.com
❯ fastly compute serve
✓ Initializing...
✓ Verifying package manifest...
✓ Verifying local rust toolchain...
✓ Building package using rust toolchain...
✓ Creating package archive...

SUCCESS: Built rust package fastly-test (pkg/fastly-test.tar.gz)

✓ Initializing...
✓ Checking latest Viceroy release...
✓ Checking installed Viceroy version...
✓ Running local server...

Jan 07 12:48:40.002 ERROR unknown import: `fastly_http_req::auto_decompress_response_set` has not been defined
Error: Other(unknown import: `fastly_http_req::auto_decompress_response_set` has not been defined)

ERROR: error during execution process:
Jan 07 12:48:40.002 ERROR unknown import: `fastly_http_req::auto_decompress_response_set` has not been defined
Error: Other(unknown import: `fastly_http_req::auto_decompress_response_set` has not been defined).

If you believe this error is the result of a bug, please file an issue: https://github.com/fastly/cli/issues/new?labels=bug&template=bug_report.md

src/fastly/fastly-test is 📦 v0.1.0 via 🦀 v1.57.0 on ☁️  mgattozzi@fastly.com
❯ tar -xvf pkg/fastly-test.tar.gz
fastly-test/
fastly-test/Cargo.toml
fastly-test/bin/
fastly-test/bin/main.wasm
fastly-test/fastly.toml

src/fastly/fastly-test is 📦 v0.1.0 via 🦀 v1.57.0 on ☁️  mgattozzi@fastly.com
❯ ../Viceroy/target/debug/viceroy fastly-test/bin/main.wasm
Jan 07 12:48:57.188  WARN no configuration provided, invoke with `-C <TOML_FILE>` to provide a configuration
Jan 07 12:48:57.188  INFO Listening on http://127.0.0.1:7878
^C%                                                                                                                                                                                                                                      
src/fastly/fastly-test is 📦 v0.1.0 via 🦀 v1.57.0 on ☁️  mgattozzi@fastly.com took 6s
❯
```