### PR TITLE
match C@E by returning FastlyStatus::Badf if a dictionary does not exist with the requested name

### DIFF
--- a/cli/tests/integration/dictionary_lookup.rs
+++ b/cli/tests/integration/dictionary_lookup.rs
@@ -60,3 +60,21 @@ async fn inline_toml_dictionary_lookup_works() -> TestResult {
 
     Ok(())
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn missing_dictionary_works() -> TestResult {
+    const FASTLY_TOML: &str = r#"
+        name = "missing-dictionary-config"
+        description = "missing dictionary test"
+        language = "rust"
+    "#;
+
+    let resp = Test::using_fixture("dictionary-lookup.wasm")
+        .using_fastly_toml(FASTLY_TOML)?
+        .against_empty()
+        .await;
+
+    assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+
+    Ok(())
+}

--- a/lib/src/session.rs
+++ b/lib/src/session.rs
@@ -573,8 +573,14 @@ impl Session {
 
     /// Look up a dictionary-handle by name.
     pub fn dictionary_handle(&mut self, name: &str) -> Result<DictionaryHandle, Error> {
-        let name = DictionaryName::new(name.to_string());
-        Ok(self.dictionaries_by_name.push(name))
+        let dict = DictionaryName::new(name.to_string());
+        if self.dictionaries.contains_key(&dict) {
+            Ok(self.dictionaries_by_name.push(dict))
+        } else {
+            Err(Error::DictionaryError(
+                crate::wiggle_abi::DictionaryError::UnknownDictionary(name.to_owned()),
+            ))
+        }
     }
 
     /// Look up a dictionary by dictionary-handle.

--- a/lib/src/wiggle_abi.rs
+++ b/lib/src/wiggle_abi.rs
@@ -142,6 +142,9 @@ impl UserErrorConversion for Session {
                 DictionaryError::UnknownDictionaryItem(_) => {
                     event!(Level::DEBUG, "Hostcall yielded an error: {}", err);
                 }
+                DictionaryError::UnknownDictionary(_) => {
+                    event!(Level::DEBUG, "Hostcall yielded an error: {}", err);
+                }
             },
             _ => event!(Level::ERROR, "Hostcall yielded an error: {}", e),
         }

--- a/lib/src/wiggle_abi/dictionary_impl.rs
+++ b/lib/src/wiggle_abi/dictionary_impl.rs
@@ -18,6 +18,9 @@ pub enum DictionaryError {
     /// A dictionary item with the given key was not found.
     #[error("Unknown dictionary item: {0}")]
     UnknownDictionaryItem(String),
+    /// A dictionary with the given name was not found.
+    #[error("Unknown dictionary: {0}")]
+    UnknownDictionary(String),
 }
 
 impl DictionaryError {
@@ -26,6 +29,7 @@ impl DictionaryError {
         use DictionaryError::*;
         match self {
             UnknownDictionaryItem(_) => FastlyStatus::None,
+            UnknownDictionary(_) => FastlyStatus::Badf,
         }
     }
 }


### PR DESCRIPTION
The previous implementation would not make use of the fastly.toml definitions and would allow any handle be created, which is not what C@E does. This pull-requests updates Viceroy to match C@E by only creating dictionaries/config-stores handles for what is defined for the service, which for Viceroy, comes from `fastly.toml`