### PR TITLE
keys can contain `.` but can not cannot be named `.` or `..`

### DIFF
--- a/cli/tests/integration/object_store.rs
+++ b/cli/tests/integration/object_store.rs
@@ -218,10 +218,10 @@ async fn object_store_bad_key_values() -> TestResult {
         authors = ["Jill Bryson <jbryson@fastly.com>", "Rose McDowall <rmcdowall@fastly.com>"]
         language = "rust"
         [local_server]
-        object_store.store_one = [{key = "its.me.the.dot.key", data = "This is some data"}]
+        object_store.store_one = [{key = ".", data = "This is some data"}]
     "#;
     match Test::using_fixture("object_store.wasm").using_fastly_toml(BAD_4_FASTLY_TOML) {
-        Err(e) => assert_eq!("invalid configuration for 'store_one': Invalid `key` value used: Keys for objects cannot contain a `.`.", &e.to_string()),
+        Err(e) => assert_eq!("invalid configuration for 'store_one': Invalid `key` value used: Keys for objects cannot be named `.`.", &e.to_string()),
         _ => panic!(),
     }
 
@@ -231,10 +231,10 @@ async fn object_store_bad_key_values() -> TestResult {
         authors = ["Jill Bryson <jbryson@fastly.com>", "Rose McDowall <rmcdowall@fastly.com>"]
         language = "rust"
         [local_server]
-        object_store.store_one = [{key = "double..dippin..dots", data = "This is some data"}]
+        object_store.store_one = [{key = "..", data = "This is some data"}]
     "#;
     match Test::using_fixture("object_store.wasm").using_fastly_toml(BAD_5_FASTLY_TOML) {
-        Err(e) => assert_eq!("invalid configuration for 'store_one': Invalid `key` value used: Keys for objects cannot contain a `..`.", &e.to_string()),
+        Err(e) => assert_eq!("invalid configuration for 'store_one': Invalid `key` value used: Keys for objects cannot be named `..`.", &e.to_string()),
         _ => panic!(),
     }
 

--- a/lib/src/object_store.rs
+++ b/lib/src/object_store.rs
@@ -135,9 +135,9 @@ fn is_valid_key(key: &str) -> Result<(), KeyValidationError> {
         return Err(KeyValidationError::StartsWithWellKnown);
     }
 
-    if key.contains("..") {
+    if key.eq("..") {
         return Err(KeyValidationError::ContainsDotDot);
-    } else if key.contains('.') {
+    } else if key.eq(".") {
         return Err(KeyValidationError::ContainsDot);
     } else if key.contains('\r') {
         return Err(KeyValidationError::ContainsCarriageReturn);
@@ -156,9 +156,9 @@ pub enum KeyValidationError {
     Over1024Bytes,
     #[error("Keys for objects cannot start with `.well-known/acme-challenge`")]
     StartsWithWellKnown,
-    #[error("Keys for objects cannot contain a `.`")]
+    #[error("Keys for objects cannot be named `.`")]
     ContainsDot,
-    #[error("Keys for objects cannot contain a `..`")]
+    #[error("Keys for objects cannot be named `..`")]
     ContainsDotDot,
     #[error("Keys for objects cannot contain a `\r`")]
     ContainsCarriageReturn,


### PR DESCRIPTION
Keys in the Object Store must follow the following rules:
* Keys can contain any sequence of valid Unicode characters, of length 1-1024 bytes when UTF-8 encoded.
* Keys cannot contain Carriage Return or Line Feed characters.
* Keys cannot start with `.well-known/acme-challenge/`.
* Keys cannot be named `.` or `..`.

The last one was documented correctly in the rustdoc comment but validated incorrectly as we were checking if the key contains a `.` anywhere when we are meant to only mark invalid if the key is exactly `.` or `..`

Checking the object-store codebase we can confirm the validation is meant to be exactly `.` and `..` -- https://github.com/fastly/object-store/blob/d3da1166a69a02df43b769312f95939ba7e566f2/api/src/api/key.rs#L78-L83

We are also missing another validation rule:
>* Keys cannot contain special charaters '[', ']', '*', '?', '#'"

-- https://github.com/fastly/object-store/blob/d3da1166a69a02df43b769312f95939ba7e566f2/api/src/api/key.rs#L92-L100

I can add that into this pull-request or another pull-request if preferred 