### PR TITLE
💕 support for inline toml dictionaries

### DIFF
--- a/cli/tests/integration/dictionary_lookup.rs
+++ b/cli/tests/integration/dictionary_lookup.rs
@@ -1,0 +1,62 @@
+use crate::common::{Test, TestResult};
+use hyper::{body::to_bytes, StatusCode};
+
+#[tokio::test(flavor = "multi_thread")]
+async fn json_dictionary_lookup_works() -> TestResult {
+    const FASTLY_TOML: &str = r#"
+        name = "json-dictionary-lookup"
+        description = "json dictionary lookup test"
+        authors = ["Jill Bryson <jbryson@fastly.com>", "Rose McDowall <rmcdowall@fastly.com>"]
+        language = "rust"
+        [local_server]
+        [local_server.dictionaries]
+        [local_server.dictionaries.animals]
+        file = "../test-fixtures/data/json-dictionary.json"
+        format = "json"
+    "#;
+
+    let resp = Test::using_fixture("dictionary-lookup.wasm")
+        .using_fastly_toml(FASTLY_TOML)?
+        .against_empty()
+        .await;
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    assert!(to_bytes(resp.into_body())
+        .await
+        .expect("can read body")
+        .to_vec()
+        .is_empty());
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn inline_toml_dictionary_lookup_works() -> TestResult {
+    const FASTLY_TOML: &str = r#"
+        name = "inline-toml-dictionary-lookup"
+        description = "inline toml dictionary lookup test"
+        authors = ["Jill Bryson <jbryson@fastly.com>", "Rose McDowall <rmcdowall@fastly.com>"]
+        language = "rust"
+        [local_server]
+        [local_server.dictionaries]
+        [local_server.dictionaries.animals]
+        format = "inline-toml"
+        [local_server.dictionaries.animals.contents]
+        dog = "woof"
+        cat = "meow"
+    "#;
+
+    let resp = Test::using_fixture("dictionary-lookup.wasm")
+        .using_fastly_toml(FASTLY_TOML)?
+        .against_empty()
+        .await;
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    assert!(to_bytes(resp.into_body())
+        .await
+        .expect("can read body")
+        .to_vec()
+        .is_empty());
+
+    Ok(())
+}

--- a/cli/tests/integration/main.rs
+++ b/cli/tests/integration/main.rs
@@ -1,5 +1,6 @@
 mod body;
 mod common;
+mod dictionary_lookup;
 mod downstream_req;
 mod env_vars;
 mod http_semantics;

--- a/lib/src/config/dictionaries.rs
+++ b/lib/src/config/dictionaries.rs
@@ -110,8 +110,8 @@ mod deserialization {
                     })?;
 
                 let dictionary = match format.as_str() {
-                    "inline-toml" => process_inline_toml_dictionary(toml)?,
-                    "json" => process_json_dictionary(toml, name)?,
+                    "inline-toml" => process_inline_toml_dictionary(&mut toml)?,
+                    "json" => process_json_dictionary(&mut toml, name)?,
                     "" => return Err(DictionaryConfigError::EmptyFormatEntry),
                     _ => {
                         return Err(DictionaryConfigError::InvalidDictionaryFileFormat(
@@ -121,6 +121,7 @@ mod deserialization {
                 };
 
                 let name = name.parse()?;
+                check_for_unrecognized_keys(&toml)?;
 
                 Ok((name, dictionary))
             }
@@ -136,7 +137,7 @@ mod deserialization {
     }
 
     fn process_inline_toml_dictionary(
-        mut toml: Table,
+        toml: &mut Table,
     ) -> Result<Dictionary, DictionaryConfigError> {
         let toml = match toml
             .remove("contents")
@@ -159,7 +160,7 @@ mod deserialization {
     }
 
     fn process_json_dictionary(
-        mut toml: Table,
+        toml: &mut Table,
         name: &str,
     ) -> Result<Dictionary, DictionaryConfigError> {
         let file = toml
@@ -175,7 +176,6 @@ mod deserialization {
                 }
                 _ => Err(DictionaryConfigError::InvalidFileEntry),
             })?;
-        check_for_unrecognized_keys(&toml)?;
         event!(
             Level::INFO,
             "checking if the dictionary '{}' adheres to Fastly's API",

--- a/lib/src/config/dictionaries.rs
+++ b/lib/src/config/dictionaries.rs
@@ -189,23 +189,16 @@ mod deserialization {
         };
 
         // Read the contents of the given file.
-        let data = fs::read_to_string(&file).map_err(|err| DictionaryConfigError::IoError {
-            name: name.to_string(),
-            error: err.to_string(),
-        })?;
+        let data = fs::read_to_string(&file).map_err(DictionaryConfigError::IoError)?;
 
         // Deserialize the contents of the given JSON file.
-        let json = match serde_json::from_str(&data).map_err(|_| {
-            DictionaryConfigError::DictionaryFileWrongFormat {
-                name: name.to_string(),
-            }
-        })? {
+        let json = match serde_json::from_str(&data)
+            .map_err(|_| DictionaryConfigError::DictionaryFileWrongFormat)?
+        {
             // Check that we were given an object.
             serde_json::Value::Object(obj) => obj,
             _ => {
-                return Err(DictionaryConfigError::DictionaryFileWrongFormat {
-                    name: name.to_string(),
-                })
+                return Err(DictionaryConfigError::DictionaryFileWrongFormat);
             }
         };
 
@@ -215,7 +208,6 @@ mod deserialization {
             let value = value
                 .as_str()
                 .ok_or_else(|| DictionaryConfigError::DictionaryItemValueWrongFormat {
-                    name: name.to_string(),
                     key: key.clone(),
                 })?
                 .to_owned();
@@ -238,7 +230,6 @@ mod deserialization {
         );
         if dict.len() > DICTIONARY_MAX_LEN {
             return Err(DictionaryConfigError::DictionaryCountTooLong {
-                name: name.to_string(),
                 size: DICTIONARY_MAX_LEN.try_into().unwrap(),
             });
         }
@@ -250,14 +241,12 @@ mod deserialization {
         for (key, value) in dict.iter() {
             if key.chars().count() > DICTIONARY_ITEM_KEY_MAX_LEN {
                 return Err(DictionaryConfigError::DictionaryItemKeyTooLong {
-                    name: name.to_string(),
                     key: key.clone(),
                     size: DICTIONARY_ITEM_KEY_MAX_LEN.try_into().unwrap(),
                 });
             }
             if value.chars().count() > DICTIONARY_ITEM_VALUE_MAX_LEN {
                 return Err(DictionaryConfigError::DictionaryItemValueTooLong {
-                    name: name.to_string(),
                     key: key.clone(),
                     size: DICTIONARY_ITEM_VALUE_MAX_LEN.try_into().unwrap(),
                 });

--- a/lib/src/config/dictionaries.rs
+++ b/lib/src/config/dictionaries.rs
@@ -66,18 +66,6 @@ mod deserialization {
         tracing::info,
     };
 
-    /// Helper function for converting a TOML [`Value`] into a [`Table`].
-    ///
-    /// This function checks that a value is a [`Value::Table`] variant and returns the underlying
-    /// [`Table`], or returns an error if the given value was not of the right type — e.g., a
-    /// [`Boolean`][Value::Boolean] or a [`String`][Value::String]).
-    fn into_table(value: Value) -> Result<Table, DictionaryConfigError> {
-        match value {
-            Value::Table(table) => Ok(table),
-            _ => Err(DictionaryConfigError::InvalidEntryType),
-        }
-    }
-
     /// Return an [`DictionaryConfigError::UnrecognizedKey`] error if any unrecognized keys are found.
     ///
     /// This should be called after we have removed and validated the keys we expect in a [`Table`].
@@ -97,9 +85,12 @@ mod deserialization {
             /// Process a dictionary's definitions, or return a [`FastlyConfigError`].
             fn process_entry(
                 name: &str,
-                defs: Value,
+                entry: Value,
             ) -> Result<(DictionaryName, Dictionary), DictionaryConfigError> {
-                let mut toml = into_table(defs)?;
+                let mut toml = match entry {
+                    Value::Table(table) => table,
+                    _ => return Err(DictionaryConfigError::InvalidEntryType),
+                };
 
                 let format = toml
                     .remove("format")

--- a/lib/src/config/dictionaries.rs
+++ b/lib/src/config/dictionaries.rs
@@ -63,7 +63,7 @@ mod deserialization {
         },
         std::{collections::HashMap, convert::TryFrom, convert::TryInto, fs, str::FromStr},
         toml::value::{Table, Value},
-        tracing::{event, Level},
+        tracing::info,
     };
 
     /// Helper function for converting a TOML [`Value`] into a [`Table`].
@@ -228,12 +228,10 @@ mod deserialization {
         name: &str,
         dict: &HashMap<String, String>,
     ) -> Result<(), DictionaryConfigError> {
-        event!(
-            Level::INFO,
+        info!(
             "checking if the dictionary '{}' adheres to Fastly's API",
             name
         );
-
         if dict.len() > DICTIONARY_MAX_LEN {
             return Err(DictionaryConfigError::DictionaryCountTooLong {
                 name: name.to_string(),
@@ -241,8 +239,7 @@ mod deserialization {
             });
         }
 
-        event!(
-            Level::INFO,
+        info!(
             "checking if the items in dictionary '{}' adhere to Fastly's API",
             name
         );
@@ -262,6 +259,7 @@ mod deserialization {
                 });
             }
         }
+
         Ok(())
     }
 

--- a/lib/src/config/unit_tests.rs
+++ b/lib/src/config/unit_tests.rs
@@ -1,9 +1,6 @@
 use {
     super::{FastlyConfig, LocalServerConfig, RawLocalServerConfig},
-    crate::{
-        config::DictionaryName,
-        error::FastlyConfigError,
-    },
+    crate::{config::DictionaryName, error::FastlyConfigError},
     std::{convert::TryInto, fs::File, io::Write},
     tempfile::tempdir,
 };

--- a/lib/src/config/unit_tests.rs
+++ b/lib/src/config/unit_tests.rs
@@ -379,6 +379,7 @@ mod json_dictionary_config_tests {
             res => panic!("unexpected result: {:?}", res),
         }
     }
+
     /// Check that dictionary definitions *must* include a `format` field.
     #[test]
     fn dictionary_configs_must_provide_a_format() {
@@ -402,6 +403,7 @@ mod json_dictionary_config_tests {
             res => panic!("unexpected result: {:?}", res),
         }
     }
+
     /// Check that dictionary definitions must include a *valid* `name` field.
     #[test]
     fn dictionary_configs_must_provide_a_valid_name() {
@@ -426,6 +428,7 @@ mod json_dictionary_config_tests {
             res => panic!("unexpected result: {:?}", res),
         }
     }
+
     /// Check that file field is a string.
     #[test]
     fn dictionary_configs_must_provide_file_as_a_string() {
@@ -442,6 +445,7 @@ mod json_dictionary_config_tests {
             res => panic!("unexpected result: {:?}", res),
         }
     }
+
     /// Check that file field is non empty.
     #[test]
     fn dictionary_configs_must_provide_a_non_empty_file() {
@@ -458,6 +462,7 @@ mod json_dictionary_config_tests {
             res => panic!("unexpected result: {:?}", res),
         }
     }
+
     /// Check that format field is a string.
     #[test]
     fn dictionary_configs_must_provide_format_as_a_string() {
@@ -474,6 +479,7 @@ mod json_dictionary_config_tests {
             res => panic!("unexpected result: {:?}", res),
         }
     }
+
     /// Check that format field is non empty.
     #[test]
     fn dictionary_configs_must_provide_a_non_empty_format() {
@@ -490,6 +496,7 @@ mod json_dictionary_config_tests {
             res => panic!("unexpected result: {:?}", res),
         }
     }
+
     /// Check that format field set to json is valid.
     #[test]
     fn valid_dictionary_config_with_format_set_to_json() {

--- a/lib/src/config/unit_tests.rs
+++ b/lib/src/config/unit_tests.rs
@@ -1,7 +1,7 @@
 use {
     super::{FastlyConfig, LocalServerConfig, RawLocalServerConfig},
     crate::{
-        config::{dictionaries::DictionaryFormat, DictionaryName},
+        config::DictionaryName,
         error::FastlyConfigError,
     },
     std::{convert::TryInto, fs::File, io::Write},
@@ -137,8 +137,8 @@ fn fastly_toml_files_with_simple_dictionary_configurations_can_be_read() {
         .dictionaries()
         .get(&DictionaryName::new("a".to_string()))
         .expect("dictionary configurations can be accessed");
-    assert_eq!(dictionary.file, file_path);
-    assert_eq!(dictionary.format, DictionaryFormat::Json);
+    assert_eq!(dictionary.file_path().unwrap(), file_path);
+    assert!(dictionary.is_json());
 }
 
 /// Check that the `local_server` section can be deserialized.

--- a/lib/src/config/unit_tests.rs
+++ b/lib/src/config/unit_tests.rs
@@ -517,3 +517,23 @@ mod json_dictionary_config_tests {
         );
     }
 }
+
+/// Unit tests for dictionaries in the `local_server` section of a `fastly.toml` package manifest.
+///
+/// These tests check that we deserialize and validate the dictionary configurations section of
+/// the TOML data properly for dictionaries using inline TOML to store their data.
+mod inline_toml_dictionary_config_tests {
+    use super::read_local_server_config;
+
+    #[test]
+    fn valid_inline_toml_dictionaries_can_be_parsed() {
+        let dictionary = r#"
+            [dictionaries.inline_toml_example]
+            format = "inline-toml"
+            contents = { apple = "fruit", potato = "vegetable" }
+        "#;
+        read_local_server_config(&dictionary).expect(
+            "can read toml data containing local dictionary configurations using json format",
+        );
+    }
+}

--- a/lib/src/config/unit_tests.rs
+++ b/lib/src/config/unit_tests.rs
@@ -150,7 +150,7 @@ mod local_server_config_tests {
         std::convert::TryInto,
     };
 
-    fn read_toml_config(toml: &str) -> Result<LocalServerConfig, FastlyConfigError> {
+    fn read_local_server_config(toml: &str) -> Result<LocalServerConfig, FastlyConfigError> {
         toml::from_str::<'_, RawLocalServerConfig>(toml)
             .expect("valid toml data")
             .try_into()
@@ -178,7 +178,7 @@ mod local_server_config_tests {
         "#,
             file_path.to_str().unwrap()
         );
-        match read_toml_config(&local_server) {
+        match read_local_server_config(&local_server) {
             Ok(_) => {}
             res => panic!("unexpected result: {:?}", res),
         }
@@ -192,7 +192,7 @@ mod local_server_config_tests {
             [backends]
             "shark" = "https://a.com"
         "#;
-        match read_toml_config(BAD_DEF) {
+        match read_local_server_config(BAD_DEF) {
             Err(InvalidBackendDefinition {
                 err: InvalidEntryType,
                 ..
@@ -209,7 +209,7 @@ mod local_server_config_tests {
             [backends]
             shark = { url = "https://a.com", shrimp = true }
         "#;
-        match read_toml_config(BAD_DEFAULT) {
+        match read_local_server_config(BAD_DEFAULT) {
             Err(InvalidBackendDefinition {
                 err: UnrecognizedKey(key),
                 ..
@@ -226,7 +226,7 @@ mod local_server_config_tests {
             [backends]
             "shark" = {}
         "#;
-        match read_toml_config(NO_URL) {
+        match read_local_server_config(NO_URL) {
             Err(InvalidBackendDefinition {
                 err: MissingUrl, ..
             }) => {}
@@ -242,7 +242,7 @@ mod local_server_config_tests {
             [backends]
             "shark" = { url = 3 }
         "#;
-        match read_toml_config(BAD_URL_FIELD) {
+        match read_local_server_config(BAD_URL_FIELD) {
             Err(InvalidBackendDefinition {
                 err: InvalidUrlEntry,
                 ..
@@ -258,7 +258,7 @@ mod local_server_config_tests {
             [backends]
             "shark" = { url = "http:://[:::1]" }
         "#;
-        match read_toml_config(BAD_URL_FIELD) {
+        match read_local_server_config(BAD_URL_FIELD) {
             Err(InvalidBackendDefinition {
                 err: InvalidUrl(_), ..
             }) => {}
@@ -273,7 +273,7 @@ mod local_server_config_tests {
             [backends]
             "shark" = { url = "http://a.com", override_host = 3 }
         "#;
-        match read_toml_config(BAD_OVERRIDE_HOST_FIELD) {
+        match read_local_server_config(BAD_OVERRIDE_HOST_FIELD) {
             Err(InvalidBackendDefinition {
                 err: InvalidOverrideHostEntry,
                 ..
@@ -289,7 +289,7 @@ mod local_server_config_tests {
             [backends]
             "shark" = { url = "http://a.com", override_host = "" }
         "#;
-        match read_toml_config(EMPTY_OVERRIDE_HOST_FIELD) {
+        match read_local_server_config(EMPTY_OVERRIDE_HOST_FIELD) {
             Err(InvalidBackendDefinition {
                 err: EmptyOverrideHost,
                 ..
@@ -305,7 +305,7 @@ mod local_server_config_tests {
             [backends]
             "shark" = { url = "http://a.com", override_host = "somehost.com\n" }
         "#;
-        match read_toml_config(BAD_OVERRIDE_HOST_FIELD) {
+        match read_local_server_config(BAD_OVERRIDE_HOST_FIELD) {
             Err(InvalidBackendDefinition {
                 err: InvalidOverrideHost(_),
                 ..
@@ -322,7 +322,7 @@ mod local_server_config_tests {
             [dictionaries]
             "thing" = "stuff"
         "#;
-        match read_toml_config(BAD_DEF) {
+        match read_local_server_config(BAD_DEF) {
             Err(InvalidDictionaryDefinition {
                 err: InvalidEntryType,
                 ..
@@ -347,7 +347,7 @@ mod local_server_config_tests {
         "#,
             file_path.to_str().unwrap()
         );
-        match read_toml_config(&bad_default) {
+        match read_local_server_config(&bad_default) {
             Err(InvalidDictionaryDefinition {
                 err: UnrecognizedKey(key),
                 ..
@@ -364,7 +364,7 @@ mod local_server_config_tests {
             [dictionaries]
             thing = {format = "json"}
         "#;
-        match read_toml_config(NO_FILE) {
+        match read_local_server_config(NO_FILE) {
             Err(InvalidDictionaryDefinition {
                 err: MissingFile, ..
             }) => {}
@@ -387,7 +387,7 @@ mod local_server_config_tests {
         "#,
             file_path.to_str().unwrap()
         );
-        match read_toml_config(&no_format_field) {
+        match read_local_server_config(&no_format_field) {
             Err(InvalidDictionaryDefinition {
                 err: MissingFormat, ..
             }) => {}
@@ -410,7 +410,7 @@ mod local_server_config_tests {
         "#,
             file_path.to_str().unwrap()
         );
-        match read_toml_config(&bad_name_field) {
+        match read_local_server_config(&bad_name_field) {
             Err(InvalidDictionaryDefinition {
                 err: InvalidName(_),
                 ..
@@ -426,7 +426,7 @@ mod local_server_config_tests {
             [dictionaries]
             "thing" = { file = 3, format = "json" }
         "#;
-        match read_toml_config(BAD_FILE_FIELD) {
+        match read_local_server_config(BAD_FILE_FIELD) {
             Err(InvalidDictionaryDefinition {
                 err: InvalidFileEntry,
                 ..
@@ -442,7 +442,7 @@ mod local_server_config_tests {
             [dictionaries]
             "thing" = { file = "", format = "json" }
         "#;
-        match read_toml_config(EMPTY_FILE_FIELD) {
+        match read_local_server_config(EMPTY_FILE_FIELD) {
             Err(InvalidDictionaryDefinition {
                 err: EmptyFileEntry,
                 ..
@@ -458,7 +458,7 @@ mod local_server_config_tests {
             [dictionaries]
             "thing" = { format = 3}
         "#;
-        match read_toml_config(BAD_FORMAT_FIELD) {
+        match read_local_server_config(BAD_FORMAT_FIELD) {
             Err(InvalidDictionaryDefinition {
                 err: InvalidFormatEntry,
                 ..
@@ -474,7 +474,7 @@ mod local_server_config_tests {
             [dictionaries]
             "thing" = { format = "" }
         "#;
-        match read_toml_config(EMPTY_FORMAT_FIELD) {
+        match read_local_server_config(EMPTY_FORMAT_FIELD) {
             Err(InvalidDictionaryDefinition {
                 err: EmptyFormatEntry,
                 ..
@@ -497,7 +497,7 @@ mod local_server_config_tests {
         "#,
             file_path.to_str().unwrap()
         );
-        read_toml_config(&dictionary).expect(
+        read_local_server_config(&dictionary).expect(
             "can read toml data containing local dictionary configurations using json format",
         );
     }

--- a/lib/src/config/unit_tests.rs
+++ b/lib/src/config/unit_tests.rs
@@ -168,10 +168,10 @@ mod local_server_config_tests {
 
         let local_server = format!(
             r#"
-            [backends]            
+            [backends]
               [backends.dog]
               url = "http://localhost:7878/dog-mocks"
-            [dicionaries]            
+            [dicionaries]
               [dicionaries.secrets]
               file = '{}'
               format = "json"

--- a/lib/src/error.rs
+++ b/lib/src/error.rs
@@ -302,8 +302,8 @@ pub enum BackendConfigError {
 #[derive(Debug, thiserror::Error)]
 pub enum DictionaryConfigError {
     /// An I/O error that occured while reading the file.
-    #[error("error reading `{name}`: {error}")]
-    IoError { name: String, error: String },
+    #[error(transparent)]
+    IoError(std::io::Error),
 
     #[error("'contents' was not provided as a TOML table")]
     InvalidContentsType,
@@ -353,30 +353,22 @@ pub enum DictionaryConfigError {
     #[error("unrecognized key '{0}'")]
     UnrecognizedKey(String),
 
-    #[error("Item key named '{key}' in dictionary named '{name}' is too long, max size is {size}")]
-    DictionaryItemKeyTooLong {
-        key: String,
-        name: String,
-        size: i32,
-    },
+    #[error("Item key named '{key}' is too long, max size is {size}")]
+    DictionaryItemKeyTooLong { key: String, size: i32 },
 
-    #[error("The dictionary named '{name}' has too many items, max amount is {size}")]
-    DictionaryCountTooLong { name: String, size: i32 },
+    #[error("too many items, max amount is {size}")]
+    DictionaryCountTooLong { size: i32 },
 
-    #[error("Item value under key named '{key}' in dictionary named '{name}' is of the wrong format. The value is expected to be a JSON String")]
-    DictionaryItemValueWrongFormat { key: String, name: String },
+    #[error("Item value under key named '{key}' is of the wrong format. The value is expected to be a JSON String")]
+    DictionaryItemValueWrongFormat { key: String },
+
+    #[error("Item value named '{key}' is too long, max size is {size}")]
+    DictionaryItemValueTooLong { key: String, size: i32 },
 
     #[error(
-        "Item value named '{key}' in dictionary named '{name}' is too long, max size is {size}"
+        "The file is of the wrong format. The file is expected to contain a single JSON Object"
     )]
-    DictionaryItemValueTooLong {
-        key: String,
-        name: String,
-        size: i32,
-    },
-
-    #[error("The file for the dictionary named '{name}' is of the wrong format. The file is expected to contain a single JSON Object")]
-    DictionaryFileWrongFormat { name: String },
+    DictionaryFileWrongFormat,
 }
 
 /// Errors related to the downstream request.

--- a/lib/src/error.rs
+++ b/lib/src/error.rs
@@ -305,6 +305,12 @@ pub enum DictionaryConfigError {
     #[error("error reading `{name}`: {error}")]
     IoError { name: String, error: String },
 
+    #[error("'contents' was not provided as a TOML table")]
+    InvalidContentsType,
+
+    #[error("inline dictionary value was not a string")]
+    InvalidInlineEntryType,
+
     #[error("definition was not provided as a TOML table")]
     InvalidEntryType,
 
@@ -328,6 +334,9 @@ pub enum DictionaryConfigError {
 
     #[error("'format' field was not a string")]
     InvalidFormatEntry,
+
+    #[error("missing 'contents' field")]
+    MissingContents,
 
     #[error("no default definition provided")]
     MissingDefault,

--- a/lib/src/wiggle_abi/dictionary_impl.rs
+++ b/lib/src/wiggle_abi/dictionary_impl.rs
@@ -52,28 +52,35 @@ impl FastlyDictionary for Session {
     ) -> Result<u32, Error> {
         let key: &str = &key.as_str()?;
         let dict = self.dictionary(dictionary)?;
-        match dict {
+        let item_bytes = match dict {
+            Dictionary::InlineToml { contents } => contents
+                .get(key)
+                .ok_or_else(|| DictionaryError::UnknownDictionaryItem(key.to_owned()))?
+                .as_bytes()
+                .to_owned(),
             Dictionary::Json { file } => {
                 let obj = read_json_file(file);
-                let item = obj
-                    .get(key)
-                    .ok_or_else(|| DictionaryError::UnknownDictionaryItem(key.to_owned()))?;
-                let item = item.as_str().unwrap();
-                let item_bytes = item.as_bytes();
-
-                if item_bytes.len() > buf_len as usize {
-                    return Err(Error::BufferLengthError {
-                        buf: "dictionary_item",
-                        len: "dictionary_item_max_len",
-                    });
-                }
-                let item_len = u32::try_from(item_bytes.len())
-                    .expect("smaller than dictionary_item_max_len means it must fit");
-
-                let mut buf_slice = buf.as_array(item_len).as_slice_mut()?;
-                buf_slice.copy_from_slice(item_bytes);
-                Ok(item_len)
+                obj.get(key)
+                    .ok_or_else(|| DictionaryError::UnknownDictionaryItem(key.to_owned()))?
+                    .as_str()
+                    // FIXME KTM: replace this unwrap with an error variant
+                    .unwrap()
+                    .as_bytes()
+                    .to_owned()
             }
+        };
+
+        if item_bytes.len() > buf_len as usize {
+            return Err(Error::BufferLengthError {
+                buf: "dictionary_item",
+                len: "dictionary_item_max_len",
+            });
         }
+        let item_len = u32::try_from(item_bytes.len())
+            .expect("smaller than dictionary_item_max_len means it must fit");
+
+        let mut buf_slice = buf.as_array(item_len).as_slice_mut()?;
+        buf_slice.copy_from_slice(&item_bytes);
+        Ok(item_len)
     }
 }

--- a/lib/src/wiggle_abi/dictionary_impl.rs
+++ b/lib/src/wiggle_abi/dictionary_impl.rs
@@ -42,10 +42,13 @@ impl FastlyDictionary for Session {
         buf: &GuestPtr<u8>,
         buf_len: u32,
     ) -> Result<u32, Error> {
-        let key: &str = &key.as_str()?;
-        let dict = self.dictionary(dictionary)?;
-        let item_bytes = dict
+        let dict = self
+            .dictionary(dictionary)?
             .contents()
+            .map_err(|err| Error::Other(err.into()))?;
+
+        let key: &str = &key.as_str()?;
+        let item_bytes = dict
             .get(key)
             .ok_or_else(|| DictionaryError::UnknownDictionaryItem(key.to_owned()))?
             .as_bytes();

--- a/lib/src/wiggle_abi/dictionary_impl.rs
+++ b/lib/src/wiggle_abi/dictionary_impl.rs
@@ -63,7 +63,7 @@ impl FastlyDictionary for Session {
             .expect("smaller than dictionary_item_max_len means it must fit");
 
         let mut buf_slice = buf.as_array(item_len).as_slice_mut()?;
-        buf_slice.copy_from_slice(&item_bytes);
+        buf_slice.copy_from_slice(item_bytes);
         Ok(item_len)
     }
 }

--- a/lib/src/wiggle_abi/dictionary_impl.rs
+++ b/lib/src/wiggle_abi/dictionary_impl.rs
@@ -48,8 +48,7 @@ impl FastlyDictionary for Session {
             .contents()
             .get(key)
             .ok_or_else(|| DictionaryError::UnknownDictionaryItem(key.to_owned()))?
-            .as_bytes()
-            .to_owned();
+            .as_bytes();
 
         if item_bytes.len() > buf_len as usize {
             return Err(Error::BufferLengthError {

--- a/test-fixtures/data/json-dictionary.json
+++ b/test-fixtures/data/json-dictionary.json
@@ -1,0 +1,4 @@
+{
+    "cat": "meow",
+    "dog": "woof"
+}

--- a/test-fixtures/src/bin/dictionary-lookup.rs
+++ b/test-fixtures/src/bin/dictionary-lookup.rs
@@ -1,0 +1,10 @@
+//! A guest program to test that dictionary lookups work properly.
+
+use fastly::Dictionary;
+
+fn main() {
+    let animals = Dictionary::open("animals");
+    assert_eq!(animals.get("dog").unwrap(), "woof");
+    assert_eq!(animals.get("cat").unwrap(), "meow");
+    assert_eq!(animals.get("lamp"), None);
+}


### PR DESCRIPTION
Fixes #142.

:crossed_fingers: _should_ also resolve #146.

this PR implements support for inline TOML dictionaries. today, dictionaries can be configured using JSON files stored on disk. as #142 outlines, this is a smidge inconsistent with the way that we configure backends. as discussion in #146 points out, this means that running a Wasm program that accesses a dictionary entails placing files on disk.

this new inline feature allows for dictionaries to be specified _inline_ within the `fastly.toml` file itself. here is an example configuration pulled from the test coverage in this branch:

```toml
name = "inline-toml-dictionary-lookup"
description = "inline toml dictionary lookup test"
authors = ["Jill Bryson <jbryson@fastly.com>", "Rose McDowall <rmcdowall@fastly.com>"]
language = "rust"

[local_server]
[local_server.dictionaries]
[local_server.dictionaries.animals]
format = "inline-toml"
[local_server.dictionaries.animals.contents]
dog = "woof"
cat = "meow"
```

as a pleasant side-effect of this work, we are also able to refactor the dictionary deserialization and lookup logic so that we only read an external JSON file _once._