### PR TITLE
🚀 `0.2.9` release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,13 @@
 ## Unreleased
 
+## 0.2.9 (2022-01-11)
+
+- Do not panic when `auto_decompress_response_set` is called ([#116](https://github.com/fastly/Viceroy/pull/116))
+
 ## 0.2.8 (2022-01-07)
-- Allow partial CA store to be loaded ([#104](https://github.com/fastly/Viceroy/pull/104)
-- Update ABI and stub out new function ([#113](https://github.com/fastly/Viceroy/pull/104)
+
+- Allow partial CA store to be loaded ([#104](https://github.com/fastly/Viceroy/pull/104))
+- Update ABI and stub out new function ([#113](https://github.com/fastly/Viceroy/pull/104))
 
 ## 0.2.7 (2021-12-01)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2063,7 +2063,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "viceroy"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "anyhow",
  "futures",
@@ -2082,7 +2082,7 @@ dependencies = [
 
 [[package]]
 name = "viceroy-lib"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "anyhow",
  "bytes",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "viceroy"
 description = "Viceroy is a local testing daemon for Compute@Edge."
-version = "0.2.9"
+version = "0.2.10"
 authors = ["Fastly"]
 edition = "2018"
 license = "Apache-2.0 WITH LLVM-exception"

--- a/cli/tests/trap-test/Cargo.lock
+++ b/cli/tests/trap-test/Cargo.lock
@@ -1960,7 +1960,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "viceroy-lib"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "anyhow",
  "bytes",

--- a/doc/RELEASING.md
+++ b/doc/RELEASING.md
@@ -22,7 +22,8 @@ Below are the steps needed to do a Viceroy release:
    crates.io registry. Note that we must do this in order of dependencies. So,
   1. `cd lib && cargo publish`
   1. `cd cli && cargo publish`
-1. Now, we should return to our release PR and add a commit to the branch that
-   bumps Viceroy to the next patch version (so `z + 1`). Then, update all the
-   lockfiles by running `make fix-build`.
+1. Now, we should return to our release PR.
+  1. Update the version fields in `lib/Cargo.toml` and `cli/Cargo.toml` to the
+     next patch version (so `z + 1`).
+  1. Update all the lockfiles by running `make generate-lockfile`.
 1. Get another approval and merge when CI passes.

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "viceroy-lib"
-version = "0.2.9"
+version = "0.2.10"
 description = "Viceroy implementation details."
 authors = ["Fastly"]
 edition = "2018"


### PR DESCRIPTION
this is a release branch, for a new `0.2.9` release containing #116. this will ensure that Viceroy is compatible with the `0.8.1` version of Fastly's Compute@Edge Rust SDK.