### PR TITLE
📈 Split `trap-test` into a separate CI job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,6 +40,42 @@ jobs:
       run: make ci
       shell: bash
 
+  # Run the trap test in an isolated job. It needs different cargo features than the usual build, so
+  # it entails rebuilding the whole workspace if we combine them in a single job. This way, we
+  # achieve some parallelism via Actions jobs.
+  trap-test:
+    strategy:
+      matrix:
+        platform: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.platform }}
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+      with:
+        submodules: true
+    - name: Install Rust
+      uses: actions-rs/toolchain@v1
+    - name: Add wasm32-wasi Rust target
+      run: rustup target add wasm32-wasi
+    - name: Cache cargo registry
+      uses: actions/cache@v1
+      with:
+        path: ~/.cargo/registry
+        key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+    - name: Cache cargo index
+      uses: actions/cache@v1
+      with:
+        path: ~/.cargo/git
+        key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
+    - name: Cache cargo build
+      uses: actions/cache@v1
+      with:
+        path: target
+        key: ${{ runner.os }}-cargo-build-target-v1-${{ hashFiles('**/Cargo.lock') }}
+    - name: trap-test
+      run: make trap-test-ci
+      shell: bash
+
   package-check:
     runs-on: ubuntu-latest
     steps:

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,5 @@
-# Default to using regular `cargo`. The `ci` target will override this.
+# Default to using regular `cargo`. CI targets may override this.
 VICEROY_CARGO=cargo
-export VICEROY_CARGO
 
 .PHONY: format
 format:

--- a/Makefile
+++ b/Makefile
@@ -1,56 +1,67 @@
+# Default to using regular `cargo`. The `ci` target will override this.
+VICEROY_CARGO=cargo
+export VICEROY_CARGO
+
 .PHONY: format
 format:
-	cargo fmt
+	$(VICEROY_CARGO) fmt
 
 .PHONY: format-check
 format-check:
-	cargo fmt -- --check
+	$(VICEROY_CARGO) fmt -- --check
 
 .PHONY: clippy
 clippy:
-	cargo clippy --all -- -D warnings
+	$(VICEROY_CARGO) clippy --all -- -D warnings
 
 .PHONY: test
 test: test-crates trap-test
 
 .PHONY: test-crates
 test-crates: fix-build
-	cargo test --all --locked
+	$(VICEROY_CARGO) test --all
 
 .PHONY: fix-build
 fix-build:
-	cd test-fixtures && cargo build --target=wasm32-wasi --locked
+	cd test-fixtures && $(VICEROY_CARGO) build --target=wasm32-wasi
 
 .PHONY: trap-test
 trap-test: fix-build
-	cd cli/tests/trap-test && cargo test fatal_error_traps --locked -- --nocapture
+	cd cli/tests/trap-test && $(VICEROY_CARGO) test fatal_error_traps -- --nocapture
 
+# The `trap-test` is its own top-level target for CI in order to achieve better build parallelism.
+.PHONY: trap-test-ci
+trap-test-ci: VICEROY_CARGO=cargo --locked
+trap-test-ci: trap-test
+
+# The main `ci` target runs everything except `trap-test`.
 .PHONY: ci
-ci: format-check clippy test
+ci: VICEROY_CARGO=cargo --locked
+ci: format-check clippy test-crates
 
 .PHONY: clean
 clean:
-	cargo clean
-	cd cli/tests/trap-test/ && cargo clean
+	$(VICEROY_CARGO) clean
+	cd cli/tests/trap-test/ && $(VICEROY_CARGO) clean
 
 # Open the documentation for the workspace in a browser.
 .PHONY: doc
 doc:
-	cargo doc --workspace --open
+	$(VICEROY_CARGO) doc --workspace --open
 
 # Open the documentation for the workspace in a browser.
 #
 # Note: This includes private items, which can be useful for development.
 .PHONY: doc-dev
 doc-dev:
-	cargo doc --no-deps --document-private-items --workspace --open
+	$(VICEROY_CARGO) doc --no-deps --document-private-items --workspace --open
 
 # Run `cargo generate-lockfile` for all of the crates in the project.
 .PHONY: generate-lockfile
 generate-lockfile:
-	cargo generate-lockfile
-	cargo generate-lockfile --manifest-path=test-fixtures/Cargo.toml
-	cargo generate-lockfile --manifest-path=cli/tests/trap-test/Cargo.toml
+	$(VICEROY_CARGO) generate-lockfile
+	$(VICEROY_CARGO) generate-lockfile --manifest-path=test-fixtures/Cargo.toml
+	$(VICEROY_CARGO) generate-lockfile --manifest-path=cli/tests/trap-test/Cargo.toml
 
 # Check that the crates can be packaged for crates.io.
 #


### PR DESCRIPTION
Fixes #18.

The `trap-test` target requires a different configuration of Cargo features than the normal `test` target. When run in sequence, that means we have to rebuild the entire workspace twice on the same job. By splitting these targets into different CI jobs, they can run in parallel, hopefully reducing the overall wall time of a CI run while keeping the same test coverage.

Along the way, I also made the use of the `cargo --locked` option more consistent in the Makefile, and enforce its presence when using the CI targets.