### PR TITLE
Extend backend TLS configuration with cert host and SNI

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -59,8 +59,10 @@ pub async fn serve(opts: Opts) -> Result<(), Error> {
         }
 
         for (name, backend) in backends.iter() {
-            let client =
-                Client::builder().build(BackendConnector::new(backend, ctx.tls_config().clone()));
+            let client = Client::builder().build(BackendConnector::new(
+                backend.clone(),
+                ctx.tls_config().clone(),
+            ));
             let req = Request::get(&backend.uri).body(Body::empty()).unwrap();
 
             event!(Level::INFO, "checking if backend '{}' is up", name);

--- a/cli/tests/integration/common.rs
+++ b/cli/tests/integration/common.rs
@@ -101,6 +101,8 @@ impl Test {
         let backend = Backend {
             uri: url.parse().expect("invalid backend URL"),
             override_host: override_host.map(|s| s.parse().expect("can parse override_host")),
+            cert_host: None,
+            use_sni: true,
         };
         self.backends.insert(name.to_owned(), Arc::new(backend));
         self

--- a/lib/src/error.rs
+++ b/lib/src/error.rs
@@ -290,6 +290,15 @@ pub enum BackendConfigError {
     #[error("'override_host' field was not a string")]
     InvalidOverrideHostEntry,
 
+    #[error("'cert_host' field is empty")]
+    EmptyCertHost,
+
+    #[error("'cert_host' field was not a string")]
+    InvalidCertHostEntry,
+
+    #[error("'use_sni' field was not a boolean")]
+    InvalidUseSniEntry,
+
     #[error("invalid url: {0}")]
     InvalidUrl(#[from] http::uri::InvalidUri),
 

--- a/lib/src/wiggle_abi.rs
+++ b/lib/src/wiggle_abi.rs
@@ -1,4 +1,6 @@
-#![allow(clippy::too_many_arguments)] // macro-generated functions in `from_witx!`
+// a few things to ignore from the `from_witx!` macro-generated code:
+#![allow(clippy::too_many_arguments)]
+#![allow(clippy::derive_partial_eq_without_eq)]
 
 //! Wiggle implementations for the Compute@Edge ABI.
 //


### PR DESCRIPTION
To get closer to parity with C@E backend configuration, we add the ability to specify a certificate hostname, distinct from both the host URI or any override host. In addition, backends can now specify whether to use SNI or not; if they do, and the cert hostname is present, it will be used for SNI.

That is slightly less flexible than C@E, which allows distinct SNI and cert hosts. That's not currently possible with the TLS implementation we're using in Viceroy, and the C@E customization is mostly used to _disable_ SNI, which we provide here using a dedicated flag.

The new backend settings are:

* `cert_host` to specify the hostname for certificate checking (and SNI, if enabled)
* `use_sni`, a boolean specifying whether to employ SNI for the backend.

Both settings are optional. If `cert_host` is not specified, the host from the backend URI is used instead. If `use_sni` is not specified, SNI is enabled by default.

Note: this PR does not include tests, which would require quite a bit of scaffolding to do properly. I have, however, tested locally using a real `fastly.toml` provided by a customer, which requires `cert_host` specification to properly reach the backend.