### PR TITLE
Add support for writing test cases directly in WAT.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
       uses: actions/cache@v1
       with:
         path: target
-        key: ${{ runner.os }}-cargo-build-target-v1-${{ hashFiles('**/Cargo.lock') }}
+        key: ${{ runner.os }}-cargo-build-target-v2-${{ hashFiles('**/Cargo.lock') }}
     - name: Install rustfmt
       run: rustup component add rustfmt
       shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,12 +21,12 @@ jobs:
       uses: actions/cache@v1
       with:
         path: ~/.cargo/registry
-        key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+        key: ${{ runner.os }}-cargo-registry-v${{ env.CACHE_GENERATION }}-${{ hashFiles('**/Cargo.lock') }}
     - name: Cache cargo index
       uses: actions/cache@v1
       with:
         path: ~/.cargo/git
-        key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
+        key: ${{ runner.os }}-cargo-index-v${{ env.CACHE_GENERATION }}-${{ hashFiles('**/Cargo.lock') }}
     - name: Cache cargo build
       uses: actions/cache@v1
       with:
@@ -63,17 +63,17 @@ jobs:
       uses: actions/cache@v1
       with:
         path: ~/.cargo/registry
-        key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+        key: ${{ runner.os }}-cargo-registry-v${{ env.CACHE_GENERATION }}-${{ hashFiles('**/Cargo.lock') }}
     - name: Cache cargo index
       uses: actions/cache@v1
       with:
         path: ~/.cargo/git
-        key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
+        key: ${{ runner.os }}-cargo-index-v${{ env.CACHE_GENERATION }}-${{ hashFiles('**/Cargo.lock') }}
     - name: Cache cargo build
       uses: actions/cache@v1
       with:
         path: target
-        key: ${{ runner.os }}-cargo-build-target-v1-${{ hashFiles('**/Cargo.lock') }}
+        key: ${{ runner.os }}-cargo-build-target-v${{ env.CACHE_GENERATION }}-${{ hashFiles('**/Cargo.lock') }}
     - name: trap-test
       run: make trap-test-ci
       shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,7 @@
 on: pull_request
 name: Test
+env:
+  CACHE_GENERATION: 2
 jobs:
   test:
     strategy:
@@ -29,7 +31,7 @@ jobs:
       uses: actions/cache@v1
       with:
         path: target
-        key: ${{ runner.os }}-cargo-build-target-v2-${{ hashFiles('**/Cargo.lock') }}
+        key: ${{ runner.os }}-cargo-build-target-v${{ env.CACHE_GENERATION }}-${{ hashFiles('**/Cargo.lock') }}
     - name: Install rustfmt
       run: rustup component add rustfmt
       shell: bash

