### PR TITLE
Add debug adapter protocol mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 publish
 verify-publishable/
 .vscode
+.idea

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,9 +49,9 @@ checksum = "4361135be9122e0870de935d7c439aef945b9f9ddd4199a553b5270b49c82a27"
 
 [[package]]
 name = "async-trait"
-version = "0.1.52"
+version = "0.1.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "061a7acccaa286c011ddc30970520b98fa40e00c9d644633fb26b5fc63a265e3"
+checksum = "ed6aa3524a2dfcf9fe180c51eae2b58738348d819517ceadf95789c51fff7600"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -140,9 +140,9 @@ checksum = "6c58ec36aac5066d5ca17df51b3e70279f5670a72102f5752cb7e7c856adfc70"
 
 [[package]]
 name = "cap-fs-ext"
-version = "0.24.1"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71f5b22f0dc04ed3404bfae102654978bfd425c5568851a89eb4d4b8f58e9590"
+checksum = "16812cf8cc096ebfddba83ad6cc768635f4d53eb6bd060f7b80866556493874a"
 dependencies = [
  "cap-primitives",
  "cap-std",
@@ -152,9 +152,9 @@ dependencies = [
 
 [[package]]
 name = "cap-primitives"
-version = "0.24.1"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "defd283f080043a702c362203c2646a4e0a2fff99baede1eea1416239f0af220"
+checksum = "ef65294d0067dd0167a84e5d50aaa52d999ab4fc7cfa59ff2ad3906afb033b36"
 dependencies = [
  "ambient-authority",
  "errno",
@@ -171,9 +171,9 @@ dependencies = [
 
 [[package]]
 name = "cap-rand"
-version = "0.24.1"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12627a93bdbbe4fb32c1ea2b2c2665ba54c49eb48f1139440ce4c6a279701461"
+checksum = "a124986fcbe880abe9ca6aad4189de44b37dbcf6ac0079f8dd9f94b379484b94"
 dependencies = [
  "ambient-authority",
  "rand",
@@ -181,9 +181,9 @@ dependencies = [
 
 [[package]]
 name = "cap-std"
-version = "0.24.1"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cbe56c8ed4cdf8360deb80dcced538968d3bac45e71befee65e95a0e262caf2"
+checksum = "3430d1b5ba78fa381eb227525578d2b85d77b42ff49be85d1e72a94f305e603c"
 dependencies = [
  "cap-primitives",
  "io-extras",
@@ -194,9 +194,9 @@ dependencies = [
 
 [[package]]
 name = "cap-time-ext"
-version = "0.24.1"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a34e5a4375b768b3acaec25dd7b53bcc15c801258c43a0ef2da2027f2028e46"
+checksum = "b9ee4390904645f384bd4e03125a4ed4d1167e9f195931c41323bacc8a2328ce"
 dependencies = [
  "cap-primitives",
  "once_cell",
@@ -240,7 +240,7 @@ dependencies = [
  "ansi_term",
  "atty",
  "bitflags",
- "strsim",
+ "strsim 0.8.0",
  "textwrap",
  "unicode-width",
  "vec_map",
@@ -273,9 +273,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95059428f66df56b63431fdb4e1947ed2190586af5c5a8a8b71122bdf5a7f469"
+checksum = "59a6001667ab124aebae2a495118e11d30984c3a653e99d86d58971708cf5e4b"
 dependencies = [
  "libc",
 ]
@@ -386,9 +386,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.2"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e54ea8bc3fb1ee042f5aace6e3c6e025d3874866da222930f70ce62aceba0bfa"
+checksum = "5aaa7bd5fb665c6864b5f963dd9097905c54125909c7aa94c9e18507cdbe6c53"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -407,10 +407,11 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.7"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c00d6d2ea26e8b151d99093005cb442fb9a37aeaca582a03ec70946f49ab5ed9"
+checksum = "1145cf131a2c6ba0615079ab6a638f7e1973ac9c2634fcbeaaad6114246efe8c"
 dependencies = [
+ "autocfg",
  "cfg-if",
  "crossbeam-utils",
  "lazy_static",
@@ -420,12 +421,99 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.7"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e5bed1f1c269533fa816a0a5492b3545209a205ca1a54842be180eb63a16a6"
+checksum = "0bf124c720b7686e3c2663cf54062ab0f68a88af2fb6a030e87e30bf721fcb38"
 dependencies = [
  "cfg-if",
  "lazy_static",
+]
+
+[[package]]
+name = "dap_types"
+version = "0.1.0"
+dependencies = [
+ "derive-getters",
+ "derive_builder",
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
+name = "darling"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f2c43f534ea4b0b049015d00269734195e6d3f0f6635cb692251aca6f9f8b3c"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e91455b86830a1c21799d94524df0845183fa55bafd9aa137b01c7d1065fa36"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim 0.10.0",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29b5acf0dea37a7f66f7b25d2c5e93fd46f8f6968b1a5d7a3e02e97768afc95a"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive-getters"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c5905670fd9c320154f3a4a01c9e609733cd7b753f3c58777ab7d5ce26686b3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d13202debe11181040ae9063d739fa32cfcaaebe2275fe387703460ae2365b30"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66e616858f6187ed828df7c64a6d71720d83767a7f19740b2d1b6fe6327b36e5"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58a94ace95092c5acb1e97a7e846b310cfbd499652f72297da7493f618a98d73"
+dependencies = [
+ "derive_builder_core",
+ "syn",
 ]
 
 [[package]]
@@ -683,13 +771,13 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d39cd93900197114fa1fcb7ae84ca742095eed9442088988ae74fa744e930e77"
+checksum = "9be70c98951c83b8d2f8f60d7065fa6d5146873094452a1008da8c2f1e4205ad"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.10.2+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -705,9 +793,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.11"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9f1f717ddc7b2ba36df7e871fd88db79326551d3d6f1fc406fbfd28b582ff8e"
+checksum = "62eeb471aa3e3c9197aa4bfeabfe02982f6dc96f750486c0bb0009ac58b26d2b"
 dependencies = [
  "bytes",
  "fnv",
@@ -797,9 +885,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.17"
+version = "0.14.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "043f0e083e9901b6cc658a77d1eb86f4fc650bbb977a4337dd63192826aa85dd"
+checksum = "b26ae0a80afebe130861d90abf98e3814a4f28a4c6ffeb5ab8ebb2be311e0ef2"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -818,6 +906,12 @@ dependencies = [
  "tracing",
  "want",
 ]
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
@@ -935,9 +1029,9 @@ checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
 name = "libc"
-version = "0.2.119"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bf2e165bb3457c8e098ea76f3e3bc9db55f87aa90d52d0e6be741470916aaa4"
+checksum = "efaa7b300f3b5fe8eb6bf21ce3895e1751d9665086af2d64b42f19701015ff4f"
 
 [[package]]
 name = "linux-raw-sys"
@@ -956,9 +1050,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.14"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
+checksum = "6389c490849ff5bc16be905ae24bc913a9c8892e19b2341dbc175e14c341c2b8"
 dependencies = [
  "cfg-if",
 ]
@@ -1020,14 +1114,15 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba272f85fa0b41fc91872be579b3bbe0f56b792aa361a380eb669469f68dafb2"
+checksum = "52da4364ffb0e4fe33a9841a98a3f3014fb964045ce4f7a45a398243c8d6b0c9"
 dependencies = [
  "libc",
  "log",
  "miow",
  "ntapi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "winapi",
 ]
 
@@ -1138,9 +1233,9 @@ dependencies = [
 
 [[package]]
 name = "paste"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0744126afe1a6dd7f394cb50a716dbe086cb06e255e53d8d0185d82828358fb5"
+checksum = "0c520e05135d6e763148b6426a837e239041653ba7becd2e538c076c738025fc"
 
 [[package]]
 name = "percent-encoding"
@@ -1230,9 +1325,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.15"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "864d3e96a899863136fc6e99f3d7cae289dafe43bf2c5ac19b70df7210c0a145"
+checksum = "632d02bff7f874a36f33ea8bb416cd484b90cc66c1194b1a1110d067a7013f58"
 dependencies = [
  "proc-macro2",
 ]
@@ -1294,21 +1389,22 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8380fe0152551244f0747b1bf41737e0f8a74f97a14ccefd1148187271634f3c"
+checksum = "8ae183fc1b06c149f0c1793e1eb447c8b04bfe46d48e9e48bfb8d2d7ed64ecf0"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "redox_users"
-version = "0.4.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "528532f3d801c87aec9def2add9ca802fe569e44a544afe633765267840abe64"
+checksum = "7776223e2696f1aa4c6b0170e83212f47296a00424305117d013dfe86fb0fe55"
 dependencies = [
  "getrandom",
  "redox_syscall",
+ "thiserror",
 ]
 
 [[package]]
@@ -1619,6 +1715,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
 name = "structopt"
 version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1644,9 +1746,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.86"
+version = "1.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a65b3f4ffa0092e9887669db0eae07941f023991ab58ea44da8fe8e2d511c6b"
+checksum = "704df27628939572cd88d33f171cd6f896f4eaca85252c6e0a72d8d8287ee86f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1995,9 +2097,12 @@ name = "viceroy"
 version = "0.2.13"
 dependencies = [
  "anyhow",
+ "dap_types",
  "futures",
  "hyper",
  "itertools",
+ "serde",
+ "serde_derive",
  "serde_json",
  "structopt",
  "tokio",
@@ -2063,6 +2168,12 @@ name = "wasi"
 version = "0.10.2+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasi-cap-std-sync"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
     "cli",
     "lib",
+    "dap_types"
 ]
 
 # Exclude our integration test fixtures, which need to be compiled to wasm

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -21,7 +21,10 @@ tracing-subscriber = "0.2.19"
 tracing-futures = "0.2.5"
 hyper = {version = "0.14.0", features = ["full"]}
 wat = "1.0.38"
+serde = "1.0.114"
+serde_derive = "1.0.114"
 serde_json = "1.0.66"
+dap_types = { path = "../dap_types" }
 
 [dev-dependencies]
 anyhow = "1.0.31"

--- a/cli/src/debugger.rs
+++ b/cli/src/debugger.rs
@@ -1,13 +1,16 @@
 use std::{
     io::{self, BufRead, Read, StdinLock, StdoutLock, Write},
-    net::SocketAddr,
+    net::{IpAddr, Ipv4Addr, SocketAddr},
+    path::Path,
 };
 
 use dap_types::{
-    requests::{Capabilities, InitializeRequestPayload, LaunchRequestPayload},
-    MessageType, ProtocolMessage, ProtocolMessageBuilder, Request, Response, ResponseBuilder,
+    events::{OutputEvent, OutputEventBuilder},
+    requests::{Capabilities, CapabilitiesBuilder, InitializeRequestPayload},
+    Event, EventBuilder, MessageType, ProtocolMessage, ProtocolMessageBuilder, Request, Response,
+    ResponseBuilder,
 };
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use tokio::task::JoinHandle;
 use tracing::{event, Level};
 use viceroy_lib::{Error, ExecuteCtx, ViceroyService};
@@ -18,13 +21,12 @@ use viceroy_lib::{Error, ExecuteCtx, ViceroyService};
 /// Viceroy does not yet support debugging but this functionality is enough to allow it to be run
 /// and inspected from within IDEs.
 pub struct DebugAdapter {
-    ctx: ExecuteCtx,
-    app_address: SocketAddr,
+    configure_ctx: Box<dyn Fn(ExecuteCtx) -> ExecuteCtx>,
 }
 
 impl DebugAdapter {
-    pub fn new(ctx: ExecuteCtx, app_address: SocketAddr) -> Self {
-        Self { ctx, app_address }
+    pub fn new(configure_ctx: Box<dyn Fn(ExecuteCtx) -> ExecuteCtx>) -> Self {
+        Self { configure_ctx }
     }
 
     pub fn serve(self) -> Result<(), Error> {
@@ -76,6 +78,13 @@ impl DebugAdapter {
                                 .request_seq(*init.seq())
                                 .success(true)
                                 .command(init.payload().command().to_string())
+                                .body(
+                                    CapabilitiesBuilder::default()
+                                        .supports_terminate_request(true)
+                                        .supports_restart_request(false)
+                                        .build()
+                                        .unwrap(),
+                                )
                                 .body(Capabilities::default())
                                 .build()
                                 .unwrap(),
@@ -97,15 +106,34 @@ impl DebugAdapter {
                     .as_str()
                     .expect("expected request to contain 'command'");
 
-                // parse message into expected struct
-                // TODO: implement Launch, Terminate, and Restart
+                // debugging
+                {
+                    let mut file = std::fs::OpenOptions::new()
+                        .write(true)
+                        .append(true)
+                        .open("/Users/kailan/Desktop/request.json")
+                        .unwrap();
+
+                    if let Err(e) = writeln!(
+                        file,
+                        "{}",
+                        serde_json::to_string_pretty(&request_data).unwrap()
+                    ) {
+                        eprintln!("Couldn't write to file: {}", e);
+                    }
+                }
+
                 match command {
                     "launch" => {
-                        let req: ProtocolMessage<Request<LaunchRequestPayload>> =
+                        let req: ProtocolMessage<Request<ViceroyLaunchRequestPayload>> =
                             serde_json::from_value(serde_json::Value::Object(request_data))
                                 .expect("could not parse launch request");
 
-                        event!(Level::INFO, "received launch command");
+                        event!(
+                            Level::INFO,
+                            "received launch command for project {}",
+                            req.payload().arguments().project
+                        );
 
                         if session.server.is_some() {
                             event!(
@@ -115,10 +143,37 @@ impl DebugAdapter {
                             continue;
                         }
 
-                        let address = self.app_address;
-                        let ctx = self.ctx.clone();
+                        let project_path = Path::new(&req.payload().arguments().project);
+                        let binary_path = project_path.join("bin/main.wasm");
 
+                        let address = SocketAddr::new(
+                            IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
+                            req.payload().arguments().port,
+                        );
+
+                        session.send_output(
+                            "console",
+                            "Loading Wasm binary...",
+                        )?;
+
+                        session.send_output(
+                            "important",
+                            "Debugging for Compute@Edge is currently in development. Please file issue reports at https://github.com/fastly/fastly-vscode.",
+                        )?;
+
+                        let ctx = (self.configure_ctx)(ExecuteCtx::new(binary_path)?);
+
+                        session.send_output(
+                            "console",
+                            &format!("Starting Compute@Edge server at http://{}", address),
+                        )?;
+
+                        // Start the Viceroy server within a tokio task so we can continue to process DAP messages.
+                        // The task's `JoinHandle` is stored to be able to terminate the server later.
                         session.server = Some(tokio::task::spawn(async move {
+                            // TODO: set up event bus so we can register hooks for events within the runtime, e.g. logging.
+                            //
+                            // This is also a step towards separating fiddle-compute-runtime from Viceroy.
                             let service = ViceroyService::new(ctx);
                             service.serve(address).await.expect("failed to serve app");
                         }));
@@ -142,12 +197,38 @@ impl DebugAdapter {
 
                         session.send_message(resp)?;
                     }
+                    "terminate" => {
+                        event!(Level::INFO, "received terminate command");
+
+                        if let Some(handle) = session.server {
+                            handle.abort();
+                            session.server = None;
+                        } else {
+                            event!(
+                                Level::WARN,
+                                "received terminate command but server is not running"
+                            );
+                        }
+
+                        break;
+                    }
                     "disconnect" => {
                         event!(Level::INFO, "received disconnect command");
+
+                        if let Some(handle) = session.server {
+                            handle.abort();
+                            session.server = None;
+                        }
+
                         break;
                     }
                     _ => {
                         event!(Level::WARN, "received unsupported command: {}", command);
+
+                        session.send_output(
+                            "console",
+                            &format!("Unsupported debugger command: {}", command),
+                        )?;
                     }
                 }
             }
@@ -155,6 +236,12 @@ impl DebugAdapter {
 
         Ok(())
     }
+}
+
+#[derive(Deserialize)]
+struct ViceroyLaunchRequestPayload {
+    port: u16,
+    project: String,
 }
 
 struct DebugSession<'a> {
@@ -165,10 +252,6 @@ struct DebugSession<'a> {
 }
 
 impl<'a> DebugSession<'a> {
-    fn start(&mut self) -> Result<(), Error> {
-        Ok(())
-    }
-
     fn read_header(&mut self) -> Result<Option<(String, String)>, Error> {
         // Read up to newline
         let mut header_bytes: Vec<u8> = vec![];
@@ -213,5 +296,31 @@ impl<'a> DebugSession<'a> {
         self.stdout.write_all(json.as_bytes())?;
         println!("Sent message {:?}", message.message_type());
         Ok(())
+    }
+
+    fn send_output<T>(&mut self, category: T, output: T) -> Result<(), Error>
+    where
+        std::string::String: std::convert::From<T>,
+    {
+        let event: ProtocolMessage<Event<OutputEvent>> = ProtocolMessageBuilder::default()
+            .message_type(MessageType::Event)
+            .seq(self.sequence)
+            .payload(
+                EventBuilder::default()
+                    .event("output".into())
+                    .body(
+                        OutputEventBuilder::default()
+                            .category(category.into())
+                            .output(output.into())
+                            .build()
+                            .unwrap(),
+                    )
+                    .build()
+                    .unwrap(),
+            )
+            .build()
+            .unwrap();
+
+        self.send_message(event)
     }
 }

--- a/cli/src/debugger.rs
+++ b/cli/src/debugger.rs
@@ -1,0 +1,217 @@
+use std::{
+    io::{self, BufRead, Read, StdinLock, StdoutLock, Write},
+    net::SocketAddr,
+};
+
+use dap_types::{
+    requests::{Capabilities, InitializeRequestPayload, LaunchRequestPayload},
+    MessageType, ProtocolMessage, ProtocolMessageBuilder, Request, Response, ResponseBuilder,
+};
+use serde::Serialize;
+use tokio::task::JoinHandle;
+use tracing::{event, Level};
+use viceroy_lib::{Error, ExecuteCtx, ViceroyService};
+
+/// The debug adapter serves a TCP socket on the given address and listens for Debug Adapter Protocol
+/// messages. These messages control the execution of the wrapped Viceroy Service.
+///
+/// Viceroy does not yet support debugging but this functionality is enough to allow it to be run
+/// and inspected from within IDEs.
+pub struct DebugAdapter {
+    ctx: ExecuteCtx,
+    app_address: SocketAddr,
+}
+
+impl DebugAdapter {
+    pub fn new(ctx: ExecuteCtx, app_address: SocketAddr) -> Self {
+        Self { ctx, app_address }
+    }
+
+    pub fn serve(self) -> Result<(), Error> {
+        let stdin = io::stdin();
+        let stdout = io::stdout();
+
+        let mut session = DebugSession {
+            stdin: stdin.lock(),
+            stdout: stdout.lock(),
+            sequence: 1,
+            server: None,
+        };
+
+        // message parsing loop
+        loop {
+            let mut content_length: usize = 0;
+
+            // header parsing loop
+            while let Some((key, value)) = session.read_header()? {
+                match key.as_str() {
+                    "Content-Length" => {
+                        content_length = value
+                            .parse::<usize>()
+                            .expect("invalid Content-Length header");
+                    }
+                    _ => {
+                        println!("Received unsupported DAP header: {}", key);
+                    }
+                }
+            }
+
+            let mut data: Vec<u8> = vec![0; content_length];
+            session.stdin.read_exact(&mut data)?;
+
+            // If this is the first message, it should be an initialize request
+            if session.sequence == 1 {
+                // parse request
+                let init: ProtocolMessage<Request<InitializeRequestPayload>> =
+                    serde_json::from_slice(&data).expect("could not parse initial request");
+                println!("Client is {}", init.payload().arguments().client_name());
+
+                // build capabilities response
+                let resp: ProtocolMessage<Response<Capabilities>> =
+                    ProtocolMessageBuilder::default()
+                        .message_type(MessageType::Response)
+                        .seq(session.sequence)
+                        .payload(
+                            ResponseBuilder::default()
+                                .request_seq(*init.seq())
+                                .success(true)
+                                .command(init.payload().command().to_string())
+                                .body(Capabilities::default())
+                                .build()
+                                .unwrap(),
+                        )
+                        .build()
+                        .unwrap();
+
+                println!("{}", serde_json::to_string_pretty(&resp).unwrap());
+
+                // send capabilities response
+                session.send_message(resp)?;
+            } else {
+                // extract command from data
+                let request_data: serde_json::Map<String, serde_json::Value> =
+                    serde_json::from_slice(&data).expect("could not parse message");
+                let command = request_data
+                    .get("command")
+                    .unwrap()
+                    .as_str()
+                    .expect("expected request to contain 'command'");
+
+                // parse message into expected struct
+                // TODO: implement Launch, Terminate, and Restart
+                match command {
+                    "launch" => {
+                        let req: ProtocolMessage<Request<LaunchRequestPayload>> =
+                            serde_json::from_value(serde_json::Value::Object(request_data))
+                                .expect("could not parse launch request");
+
+                        event!(Level::INFO, "received launch command");
+
+                        if session.server.is_some() {
+                            event!(
+                                Level::WARN,
+                                "received launch command but server is already running"
+                            );
+                            continue;
+                        }
+
+                        let address = self.app_address;
+                        let ctx = self.ctx.clone();
+
+                        session.server = Some(tokio::task::spawn(async move {
+                            let service = ViceroyService::new(ctx);
+                            service.serve(address).await.expect("failed to serve app");
+                        }));
+
+                        // We use `Option<u8>` as the generic type for the payload, as the launch response does not have a payload
+                        let resp: ProtocolMessage<Response<Option<u8>>> =
+                            ProtocolMessageBuilder::default()
+                                .message_type(MessageType::Response)
+                                .seq(session.sequence)
+                                .payload(
+                                    ResponseBuilder::default()
+                                        .request_seq(*req.seq())
+                                        .success(true)
+                                        .command(req.payload().command().to_string())
+                                        .body(None)
+                                        .build()
+                                        .unwrap(),
+                                )
+                                .build()
+                                .unwrap();
+
+                        session.send_message(resp)?;
+                    }
+                    "disconnect" => {
+                        event!(Level::INFO, "received disconnect command");
+                        break;
+                    }
+                    _ => {
+                        event!(Level::WARN, "received unsupported command: {}", command);
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+struct DebugSession<'a> {
+    stdin: StdinLock<'a>,
+    stdout: StdoutLock<'a>,
+    sequence: u32,
+    server: Option<JoinHandle<()>>,
+}
+
+impl<'a> DebugSession<'a> {
+    fn start(&mut self) -> Result<(), Error> {
+        Ok(())
+    }
+
+    fn read_header(&mut self) -> Result<Option<(String, String)>, Error> {
+        // Read up to newline
+        let mut header_bytes: Vec<u8> = vec![];
+        self.stdin.read_until(0x0A, &mut header_bytes)?;
+
+        // If there are no more headers, the remaining data should just be a carriage return
+        if header_bytes.len() == 2 {
+            return Ok(None);
+        }
+
+        assert_eq!(
+            header_bytes.pop(),
+            Some(0x0A),
+            "DAP header should be terminated with \\r\\n"
+        );
+        assert_eq!(
+            header_bytes.pop(),
+            Some(0x0D),
+            "DAP header should be terminated with \\r\\n"
+        );
+
+        let header =
+            String::from_utf8(header_bytes).expect("invalid DAP header received. expected UTF-8");
+
+        let (key, value) = header.split_at(header.find(": ").expect("invalid DAP header format"));
+
+        println!("header! key: {}, value{}", key, value);
+
+        Ok(Some((key.to_string(), value[2..value.len()].to_string())))
+    }
+
+    fn send_message<T>(&mut self, message: ProtocolMessage<T>) -> Result<(), Error>
+    where
+        T: Serialize,
+    {
+        self.sequence += 1;
+        let json = serde_json::to_string(&message).expect("could not serialize response");
+        let headers = "Content-Length: ".to_string() + &json.len().to_string() + "\r\n\r\n";
+
+        let header_bytes = headers.as_bytes();
+        self.stdout.write_all(header_bytes)?;
+        self.stdout.write_all(json.as_bytes())?;
+        println!("Sent message {:?}", message.message_type());
+        Ok(())
+    }
+}

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -15,8 +15,8 @@
 
 use crate::debugger::DebugAdapter;
 
-mod opts;
 mod debugger;
+mod opts;
 
 use {
     crate::opts::Opts,
@@ -43,6 +43,20 @@ pub async fn serve(opts: Opts) -> Result<(), Error> {
         .with_log_stderr(opts.log_stderr() || opts.debug_adapter())
         .with_log_stdout(opts.log_stdout() || opts.debug_adapter());
 
+    // Configure the execution context
+    ctx = configure_ctx(ctx, &opts).await?;
+
+    let service = ViceroyService::new(ctx);
+    let addr = opts.addr();
+
+    event!(Level::INFO, "Listening on http://{}", addr);
+    service.serve(addr).await?;
+
+    unreachable!()
+}
+
+// Configures the given `ExecuteCtx` using parameters from the given `Opts`.
+pub async fn configure_ctx(mut ctx: ExecuteCtx, opts: &Opts) -> Result<ExecuteCtx, Error> {
     if let Some(config_path) = opts.config_path() {
         let config = FastlyConfig::from_file(config_path)?;
         let backends = config.backends();
@@ -101,25 +115,7 @@ pub async fn serve(opts: Opts) -> Result<(), Error> {
         );
     }
 
-    let addr = opts.addr();
-
-    if opts.debug_adapter() {
-        event!(Level::INFO, "Starting debug server");
-
-        // Create debug adapter with the configured guest address
-        let debugger = DebugAdapter::new(ctx, addr);
-
-        // Start the debugger
-        debugger.serve()?;
-
-    } else {
-        let service = ViceroyService::new(ctx);
-
-        event!(Level::INFO, "Listening on http://{}", addr);
-        service.serve(addr).await?;
-    }
-
-    unreachable!()
+    Ok(ctx)
 }
 
 #[tokio::main]
@@ -127,18 +123,28 @@ pub async fn main() -> Result<(), Error> {
     // Parse the command-line options, exiting if there are any errors
     let opts = Opts::from_args();
 
-    //install_tracing_subscriber(&opts);
+    if !opts.debug_adapter() {
+        install_tracing_subscriber(&opts);
 
-    tokio::select! {
-        _ = tokio::signal::ctrl_c() => {
-            Ok(())
-        }
-        res = serve(opts) => {
-            if let Err(ref e) = res {
-                event!(Level::ERROR, "{}", e);
+        tokio::select! {
+            _ = tokio::signal::ctrl_c() => {
+                Ok(())
             }
-            res
+            res = serve(opts) => {
+                if let Err(ref e) = res {
+                    event!(Level::ERROR, "{}", e);
+                }
+                res
+            }
         }
+    } else {
+        event!(Level::INFO, "Starting debug server");
+
+        // Create debug adapter with the configured guest address
+        let debugger = DebugAdapter::new(Box::new(|ctx| ctx));
+
+        // Start the debugger
+        debugger.serve()
     }
 }
 

--- a/cli/src/opts.rs
+++ b/cli/src/opts.rs
@@ -48,7 +48,7 @@ pub struct Opts {
     /// [DAP]: https://microsoft.github.io/debug-adapter-protocol/overview
     // NB: struct_opt won't let us use `default_value` here, but the default is `false`
     #[structopt(long = "debug-adapter")]
-    debug_adapter: bool
+    debug_adapter: bool,
 }
 
 impl Opts {

--- a/cli/src/opts.rs
+++ b/cli/src/opts.rs
@@ -42,6 +42,13 @@ pub struct Opts {
     /// to a value before starting Viceroy
     #[structopt(short = "v", parse(from_occurrences))]
     verbosity: usize,
+    /// Whether to enable debugging mode, which will enable Viceroy to
+    /// exchange [DAP] messages with an IDE over stdio.
+    ///
+    /// [DAP]: https://microsoft.github.io/debug-adapter-protocol/overview
+    // NB: struct_opt won't let us use `default_value` here, but the default is `false`
+    #[structopt(long = "debug-adapter")]
+    debug_adapter: bool
 }
 
 impl Opts {
@@ -76,6 +83,11 @@ impl Opts {
     /// to a value before starting Viceroy
     pub fn verbosity(&self) -> usize {
         self.verbosity
+    }
+
+    /// Whether to enable debugging mode.
+    pub fn debug_adapter(&self) -> bool {
+        self.debug_adapter
     }
 }
 

--- a/dap_types/Cargo.toml
+++ b/dap_types/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "dap_types"
+version = "0.1.0"
+description = "Types for the Debug Adapter Protocol."
+authors = ["Fastly"]
+edition = "2018"
+license = "Apache-2.0 WITH LLVM-exception"
+include = [
+    "LICENSE",
+    "src/**/*"
+]
+
+[dependencies]
+serde = "1.0.114"
+serde_derive = "1.0.114"
+derive-getters = "0.2.0"
+derive_builder = "0.10.2"

--- a/dap_types/src/base.rs
+++ b/dap_types/src/base.rs
@@ -1,66 +1,65 @@
 use derive_builder::Builder;
 use derive_getters::Getters;
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "lowercase")]
 pub enum MessageType {
-  Request,
-  Response,
-  Event
+    Request,
+    Response,
+    Event,
 }
 
 /// A message in the Debug Adapter Protocol format. The generic argument `P` describes
 /// the type of the message payload (e.g. `Request<LaunchArguments>`)
 #[derive(Serialize, Deserialize, Builder, Getters, Debug, Clone)]
 pub struct ProtocolMessage<P> {
-  // Sequence number (also known as message ID). For protocol messages of type
-  // ['request'](MessageType::Request) this ID can be used to cancel the request.
-  seq: u32,
+    // Sequence number (also known as message ID). For protocol messages of type
+    // ['request'](MessageType::Request) this ID can be used to cancel the request.
+    seq: u32,
 
-  #[serde(rename="type")]
-  message_type: MessageType,
+    #[serde(rename = "type")]
+    message_type: MessageType,
 
-  // The payload of the message. Flattened during (de)serialization so the
-  // payload's fields are moved to the top level.
-  #[serde(flatten)]
-  payload: P
+    // The payload of the message. Flattened during (de)serialization so the
+    // payload's fields are moved to the top level.
+    #[serde(flatten)]
+    payload: P,
 }
 
 /// A request initiated by either the client or debug adapter. The generic argument
 /// `P` describes the type of the request arguments.
 #[derive(Serialize, Deserialize, Builder, Getters, Debug, Clone)]
 pub struct Request<P> {
-  command: String,
+    command: String,
 
-  arguments: P
+    arguments: P,
 }
-
 
 /// A response to a request. The generic argument `P` describes the type of the response
 /// body.
 #[derive(Serialize, Deserialize, Builder, Getters, Debug, Clone)]
 pub struct Response<P> {
-  // The sequence number of the request that this response was triggered by.
-  request_seq: u32,
+    // The sequence number of the request that this response was triggered by.
+    request_seq: u32,
 
-  // The command originally requested
-  command: String,
+    // The command originally requested
+    command: String,
 
-  success: bool,
+    success: bool,
 
-  // Contains the error message is `success` is false
-  #[builder(setter(into, strip_option), default)]
-  message: Option<String>,
+    // Contains the error message is `success` is false
+    #[builder(setter(into, strip_option), default)]
+    message: Option<String>,
 
-  body: P
+    body: P,
 }
 
 /// An event produced by the debug adapter. The generic argument `P` describes the
 /// type of the event body.
 #[derive(Serialize, Deserialize, Builder, Getters, Debug, Clone)]
 pub struct Event<P> {
-  event: String,
+    event: String,
 
-  body: P
+    body: P,
 }

--- a/dap_types/src/base.rs
+++ b/dap_types/src/base.rs
@@ -1,0 +1,66 @@
+use derive_builder::Builder;
+use derive_getters::Getters;
+use serde::{Serialize, Deserialize};
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "lowercase")]
+pub enum MessageType {
+  Request,
+  Response,
+  Event
+}
+
+/// A message in the Debug Adapter Protocol format. The generic argument `P` describes
+/// the type of the message payload (e.g. `Request<LaunchArguments>`)
+#[derive(Serialize, Deserialize, Builder, Getters, Debug, Clone)]
+pub struct ProtocolMessage<P> {
+  // Sequence number (also known as message ID). For protocol messages of type
+  // ['request'](MessageType::Request) this ID can be used to cancel the request.
+  seq: u32,
+
+  #[serde(rename="type")]
+  message_type: MessageType,
+
+  // The payload of the message. Flattened during (de)serialization so the
+  // payload's fields are moved to the top level.
+  #[serde(flatten)]
+  payload: P
+}
+
+/// A request initiated by either the client or debug adapter. The generic argument
+/// `P` describes the type of the request arguments.
+#[derive(Serialize, Deserialize, Builder, Getters, Debug, Clone)]
+pub struct Request<P> {
+  command: String,
+
+  arguments: P
+}
+
+
+/// A response to a request. The generic argument `P` describes the type of the response
+/// body.
+#[derive(Serialize, Deserialize, Builder, Getters, Debug, Clone)]
+pub struct Response<P> {
+  // The sequence number of the request that this response was triggered by.
+  request_seq: u32,
+
+  // The command originally requested
+  command: String,
+
+  success: bool,
+
+  // Contains the error message is `success` is false
+  #[builder(setter(into, strip_option), default)]
+  message: Option<String>,
+
+  body: P
+}
+
+/// An event produced by the debug adapter. The generic argument `P` describes the
+/// type of the event body.
+#[derive(Serialize, Deserialize, Builder, Getters, Debug, Clone)]
+pub struct Event<P> {
+  event: String,
+
+  body: P
+}

--- a/dap_types/src/events.rs
+++ b/dap_types/src/events.rs
@@ -1,0 +1,10 @@
+use derive_builder::Builder;
+use derive_getters::Getters;
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Builder, Getters, Debug, Clone, Default)]
+#[serde(rename_all = "camelCase", default)]
+pub struct OutputEvent {
+    category: String,
+    output: String,
+}

--- a/dap_types/src/lib.rs
+++ b/dap_types/src/lib.rs
@@ -1,5 +1,5 @@
 mod base;
-pub mod requests;
 pub mod events;
+pub mod requests;
 
 pub use base::*;

--- a/dap_types/src/lib.rs
+++ b/dap_types/src/lib.rs
@@ -1,0 +1,5 @@
+mod base;
+pub mod requests;
+pub mod events;
+
+pub use base::*;

--- a/dap_types/src/requests.rs
+++ b/dap_types/src/requests.rs
@@ -60,16 +60,17 @@ pub struct InitializeRequestPayload {
 
 #[derive(Serialize, Deserialize, Builder, Getters, Debug, Clone, Default)]
 #[serde(rename_all = "camelCase", default)]
+#[builder(default)]
 /// Describes the capabilities of the debug adapter.
 pub struct Capabilities {
-  supports_configuration_done_request: bool,
-  supports_restart_request: bool,
-  #[serde(rename = "support_terminate_buggee")]
-  supports_terminate_debuggee: bool,
-  #[serde(rename = "support_suspend_buggee")]
-  supports_suspend_debuggee: bool,
-  supports_terminate_request: bool,
-  supports_cancel_request: bool,
+    supports_configuration_done_request: bool,
+    supports_restart_request: bool,
+    #[serde(rename = "supportTerminateDebuggee")]
+    supports_terminate_debuggee: bool,
+    #[serde(rename = "supportSuspendDebuggee")]
+    supports_suspend_debuggee: bool,
+    supports_terminate_request: bool,
+    supports_cancel_request: bool,
 }
 
 #[derive(Serialize, Deserialize, Builder, Getters, Debug, Clone, Default)]
@@ -78,5 +79,3 @@ pub struct Capabilities {
 pub struct LaunchRequestPayload {
     no_debug: bool,
 }
-
-

--- a/dap_types/src/requests.rs
+++ b/dap_types/src/requests.rs
@@ -1,0 +1,82 @@
+use derive_builder::Builder;
+use derive_getters::Getters;
+use serde::{Deserialize, Serialize};
+
+fn true_bool() -> bool {
+    true
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "lowercase")]
+#[serde(untagged)]
+pub enum PathFormat {
+    Path,
+    Uri,
+    Other(String),
+}
+
+/// Sent from the client to the debug adpater to configure capabilities.
+///
+/// Until the debug adapter has responded to with an ‘initialize’ response,
+/// the client must not send any additional requests or events to the debug adapter.
+#[derive(Serialize, Deserialize, Builder, Getters, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct InitializeRequestPayload {
+    #[serde(rename = "clientID")]
+    client_id: String,
+    client_name: String,
+
+    #[serde(rename = "adapterID")]
+    adapter_id: String,
+
+    // The ISO-639 locale of the (frontend) client using this adapter, e.g. en-US or de-CH.
+    locale: String,
+
+    // If true all line numbers are 1-based (default).
+    #[serde(default = "true_bool")]
+    lines_start_at1: bool,
+
+    // If true all column numbers are 1-based (default).
+    #[serde(default = "true_bool")]
+    columns_start_at1: bool,
+
+    path_format: PathFormat,
+
+    #[serde(default)]
+    supports_variable_type: bool,
+    #[serde(default)]
+    supports_variable_paging: bool,
+    #[serde(default)]
+    supports_run_in_terminal_request: bool,
+    #[serde(default)]
+    supports_memory_references: bool,
+    #[serde(default)]
+    supports_progress_reporting: bool,
+    #[serde(default)]
+    supports_invalidated_event: bool,
+    #[serde(default)]
+    supports_memory_event: bool,
+}
+
+#[derive(Serialize, Deserialize, Builder, Getters, Debug, Clone, Default)]
+#[serde(rename_all = "camelCase", default)]
+/// Describes the capabilities of the debug adapter.
+pub struct Capabilities {
+  supports_configuration_done_request: bool,
+  supports_restart_request: bool,
+  #[serde(rename = "support_terminate_buggee")]
+  supports_terminate_debuggee: bool,
+  #[serde(rename = "support_suspend_buggee")]
+  supports_suspend_debuggee: bool,
+  supports_terminate_request: bool,
+  supports_cancel_request: bool,
+}
+
+#[derive(Serialize, Deserialize, Builder, Getters, Debug, Clone, Default)]
+#[serde(rename_all = "camelCase", default)]
+/// A request to start the debuggee with or without debugging.
+pub struct LaunchRequestPayload {
+    no_debug: bool,
+}
+
+

--- a/lib/src/event.rs
+++ b/lib/src/event.rs
@@ -1,0 +1,3 @@
+pub enum Event {
+  Log(String, String)
+}

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -27,5 +27,6 @@ mod service;
 mod streaming_body;
 mod upstream;
 mod wiggle_abi;
+mod event;
 
-pub use {error::Error, execute::ExecuteCtx, service::ViceroyService, upstream::BackendConnector};
+pub use {error::Error, execute::ExecuteCtx, service::ViceroyService, upstream::BackendConnector, event::Event};

--- a/lib/src/wiggle_abi/log_impl.rs
+++ b/lib/src/wiggle_abi/log_impl.rs
@@ -1,7 +1,10 @@
 //! fastly_log` hostcall implementations.
 
+use crate::Event;
+
 use {
     crate::{
+        event,
         error::Error,
         session::Session,
         wiggle_abi::{fastly_log::FastlyLog, types::EndpointHandle},
@@ -41,6 +44,9 @@ impl FastlyLog for Session {
     ) -> Result<u32, Error> {
         let endpoint = self.log_endpoint(endpoint_handle)?;
         let msg = msg.as_slice()?;
+
+        self.send_event(Event::Log("endpoint".to_string(), String::from_utf8(msg.to_vec()).unwrap_or_else(|_| "invalid utf8".into())));
+
         endpoint
             .write_entry(&msg)
             .map(|_| msg.len() as u32)


### PR DESCRIPTION
This is a minimal [Debug Adapter Protocol](https://microsoft.github.io/debug-adapter-protocol/) implementation in support of a VS Code extension for Compute@Edge.

Running Viceroy with the debug flag (`viceroy --debug bin/main.wasm`) will not start the server instantly. Instead, it will wait for a DAP handshake and a `Launch` request over stdin, which will then launch the server. Instead of standard log output, stdout outputs JSON-encoded DAP messages. This allows any IDEs that support DAP (most) to easily run Viceroy and receive telemetry. 

Requests such as `Restart` and `Terminate` are supported but actual debugging is not implemented. Output from log endpoints and guest stdio is streamed to the IDE. In the future, we could provide more telemetry data like we do in Fiddle. 

This introduces a new crate to the root workspace (dap_types) and a new `debugger` module within viceroy_cli. In the Viceroy main() method we fork the ViceroyService.serve() logic based on presence of the `—debug` flag.

This work also supports the eventual removal of the internal Fiddle fork of Viceroy, as we are able to start surfacing events from the runtime.

---

Still to come: 
- [x] Split large `serve` method into modules – header parsing, msg parsing, request matching
- [x] Remove commented-out request event
- [ ] Improve documentation
- [x] Identify log endpoint in log event
- [ ] Test on Windows
