### PR TITLE
Add metadata to viceroy and viceroy-lib Cargo.toml

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -6,6 +6,17 @@ authors = ["Fastly"]
 readme = "../README.md"
 edition = "2018"
 license = "Apache-2.0 WITH LLVM-exception"
+documentation = "https://developer.fastly.com/learning/compute/testing/#running-a-local-testing-server"
+homepage = "https://developer.fastly.com/learning/compute/"
+repository = "https://github.com/fastly/Viceroy"
+keywords = ["wasm", "fastly", "compute@edge"]
+categories = [
+  "command-line-utilities",
+  "development-tools",
+  "network-programming",
+  "simulation",
+  "wasm"
+]
 
 [[bin]]
 name = "viceroy"

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -5,6 +5,16 @@ description = "Viceroy implementation details."
 authors = ["Fastly"]
 edition = "2018"
 license = "Apache-2.0 WITH LLVM-exception"
+documentation = "https://docs.rs/viceroy-lib"
+homepage = "https://github.com/fastly/Viceroy"
+repository = "https://github.com/fastly/Viceroy"
+keywords = ["wasm", "fastly", "compute@edge"]
+categories = [
+  "development-tools",
+  "network-programming",
+  "simulation",
+  "wasm"
+]
 include = [
     "README.md",
     "LICENSE",


### PR DESCRIPTION
This adds some extra metadata for both the CLI tool and the library so
that publishes to crates.io won't produce warnings and to make Viceroy
more discoverable. It also points to the correct documentation for the
CLI tool on Fastly's website for the CLI which is how most will interact
with it, whereas the lib points to `docs.rs` so that they know how to
use the library itself.

Closes #17