### PR TITLE
Define README path in config toml

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -3,6 +3,7 @@ name = "viceroy"
 description = "Viceroy is a local testing daemon for Compute@Edge."
 version = "0.2.10"
 authors = ["Fastly"]
+readme = "../README.md"
 edition = "2018"
 license = "Apache-2.0 WITH LLVM-exception"
 


### PR DESCRIPTION
Hello,
I've define path of README in toml, to let document displayed in crate.

It aims to solve the following https://github.com/fastly/Viceroy/issues/46