### PR TITLE
Add validation rule for object-store keys to confirm they do not contain the characters: [, ], *, ?, #

### DIFF
--- a/cli/tests/integration/object_store.rs
+++ b/cli/tests/integration/object_store.rs
@@ -264,5 +264,70 @@ async fn object_store_bad_key_values() -> TestResult {
         _ => panic!(),
     }
 
+    const BAD_8_FASTLY_TOML: &str = r#"
+        name = "object-store-test"
+        description = "object store test"
+        authors = ["Jill Bryson <jbryson@fastly.com>", "Rose McDowall <rmcdowall@fastly.com>"]
+        language = "rust"
+        [local_server]
+        object_store.store_one = [{key = "howdy[", data = "This is some data"}]
+    "#;
+    match Test::using_fixture("object_store.wasm").using_fastly_toml(BAD_8_FASTLY_TOML) {
+        Err(e) => assert_eq!("invalid configuration for 'store_one': Invalid `key` value used: Keys for objects cannot contain a `[`.", &e.to_string()),
+        _ => panic!(),
+    }
+
+    const BAD_9_FASTLY_TOML: &str = r#"
+        name = "object-store-test"
+        description = "object store test"
+        authors = ["Jill Bryson <jbryson@fastly.com>", "Rose McDowall <rmcdowall@fastly.com>"]
+        language = "rust"
+        [local_server]
+        object_store.store_one = [{key = "hello]", data = "This is some data"}]
+    "#;
+    match Test::using_fixture("object_store.wasm").using_fastly_toml(BAD_9_FASTLY_TOML) {
+        Err(e) => assert_eq!("invalid configuration for 'store_one': Invalid `key` value used: Keys for objects cannot contain a `]`.", &e.to_string()),
+        _ => panic!(),
+    }
+
+    const BAD_10_FASTLY_TOML: &str = r#"
+        name = "object-store-test"
+        description = "object store test"
+        authors = ["Jill Bryson <jbryson@fastly.com>", "Rose McDowall <rmcdowall@fastly.com>"]
+        language = "rust"
+        [local_server]
+        object_store.store_one = [{key = "yoohoo*", data = "This is some data"}]
+    "#;
+    match Test::using_fixture("object_store.wasm").using_fastly_toml(BAD_10_FASTLY_TOML) {
+        Err(e) => assert_eq!("invalid configuration for 'store_one': Invalid `key` value used: Keys for objects cannot contain a `*`.", &e.to_string()),
+        _ => panic!(),
+    }
+
+    const BAD_11_FASTLY_TOML: &str = r#"
+        name = "object-store-test"
+        description = "object store test"
+        authors = ["Jill Bryson <jbryson@fastly.com>", "Rose McDowall <rmcdowall@fastly.com>"]
+        language = "rust"
+        [local_server]
+        object_store.store_one = [{key = "hey?", data = "This is some data"}]
+    "#;
+    match Test::using_fixture("object_store.wasm").using_fastly_toml(BAD_11_FASTLY_TOML) {
+        Err(e) => assert_eq!("invalid configuration for 'store_one': Invalid `key` value used: Keys for objects cannot contain a `?`.", &e.to_string()),
+        _ => panic!(),
+    }
+
+    const BAD_12_FASTLY_TOML: &str = r#"
+        name = "object-store-test"
+        description = "object store test"
+        authors = ["Jill Bryson <jbryson@fastly.com>", "Rose McDowall <rmcdowall@fastly.com>"]
+        language = "rust"
+        [local_server]
+        object_store.store_one = [{key = "ello ello#", data = "This is some data"}]
+    "#;
+    match Test::using_fixture("object_store.wasm").using_fastly_toml(BAD_12_FASTLY_TOML) {
+        Err(e) => assert_eq!("invalid configuration for 'store_one': Invalid `key` value used: Keys for objects cannot contain a `#`.", &e.to_string()),
+        _ => panic!(),
+    }
+
     Ok(())
 }

--- a/lib/src/object_store.rs
+++ b/lib/src/object_store.rs
@@ -140,9 +140,19 @@ fn is_valid_key(key: &str) -> Result<(), KeyValidationError> {
     } else if key.eq(".") {
         return Err(KeyValidationError::ContainsDot);
     } else if key.contains('\r') {
-        return Err(KeyValidationError::ContainsCarriageReturn);
+        return Err(KeyValidationError::Contains("\r".to_owned()));
     } else if key.contains('\n') {
-        return Err(KeyValidationError::ContainsLineFeed);
+        return Err(KeyValidationError::Contains("\n".to_owned()));
+    } else if key.contains('[') {
+        return Err(KeyValidationError::Contains("[".to_owned()));
+    } else if key.contains(']') {
+        return Err(KeyValidationError::Contains("]".to_owned()));
+    } else if key.contains('*') {
+        return Err(KeyValidationError::Contains("*".to_owned()));
+    } else if key.contains('?') {
+        return Err(KeyValidationError::Contains("?".to_owned()));
+    } else if key.contains('#') {
+        return Err(KeyValidationError::Contains("#".to_owned()));
     }
 
     Ok(())
@@ -160,8 +170,6 @@ pub enum KeyValidationError {
     ContainsDot,
     #[error("Keys for objects cannot be named `..`")]
     ContainsDotDot,
-    #[error("Keys for objects cannot contain a `\r`")]
-    ContainsCarriageReturn,
-    #[error("Keys for objects cannot contain a `\n`")]
-    ContainsLineFeed,
+    #[error("Keys for objects cannot contain a `{0}`")]
+    Contains(String),
 }


### PR DESCRIPTION
I found this validation was missing when running the object-store tests for the js-compute-runtime project.

Here is a link to the object-store codebase which contains the same validation rule: https://github.com/fastly/object-store/blob/d3da1166a69a02df43b769312f95939ba7e566f2/api/src/api/key.rs#L92-L100