### PR TITLE
Add stubs for mTLS info hostcalls

### DIFF
--- a/lib/compute-at-edge-abi/compute-at-edge.witx
+++ b/lib/compute-at-edge-abi/compute-at-edge.witx
@@ -127,6 +127,17 @@
         (result $err (expected (error $fastly_status)))
     )
 
+    (@interface func (export "downstream_tls_raw_client_certificate")
+        (param $raw_client_cert_out (@witx pointer (@witx char8)))
+        (param $raw_client_cert_max_len (@witx usize))
+        (param $nwritten_out (@witx pointer (@witx usize)))
+        (result $err (expected (error $fastly_status)))
+    )
+
+    (@interface func (export "downstream_tls_client_cert_verify_result")
+        (result $err (expected $client_cert_verify_result (error $fastly_status)))
+    )
+
     (@interface func (export "downstream_tls_ja3_md5")
         ;; must be a 16-byte array
         (param $cja3_md5_out (@witx pointer (@witx char8)))

--- a/lib/compute-at-edge-abi/typenames.witx
+++ b/lib/compute-at-edge-abi/typenames.witx
@@ -162,3 +162,40 @@
     (field $sni_hostname (@witx pointer (@witx char8)))
     (field $sni_hostname_len u32)
     ))
+
+;;; TLS client certificate verified result from downstream.
+(typename $client_cert_verify_result
+    (enum (@witx tag u32)
+        ;;; Success value.
+        ;;;
+        ;;; This indicates that client certificate verified successfully.
+        $ok
+        ;;; bad certificate error.
+        ;;;
+        ;;; This error means the certificate is corrupt
+        ;;; (e.g., the certificate signatures do not verify correctly).
+        $bad_certificate
+        ;;; certificate revoked error.
+        ;;;
+        ;;; This error means the client certificate is revoked by its signer.
+        $certificate_revoked
+        ;;; certificate expired error.
+        ;;;
+        ;;; This error means the client certificate has expired or is not currently valid.
+        $certificate_expired
+        ;;; unknown CA error.
+        ;;;
+        ;;; This error means the valid certificate chain or partial chain was received,
+        ;;; but the certificate was not accepted because the CA certificate could not be
+        ;;; located or could not be matched with a known trust anchor.
+        $unknown_ca
+        ;;; certificate missing error.
+        ;;;
+        ;;; This error means the client does not provide a certificate
+        ;;; during the handshake..
+        $certificate_missing
+        ;;; certificate unknown error.
+        ;;;
+        ;;; This error means the client certificate was received, but some other (unspecified)
+        ;;; issue arose in processing the certificate, rendering it unacceptable.
+        $certificate_unknown))

--- a/lib/src/wiggle_abi/req_impl.rs
+++ b/lib/src/wiggle_abi/req_impl.rs
@@ -10,9 +10,10 @@ use {
             fastly_http_req::FastlyHttpReq,
             headers::HttpHeaders,
             types::{
-                BackendConfigOptions, BodyHandle, CacheOverrideTag, ContentEncodings,
-                DynamicBackendConfig, FramingHeadersMode, HttpVersion, MultiValueCursor,
-                MultiValueCursorResult, PendingRequestHandle, RequestHandle, ResponseHandle,
+                BackendConfigOptions, BodyHandle, CacheOverrideTag, ClientCertVerifyResult,
+                ContentEncodings, DynamicBackendConfig, FramingHeadersMode, HttpVersion,
+                MultiValueCursor, MultiValueCursorResult, PendingRequestHandle, RequestHandle,
+                ResponseHandle,
             },
         },
     },
@@ -117,6 +118,23 @@ impl FastlyHttpReq for Session {
         chello_max_len: u32,
         nwritten_out: &GuestPtr<u32>,
     ) -> Result<(), Error> {
+        Err(Error::NotAvailable("Client TLS data"))
+    }
+
+    #[allow(unused_variables)] // FIXME HL 2022-09-19: Remove this directive once implemented.
+    fn downstream_tls_raw_client_certificate<'a>(
+        &mut self,
+        _raw_client_cert_out: &GuestPtr<'a, u8>,
+        _raw_client_cert_max_len: u32,
+        _nwritten_out: &GuestPtr<u32>,
+    ) -> Result<(), Error> {
+        Err(Error::NotAvailable("Client TLS data"))
+    }
+
+    #[allow(unused_variables)] // FIXME HL 2022-09-19: Remove this directive once implemented.
+    fn downstream_tls_client_cert_verify_result(
+        &mut self,
+    ) -> Result<ClientCertVerifyResult, Error> {
         Err(Error::NotAvailable("Client TLS data"))
     }
 


### PR DESCRIPTION
These stubs return errors for now. There is no existing program using these new calls.