### PR TITLE
🎫 Add stubs for JA3 and WebSocket upgrade hostcalls

### DIFF
--- a/lib/compute-at-edge-abi/compute-at-edge.witx
+++ b/lib/compute-at-edge-abi/compute-at-edge.witx
@@ -127,6 +127,12 @@
         (result $err (expected (error $fastly_status)))
     )
 
+    (@interface func (export "downstream_tls_ja3_md5")
+        ;; must be a 16-byte array
+        (param $cja3_md5_out (@witx pointer (@witx char8)))
+        (result $err (expected $num_bytes (error $fastly_status)))
+    )
+
     (@interface func (export "new")
         (result $err (expected $request_handle (error $fastly_status)))
     )
@@ -301,6 +307,11 @@
     (@interface func (export "auto_decompress_response_set")
         (param $h $request_handle)
         (param $encodings $content_encodings)
+        (result $err (expected (error $fastly_status)))
+    )
+
+    (@interface func (export "upgrade_websocket")
+        (param $backend_name string)
         (result $err (expected (error $fastly_status)))
     )
 

--- a/lib/src/wiggle_abi/req_impl.rs
+++ b/lib/src/wiggle_abi/req_impl.rs
@@ -94,6 +94,11 @@ impl FastlyHttpReq for Session {
         Err(Error::NotAvailable("Client TLS data"))
     }
 
+    #[allow(unused_variables)] // FIXME ACF 2022-05-03: Remove this directive once implemented.
+    fn upgrade_websocket(&mut self, backend_name: &GuestPtr<str>) -> Result<(), Error> {
+        Err(Error::NotAvailable("WebSocket upgrade"))
+    }
+
     #[allow(unused_variables)] // FIXME KTM 2020-06-25: Remove this directive once implemented.
     fn downstream_tls_protocol<'a>(
         &mut self,
@@ -112,6 +117,11 @@ impl FastlyHttpReq for Session {
         nwritten_out: &GuestPtr<u32>,
     ) -> Result<(), Error> {
         Err(Error::NotAvailable("Client TLS data"))
+    }
+
+    #[allow(unused_variables)] // FIXME ACF 2022-05-03: Remove this directive once implemented.
+    fn downstream_tls_ja3_md5(&mut self, ja3_md5_out: &GuestPtr<u8>) -> Result<u32, Error> {
+        Err(Error::NotAvailable("Client TLS JA3 hash"))
     }
 
     fn framing_headers_mode_set(


### PR DESCRIPTION
These stubs return errors for now, but existing programs will not call them. This solely prevents link errors.