### PR TITLE
Move the `listening on` log message to after the port is bound

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -98,7 +98,6 @@ pub async fn serve(opts: Opts) -> Result<(), Error> {
     }
 
     let addr = opts.addr();
-    event!(Level::INFO, "Listening on http://{}", addr);
     ViceroyService::new(ctx).serve(addr).await?;
 
     unreachable!()

--- a/cli/src/opts.rs
+++ b/cli/src/opts.rs
@@ -147,7 +147,7 @@ mod opts_tests {
                 kind: ErrorKind::ValueValidation,
                 message,
                 ..
-            }) if message.contains("invalid IP address syntax") => Ok(()),
+            }) if message.contains("invalid socket address syntax") => Ok(()),
             res => panic!("unexpected result: {:?}", res),
         }
     }

--- a/lib/src/service.rs
+++ b/lib/src/service.rs
@@ -15,6 +15,7 @@ use {
         pin::Pin,
         task::{self, Poll},
     },
+    tracing::{event, Level},
 };
 
 /// A Viceroy service uses a Wasm module and a handler function to respond to HTTP requests.
@@ -61,7 +62,9 @@ impl ViceroyService {
     /// each time a new request is sent. This function will only return if an error occurs.
     // FIXME KTM 2020-06-22: Once `!` is stabilized, this should be `Result<!, hyper::Error>`.
     pub async fn serve(self, addr: SocketAddr) -> Result<(), hyper::Error> {
-        hyper::Server::bind(&addr).serve(self).await?;
+        let server = hyper::Server::bind(&addr).serve(self);
+        event!(Level::INFO, "Listening on http://{}", server.local_addr());
+        server.await?;
         Ok(())
     }
 }


### PR DESCRIPTION
Currently viceroy will echo the value of the `--addr` flag in the `listening on` log line it prints during startup. If you're trying to run it on any available port and bind to an address like `127.0.0.1:0`, you'll see the message `listening on http://127.0.0.1:0` in the output instead of the port that was picked by the os.

This PR moves the log line into the `ViceroyService::serve` function, and prints the value bound by hyper when starting the server instead of the one passed in on the command line.