### PR TITLE
Fixes an inconsistency between the typenames.witx in Viceroy versus Compute@Edge

### DIFF
--- a/lib/compute-at-edge-abi/typenames.witx
+++ b/lib/compute-at-edge-abi/typenames.witx
@@ -123,7 +123,7 @@
         $manually_from_headers))
 
 (typename $tls_version
-    (flags (@witx repr u32)
+    (enum (@witx tag u32)
        $tls_1
        $tls_1_1
        $tls_1_2


### PR DESCRIPTION
The Compute@Edge version of this type is correct: it's an enumeration of exactly one of the provided values. The prior version in Viceroy appears to be an early version that never got properly updated.