### PR TITLE
Update cache action and unify steps

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,7 @@ jobs:
       with:
         submodules: true
     - name: Install Rust
+      id: toolchain
       uses: actions-rs/toolchain@v1
     - name: Add wasm32-wasi Rust target
       run: rustup target add wasm32-wasi
@@ -26,7 +27,7 @@ jobs:
           ~/.cargo/registry/cache/
           ~/.cargo/git/db/
           target/
-        key: ${{ runner.os }}-cargo-v${{ env.CACHE_GENERATION }}-${{ hashFiles('**/Cargo.lock') }}
+        key: ${{ runner.os }}-cargo-v${{ env.CACHE_GENERATION }}-${{ steps.toolchain.outputs.rustc_hash }}-${{ hashFiles('**/Cargo.lock') }}
     - name: Install rustfmt
       run: rustup component add rustfmt
       shell: bash
@@ -52,6 +53,7 @@ jobs:
         submodules: true
     - name: Install Rust
       uses: actions-rs/toolchain@v1
+      id: toolchain
     - name: Add wasm32-wasi Rust target
       run: rustup target add wasm32-wasi
     - name: Cache cargo
@@ -63,7 +65,7 @@ jobs:
           ~/.cargo/registry/cache/
           ~/.cargo/git/db/
           target/
-        key: ${{ runner.os }}-cargo-v${{ env.CACHE_GENERATION }}-${{ hashFiles('**/Cargo.lock') }}
+        key: ${{ runner.os }}-cargo-v${{ env.CACHE_GENERATION }}-${{ steps.toolchain.outputs.rustc_hash }}-${{ hashFiles('**/Cargo.lock') }}
     - name: trap-test
       run: make trap-test-ci
       shell: bash
@@ -75,14 +77,12 @@ jobs:
         uses: actions/checkout@v2
         with:
           submodules: true
-
       - name: Install latest Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
           default: true
           override: true
-
       - name: Check crates can be published
         run: make package-check
         shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,7 @@
 on: pull_request
 name: Test
 env:
-  CACHE_GENERATION: 2
+  CACHE_GENERATION: 0
 jobs:
   test:
     strategy:
@@ -17,21 +17,16 @@ jobs:
       uses: actions-rs/toolchain@v1
     - name: Add wasm32-wasi Rust target
       run: rustup target add wasm32-wasi
-    - name: Cache cargo registry
-      uses: actions/cache@v1
+    - name: Cache cargo
+      uses: actions/cache@v2
       with:
-        path: ~/.cargo/registry
-        key: ${{ runner.os }}-cargo-registry-v${{ env.CACHE_GENERATION }}-${{ hashFiles('**/Cargo.lock') }}
-    - name: Cache cargo index
-      uses: actions/cache@v1
-      with:
-        path: ~/.cargo/git
-        key: ${{ runner.os }}-cargo-index-v${{ env.CACHE_GENERATION }}-${{ hashFiles('**/Cargo.lock') }}
-    - name: Cache cargo build
-      uses: actions/cache@v1
-      with:
-        path: target
-        key: ${{ runner.os }}-cargo-build-target-v${{ env.CACHE_GENERATION }}-${{ hashFiles('**/Cargo.lock') }}
+        path: |
+          ~/.cargo/bin/
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+          target/
+        key: ${{ runner.os }}-cargo-v${{ env.CACHE_GENERATION }}-${{ hashFiles('**/Cargo.lock') }}
     - name: Install rustfmt
       run: rustup component add rustfmt
       shell: bash
@@ -59,21 +54,16 @@ jobs:
       uses: actions-rs/toolchain@v1
     - name: Add wasm32-wasi Rust target
       run: rustup target add wasm32-wasi
-    - name: Cache cargo registry
-      uses: actions/cache@v1
+    - name: Cache cargo
+      uses: actions/cache@v2
       with:
-        path: ~/.cargo/registry
-        key: ${{ runner.os }}-cargo-registry-v${{ env.CACHE_GENERATION }}-${{ hashFiles('**/Cargo.lock') }}
-    - name: Cache cargo index
-      uses: actions/cache@v1
-      with:
-        path: ~/.cargo/git
-        key: ${{ runner.os }}-cargo-index-v${{ env.CACHE_GENERATION }}-${{ hashFiles('**/Cargo.lock') }}
-    - name: Cache cargo build
-      uses: actions/cache@v1
-      with:
-        path: target
-        key: ${{ runner.os }}-cargo-build-target-v${{ env.CACHE_GENERATION }}-${{ hashFiles('**/Cargo.lock') }}
+        path: |
+          ~/.cargo/bin/
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+          target/
+        key: ${{ runner.os }}-cargo-v${{ env.CACHE_GENERATION }}-${{ hashFiles('**/Cargo.lock') }}
     - name: trap-test
       run: make trap-test-ci
       shell: bash


### PR DESCRIPTION
While looking at the cache issue from #134, I noticed errors in the
GHA output when creating the cache tarball. Furthermore, a newer
version of the cache action existed with some improvements, for
example the ability to use multiple paths in a single step.

This PR bumps the cache action to v2, merging all the steps together
as with the official example, hopefully fixing the errors and
speeding things up.

It also includes the rustc version hash in the cache key.