### PR TITLE
𝟎 only log non-zero exit status codes

### DIFF
--- a/lib/src/execute.rs
+++ b/lib/src/execute.rs
@@ -264,7 +264,10 @@ impl ExecuteCtx {
             .await
             .map(|_| ())
             .map_err(|trap| {
-                event!(Level::ERROR, "WebAssembly trapped: {}", trap);
+                // Be sure that we only log non-zero status codes.
+                if trap.i32_exit_status() != Some(0) {
+                    event!(Level::ERROR, "WebAssembly trapped: {}", trap);
+                }
                 ExecutionError::WasmTrap(trap)
             });
 


### PR DESCRIPTION
if a program invokes e.g., `std::process:exit(0)`, this should not cause
confusing messages as reported in #127:

```
  Jan 1 00:00:00.123 ERROR viceroy_lib::execute: WebAssembly huhu: Exited with i32 exit status 0
wasm backtrace:
    0: 0x280ea - <unknown>!__wasi_proc_exit
    1: 0x280f6 - <unknown>!_Exit
```

apologies for the lack of test coverage here.

this is unfortunately difficult to test, because the
`Result<(), ExecutionError>` of `ExecuteCtx::run_guest` is spawned in a
task that we do not join on later. (note: that is intentional)

the alternative of a test that checks for a particular log message felt
brittle, and this is a relatively straightfoward change.