### PR TITLE
run integration tests on port 17878 to avoid port conflicts

### DIFF
--- a/cli/tests/integration/common.rs
+++ b/cli/tests/integration/common.rs
@@ -190,14 +190,14 @@ impl Test {
             .with_object_store(self.object_store.clone())
             .with_log_stderr(self.log_stderr)
             .with_log_stdout(self.log_stdout);
-        let addr: SocketAddr = "127.0.0.1:7878".parse().unwrap();
+        let addr: SocketAddr = "127.0.0.1:17878".parse().unwrap();
 
         // spawn any mock hosts, keeping a handle on each host task for clean termination.
         let host_handles: Vec<_> = self.hosts.iter().map(HostSpec::spawn).collect();
 
         if self.via_hyper {
             let svc = ViceroyService::new(ctx);
-            // We are going to host the service at port 7878, and so it's vital to make sure
+            // We are going to host the service at port 17878, and so it's vital to make sure
             // that we shut down the service after our test request, so that if there are
             // additional tests we can spin up a fresh service at the same port.
             //
@@ -258,9 +258,9 @@ impl Test {
             .expect("singleton back from against_many")
     }
 
-    /// Pass an empty `GET 127.0.0.1:7878` request through this test.
+    /// Pass an empty `GET 127.0.0.1:17878` request through this test.
     pub async fn against_empty(&self) -> Response<Body> {
-        self.against(Request::get("http://127.0.0.1:7878/").body("").unwrap())
+        self.against(Request::get("http://127.0.0.1:17878/").body("").unwrap())
             .await
     }
 }

--- a/cli/tests/integration/downstream_req.rs
+++ b/cli/tests/integration/downstream_req.rs
@@ -5,7 +5,7 @@ use {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn downstream_request_works() -> TestResult {
-    let req = Request::get("http://127.0.0.1:7878")
+    let req = Request::get("http://127.0.0.1:17878")
         .header("Accept", "text/html")
         .header("X-Custom-Test", "abcdef")
         .body("Hello, world!")?;

--- a/cli/tests/integration/http_semantics.rs
+++ b/cli/tests/integration/http_semantics.rs
@@ -23,7 +23,7 @@ async fn framing_headers_are_overridden() -> TestResult {
     let resp = test
         .via_hyper()
         .against(
-            Request::post("http://127.0.0.1:7878")
+            Request::post("http://127.0.0.1:17878")
                 .body("greetings")
                 .unwrap(),
         )
@@ -52,7 +52,7 @@ async fn content_length_is_computed_correctly() -> TestResult {
 
     let resp = test
         .via_hyper()
-        .against(Request::get("http://127.0.0.1:7878").body("").unwrap())
+        .against(Request::get("http://127.0.0.1:17878").body("").unwrap())
         .await;
 
     assert_eq!(resp.status(), StatusCode::OK);

--- a/cli/tests/integration/memory.rs
+++ b/cli/tests/integration/memory.rs
@@ -15,7 +15,7 @@ async fn direct_wasm_works() -> TestResult {
 async fn heap_limit_test_ok() -> TestResult {
     let resp = Test::using_wat_fixture("combined_heap_limits.wat")
         .against(
-            Request::get("http://127.0.0.1:7878/")
+            Request::get("http://127.0.0.1:17878/")
                 .header("guest-kb", "235")
                 .header("header-kb", "1")
                 .header("body-kb", "16")
@@ -40,7 +40,7 @@ async fn heap_limit_test_ok() -> TestResult {
 async fn heap_limit_test_bad() -> TestResult {
     let resp = Test::using_wat_fixture("combined_heap_limits.wat")
         .against(
-            Request::get("http://127.0.0.1:7878/")
+            Request::get("http://127.0.0.1:17878/")
                 .header("guest-kb", "150000")
                 .body("")
                 .unwrap(),

--- a/cli/tests/integration/upstream.rs
+++ b/cli/tests/integration/upstream.rs
@@ -138,7 +138,7 @@ async fn override_host_works() -> TestResult {
     let resp = test
         .via_hyper()
         .against(
-            Request::get("http://localhost:7878/override")
+            Request::get("http://localhost:17878/override")
                 .header("Viceroy-Backend", "override-host")
                 .body("")
                 .unwrap(),

--- a/cli/tests/integration/upstream_dynamic.rs
+++ b/cli/tests/integration/upstream_dynamic.rs
@@ -80,7 +80,7 @@ async fn override_host_works() -> TestResult {
     let resp = test
         .via_hyper()
         .against(
-            Request::get("http://localhost:7878/override")
+            Request::get("http://localhost:17878/override")
                 .header("Dynamic-Backend", "127.0.0.1:9000")
                 .header("With-Override", "otherhost.com")
                 .body("")
@@ -102,7 +102,7 @@ async fn duplication_errors_right() -> TestResult {
 
     let resp = test
         .against(
-            Request::get("http://localhost:7878/override")
+            Request::get("http://localhost:17878/override")
                 .header("Dynamic-Backend", "127.0.0.1:9000")
                 .header("Supplementary-Backend", "dynamic-backend")
                 .body("")
@@ -114,7 +114,7 @@ async fn duplication_errors_right() -> TestResult {
 
     let resp = test
         .against(
-            Request::get("http://localhost:7878/override")
+            Request::get("http://localhost:17878/override")
                 .header("Dynamic-Backend", "127.0.0.1:9000")
                 .header("Supplementary-Backend", "static")
                 .body("")


### PR DESCRIPTION
If you're already running viceroy on its default 7878 port, several
intergration tests fail because they try to bind to that port.
