### PR TITLE
Reduce precision of request duration log

### DIFF
--- a/lib/src/execute.rs
+++ b/lib/src/execute.rs
@@ -287,7 +287,7 @@ impl ExecuteCtx {
             bytesize::ByteSize::kib(heap_pages as u64 * 64)
         );
 
-        info!("request completed in {:?}", request_duration);
+        info!("request completed in {:.0?}", request_duration);
 
         outcome
     }


### PR DESCRIPTION
At the moment, a request logs its duration with needlessly high precision:

```
Aug 05 09:44:15.967  INFO request{id=5}: request completed in 363.058968ms
```

This change reduces the precision to a whole number, which is still precise enough to be useful to humans:

```
Aug 05 09:44:15.967  INFO request{id=5}: request completed in 363ms
```