--- a/cli/tests/integration/common.rs
+++ b/cli/tests/integration/common.rs
@@ -20,8 +20,6 @@ use viceroy_lib::{
 /// ```
 /// let module_path = format!("{}/guest.wasm", RUST_FIXTURE_PATH);
 /// ```
-///
-/// [format]: https://doc.rust-lang.org/std/fmt/fn.format.html
 pub static RUST_FIXTURE_PATH: &str = "../test-fixtures/target/wasm32-wasi/debug/";
 
 /// A shorthand for the path to our test fixtures' build artifacts for WAT tests.
@@ -32,8 +30,6 @@ pub static RUST_FIXTURE_PATH: &str = "../test-fixtures/target/wasm32-wasi/debug/
 /// ```
 /// let module_path = format!("{}/guest.wat", WAT_FIXTURE_PATH);
 /// ```
-///
-/// [format]: https://doc.rust-lang.org/std/fmt/fn.format.html
 pub static WAT_FIXTURE_PATH: &str = "../test-fixtures/";
 
 /// A catch-all error, so we can easily use `?` in test cases.

--- a/cli/tests/integration/main.rs
+++ b/cli/tests/integration/main.rs
@@ -4,6 +4,7 @@ mod downstream_req;
 mod env_vars;
 mod http_semantics;
 mod logging;
+mod memory;
 mod request;
 mod response;
 mod sending_response;

--- a/cli/tests/integration/memory.rs
+++ b/cli/tests/integration/memory.rs
@@ -1,0 +1,11 @@
+use crate::common::{Test, TestResult};
+use hyper::StatusCode;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn direct_wasm_works() -> TestResult {
+    let resp = Test::using_wat_fixture("return_ok.wat")
+        .against_empty()
+        .await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    Ok(())
+}

--- a/cli/tests/trap-test/src/main.rs
+++ b/cli/tests/trap-test/src/main.rs
@@ -1,5 +1,5 @@
 use {
-    crate::common::{TestResult, FIXTURE_PATH},
+    crate::common::{TestResult, RUST_FIXTURE_PATH},
     http::header::WARNING,
     hyper::{Body, Request, StatusCode},
     viceroy_lib::ExecuteCtx,
@@ -10,7 +10,7 @@ mod common;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn fatal_error_traps() -> TestResult {
-    let module_path = format!("../../{}/response.wasm", FIXTURE_PATH);
+    let module_path = format!("../../{}/response.wasm", RUST_FIXTURE_PATH);
     let ctx = ExecuteCtx::new(module_path)?;
     let req = Request::get("http://127.0.0.1:7878/").body(Body::from(""))?;
     let resp = ctx

--- a/test-fixtures/return_ok.wat
+++ b/test-fixtures/return_ok.wat
@@ -1,0 +1,77 @@
+(module
+  (import "fastly_http_resp" "new"
+    (func $response_new
+      (param i32)
+      (result i32)))
+  (import "fastly_http_resp" "status_set"
+    (func $response_set_status
+      (param i32) (param i32)
+      (result i32)))
+  (import "fastly_http_resp" "send_downstream"
+    (func $response_send
+      (param i32) (param i32) (param i32)
+      (result i32)))
+ 
+  (import "wasi_snapshot_preview1" "proc_exit"
+    (func $wasi_exit
+      (param i32)))
+
+  ;; we're going to fix a few memory locations as constants, just to avoid
+  ;; some other messiness, even though it's bad software engineering.
+  (global $response_handle_buffer i32 (i32.const 4))
+
+  (func $main (export "_start")
+    (i32.const 200)
+    (call $send_response)
+    (i32.const 0)
+    (call $wasi_exit)
+    unreachable
+    )
+
+  ;; Send a resposne back to the test harness, using the status code
+  ;; provided in the first argument. This message will have no body,
+  ;; and no headers, just the response code. It will fail catastrophically
+  ;; (i.e., end this execution) if anything goes wrong in the process.
+  (func $send_response (param $result i32)
+      ;; create the response
+      (global.get $response_handle_buffer)
+      (call $response_new)
+      (call $maybe_error_die)
+
+      ;; set the status
+      (global.get $response_handle_buffer)
+      (i32.load)
+      (local.get $result)
+      (call $response_set_status)
+      (call $maybe_error_die)
+
+      ;; send it to the client
+      (global.get $response_handle_buffer)
+      (i32.load)
+      (i32.const 0) ;; empty body
+      (i32.const 0) ;; not streaming
+      (call $response_send)
+      (call $maybe_error_die)
+    )
+
+  ;; this is not super informative, but: check to see if the status code
+  ;; from whatever hostcall we just invoked came back as OK (0); if not,
+  ;; immediately exit with the return value as a diagnostic. (Not that it
+  ;; tells us where that value came from, but at least it's something?)
+  (func $maybe_error_die (param $status_code i32)
+    (block $test_block
+      (local.get $status_code)
+      (i32.const 0)
+      (i32.ne)
+      (br_if $test_block)
+      (return)
+    )
+    (local.get $status_code)
+    (call $wasi_exit)
+    unreachable
+    )
+
+  (memory (;0;) 1) ;; 1 * 64k = 64k :)
+  (export "memory" (memory 0))
+
+  )


### PR DESCRIPTION
This version leverages `wasmtime`'s ability to compile/run WAT directly to avoid the need to install additional tooling on the build machines, at the cost of requiring some fiddling with the test harness.

Resolves #130.