### PR TITLE
🍎 config: expose `FastlyConfig::from_str`

### DIFF
--- a/lib/src/config.rs
+++ b/lib/src/config.rs
@@ -80,7 +80,7 @@ impl FastlyConfig {
     }
 
     /// Parse a string containing TOML data into a `FastlyConfig`.
-    fn from_str(toml: impl AsRef<str>) -> Result<Self, FastlyConfigError> {
+    pub fn from_str(toml: impl AsRef<str>) -> Result<Self, FastlyConfigError> {
         toml::from_str::<'_, TomlFastlyConfig>(toml.as_ref())
             .map_err(Into::into)
             .and_then(TryInto::try_into)


### PR DESCRIPTION
in order to facilitate using `viceroy_lib` in tests, without needing to
write many `fastly.toml` files to the filesystem, we expose the
`from_str` constructor for `FastlyConfig`.

this patch is made with use cases like those described in #146 in
mind. cc: @GeeWee 