### PR TITLE
do not panic on calls to auto_decompress_response_set which are not setting the decompression to gzip

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -405,9 +405,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ed27e177f16d65f0f0c22a213e17c696ace5dd64b14258b52f9417ccb52db4"
+checksum = "e54ea8bc3fb1ee042f5aace6e3c6e025d3874866da222930f70ce62aceba0bfa"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -426,9 +426,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.5"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ec02e091aa634e2c3ada4a392989e7c3116673ef0ac5b72232439094d73b7fd"
+checksum = "97242a70df9b89a65d0b6df3c4bf5b9ce03c5b7309019777fbde37e7537f8762"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -439,9 +439,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db"
+checksum = "cfcae03edb34f947e64acdb1c33ec169824e20657e9ecb61cef6c8c74dcb8120"
 dependencies = [
  "cfg-if",
  "lazy_static",
@@ -551,6 +551,15 @@ checksum = "057adc3b19851383cf03ce9020318ee6eabb8f0b187987e916417b444583f8d5"
 dependencies = [
  "bitflags",
  "http",
+]
+
+[[package]]
+name = "fastrand"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "779d043b6a0b90cc4c0ed7ee380a6504394cee7efd7db050e3774eee387324b2"
+dependencies = [
+ "instant",
 ]
 
 [[package]]
@@ -840,9 +849,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc633605454125dec4b66843673f01c7df2b89479b32e0ed634e43a91cff62a5"
+checksum = "282a6247722caba404c065016bbfa522806e51714c34f5dfc3e4a3a46fcb4223"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -1736,13 +1745,13 @@ checksum = "d9bffcddbc2458fa3e6058414599e3c838a022abae82e5c67b4f7f80298d5bff"
 
 [[package]]
 name = "tempfile"
-version = "3.2.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
+checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
 dependencies = [
  "cfg-if",
+ "fastrand",
  "libc",
- "rand",
  "redox_syscall",
  "remove_dir_all",
  "winapi",

--- a/cli/tests/trap-test/Cargo.lock
+++ b/cli/tests/trap-test/Cargo.lock
@@ -390,9 +390,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ed27e177f16d65f0f0c22a213e17c696ace5dd64b14258b52f9417ccb52db4"
+checksum = "e54ea8bc3fb1ee042f5aace6e3c6e025d3874866da222930f70ce62aceba0bfa"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -411,9 +411,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.5"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ec02e091aa634e2c3ada4a392989e7c3116673ef0ac5b72232439094d73b7fd"
+checksum = "97242a70df9b89a65d0b6df3c4bf5b9ce03c5b7309019777fbde37e7537f8762"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -424,9 +424,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db"
+checksum = "cfcae03edb34f947e64acdb1c33ec169824e20657e9ecb61cef6c8c74dcb8120"
 dependencies = [
  "cfg-if",
  "lazy_static",
@@ -825,9 +825,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc633605454125dec4b66843673f01c7df2b89479b32e0ed634e43a91cff62a5"
+checksum = "282a6247722caba404c065016bbfa522806e51714c34f5dfc3e4a3a46fcb4223"
 dependencies = [
  "autocfg",
  "hashbrown",

--- a/lib/src/wiggle_abi/req_impl.rs
+++ b/lib/src/wiggle_abi/req_impl.rs
@@ -471,8 +471,12 @@ impl FastlyHttpReq for Session {
     fn auto_decompress_response_set(
         &mut self,
         _h: RequestHandle,
-        _encodings: ContentEncodings,
+        encodings: ContentEncodings,
     ) -> Result<(), Error> {
-        unimplemented!("auto_decompress_response_set has not yet been implemented in Viceroy");
+        if u32::from(encodings) == 1 {
+            unimplemented!("calling auto_decompress_response_set with GZIP has not yet been implemented in Viceroy");
+        } else {
+            Ok(())
+        }
     }
 }

--- a/test-fixtures/Cargo.lock
+++ b/test-fixtures/Cargo.lock
@@ -61,9 +61,9 @@ dependencies = [
 
 [[package]]
 name = "fastly"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b1d6d1476a85603b9fd5162f747570686f4637383d9f8798d5ef0f2e628193b"
+checksum = "d5bc0bf3b13c32c6f10cc1b199e405939248aa2425d2c85608740a6b25562c83"
 dependencies = [
  "anyhow",
  "bytes 0.5.6",
@@ -95,9 +95,9 @@ dependencies = [
 
 [[package]]
 name = "fastly-shared"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "010266f409d00e3d4cf2e0f3e201265960b96fa342bbddf366a41beea5d10346"
+checksum = "a50fae8c678779e8dcd18e36f9982d09c706764e8976c542fd53193a62d83727"
 dependencies = [
  "bitflags",
  "http",
@@ -106,10 +106,11 @@ dependencies = [
 
 [[package]]
 name = "fastly-sys"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd84c88b732ac6d5711363856a3d4b686fd2691ba753d565879779c6ba8d84b"
+checksum = "afcf0f870a0c9ac8166b0797a9391e5df81b7b5cc13b53b4d305e0b1368801d4"
 dependencies = [
+ "bitflags",
  "fastly-shared",
 ]
 

--- a/test-fixtures/Cargo.toml
+++ b/test-fixtures/Cargo.toml
@@ -8,9 +8,9 @@ license = "Apache-2.0 WITH LLVM-exception"
 publish = false
 
 [dependencies]
-fastly = "=0.8.0"
-fastly-shared = "=0.8.0"
-fastly-sys = "=0.8.0"
+fastly = "=0.8.1"
+fastly-shared = "=0.8.1"
+fastly-sys = "=0.8.1"
 bytes = "1.0.0"
 http = "0.2.1"
 serde = "1.0.114"

--- a/test-fixtures/src/bin/request.rs
+++ b/test-fixtures/src/bin/request.rs
@@ -9,7 +9,7 @@ use {
         header_append, header_insert, header_remove, header_value_get, method_get, method_set, new,
         uri_get, uri_set, version_get, version_set,
     },
-    fastly_sys::RequestHandle,
+    fastly_sys::{ContentEncodings, RequestHandle},
     http::header::{HeaderName, HeaderValue},
     http::{Method, Uri},
 };
@@ -420,11 +420,18 @@ fn test_header_multi_value_set_and_get() {
     assert_eq!(0, no_header_names.len());
 }
 
+fn test_decompress_gzip_response() {
+    let mut request = FastlyRequestHandle::new();
+
+    request.set_auto_decompress_response(ContentEncodings::GZIP);
+}
+
 fn main() {
     test_version_set_and_get();
     test_uri_set_and_get();
     test_method_set_and_get();
     test_header_value_get_and_insert();
     test_header_append_and_remove();
-    test_header_multi_value_set_and_get()
+    test_header_multi_value_set_and_get();
+    test_decompress_gzip_response()
 }

--- a/test-fixtures/src/bin/request.rs
+++ b/test-fixtures/src/bin/request.rs
@@ -420,10 +420,10 @@ fn test_header_multi_value_set_and_get() {
     assert_eq!(0, no_header_names.len());
 }
 
-fn test_decompress_gzip_response() {
+fn test_default_decompress_response() {
     let mut request = FastlyRequestHandle::new();
 
-    request.set_auto_decompress_response(ContentEncodings::GZIP);
+    request.set_auto_decompress_response(ContentEncodings::default());
 }
 
 fn main() {
@@ -433,5 +433,5 @@ fn main() {
     test_header_value_get_and_insert();
     test_header_append_and_remove();
     test_header_multi_value_set_and_get();
-    test_decompress_gzip_response()
+    test_default_decompress_response()
 }


### PR DESCRIPTION
I've added two tests, one which set the decompression to the default value - this should not cause a panic, and another test which sets the decompression to gzip - this should cause a panic due to it being unimplemented.

This aims to resolve #115 