### PR TITLE
Correct error message when the Backend URL is missing a scheme

### DIFF
--- a/lib/src/upstream.rs
+++ b/lib/src/upstream.rs
@@ -128,7 +128,7 @@ fn canonical_uri(original_uri: &Uri, canonical_host: &str, backend: &Backend) ->
         backend
             .uri
             .scheme_str()
-            .expect("Backend URL included a scheme"),
+            .expect("Backend URL is missing a scheme"),
     );
     canonical_uri.push_str("://");
 


### PR DESCRIPTION
Previously the error message said "Backend URL included a scheme" but the error looks to be because a scheme was _not_ included in the Backend URL.

This commit updates the error message to state that the scheme is missing