### PR TITLE
Provide stubs for new framing headers settings

### DIFF
--- a/lib/compute-at-edge-abi/compute-at-edge.witx
+++ b/lib/compute-at-edge-abi/compute-at-edge.witx
@@ -303,6 +303,13 @@
         (param $encodings $content_encodings)
         (result $err (expected (error $fastly_status)))
     )
+
+    ;;; Adjust how this requests's framing headers are determined.
+    (@interface func (export "framing_headers_mode_set")
+        (param $h $request_handle)
+        (param $mode $framing_headers_mode)
+        (result $err (expected (error $fastly_status)))
+    )
 )
 
 (module $fastly_http_resp
@@ -402,6 +409,13 @@
 
     (@interface func(export "close")
         (param $h $response_handle)
+        (result $err (expected (error $fastly_status)))
+    )
+
+    ;;; Adjust how this response's framing headers are determined.
+    (@interface func (export "framing_headers_mode_set")
+        (param $h $response_handle)
+        (param $mode $framing_headers_mode)
         (result $err (expected (error $fastly_status)))
     )
 )

--- a/lib/compute-at-edge-abi/typenames.witx
+++ b/lib/compute-at-edge-abi/typenames.witx
@@ -113,3 +113,8 @@
 (typename $content_encodings
     (flags (@witx repr u32)
         $gzip))
+
+(typename $framing_headers_mode
+    (enum (@witx tag u32)
+        $automatic
+        $manually_from_headers))

--- a/lib/src/config.rs
+++ b/lib/src/config.rs
@@ -130,10 +130,10 @@ impl TryInto<FastlyConfig> for TomlFastlyConfig {
             .transpose()?
             .unwrap_or_default();
         Ok(FastlyConfig {
-            name: name.unwrap_or_else(String::new),
-            description: description.unwrap_or_else(String::new),
-            authors: authors.unwrap_or_else(Vec::new),
-            language: language.unwrap_or_else(String::new),
+            name: name.unwrap_or_default(),
+            description: description.unwrap_or_default(),
+            authors: authors.unwrap_or_default(),
+            language: language.unwrap_or_default(),
             local_server,
         })
     }

--- a/lib/src/wiggle_abi/req_impl.rs
+++ b/lib/src/wiggle_abi/req_impl.rs
@@ -9,8 +9,9 @@ use {
             fastly_http_req::FastlyHttpReq,
             headers::HttpHeaders,
             types::{
-                BodyHandle, CacheOverrideTag, ContentEncodings, HttpVersion, MultiValueCursor,
-                MultiValueCursorResult, PendingRequestHandle, RequestHandle, ResponseHandle,
+                BodyHandle, CacheOverrideTag, ContentEncodings, FramingHeadersMode, HttpVersion,
+                MultiValueCursor, MultiValueCursorResult, PendingRequestHandle, RequestHandle,
+                ResponseHandle,
             },
         },
     },
@@ -111,6 +112,19 @@ impl FastlyHttpReq for Session {
         nwritten_out: &GuestPtr<u32>,
     ) -> Result<(), Error> {
         Err(Error::NotAvailable("Client TLS data"))
+    }
+
+    fn framing_headers_mode_set(
+        &mut self,
+        _h: RequestHandle,
+        mode: FramingHeadersMode,
+    ) -> Result<(), Error> {
+        match mode {
+            FramingHeadersMode::ManuallyFromHeaders => {
+                Err(Error::NotAvailable("Manual framing headers"))
+            }
+            FramingHeadersMode::Automatic => Ok(()),
+        }
     }
 
     fn new(&mut self) -> Result<RequestHandle, Error> {

--- a/lib/src/wiggle_abi/resp_impl.rs
+++ b/lib/src/wiggle_abi/resp_impl.rs
@@ -8,8 +8,8 @@ use {
             fastly_http_resp::FastlyHttpResp,
             headers::HttpHeaders,
             types::{
-                BodyHandle, HttpStatus, HttpVersion, MultiValueCursor, MultiValueCursorResult,
-                ResponseHandle,
+                BodyHandle, FramingHeadersMode, HttpStatus, HttpVersion, MultiValueCursor,
+                MultiValueCursorResult, ResponseHandle,
             },
         },
     },
@@ -164,6 +164,19 @@ impl FastlyHttpResp for Session {
         let status = hyper::StatusCode::from_u16(status)?;
         resp.status = status;
         Ok(())
+    }
+
+    fn framing_headers_mode_set(
+        &mut self,
+        _h: ResponseHandle,
+        mode: FramingHeadersMode,
+    ) -> Result<(), Error> {
+        match mode {
+            FramingHeadersMode::ManuallyFromHeaders => {
+                Err(Error::NotAvailable("Manual framing headers"))
+            }
+            FramingHeadersMode::Automatic => Ok(()),
+        }
     }
 
     fn close(&mut self, resp_handle: ResponseHandle) -> Result<(), Error> {


### PR DESCRIPTION
This PR adds stub implementations for the new hostcalls providing custom framing header controls. Attempting to use manual controls results in an error for now.