### PR TITLE
Return a FastlyStatus::Inval when opening a non-existant object-store

### DIFF
--- a/lib/src/error.rs
+++ b/lib/src/error.rs
@@ -218,6 +218,10 @@ pub enum HandleError {
     /// A dictionary handle was not valid.
     #[error("Invalid dictionary handle: {0}")]
     InvalidDictionaryHandle(crate::wiggle_abi::types::DictionaryHandle),
+
+    /// An object-store handle was not valid.
+    #[error("Invalid object-store handle: {0}")]
+    InvalidObjectStoreHandle(crate::wiggle_abi::types::ObjectStoreHandle),
 }
 
 /// Errors that can occur in a worker thread running a guest module.

--- a/lib/src/object_store.rs
+++ b/lib/src/object_store.rs
@@ -104,6 +104,9 @@ pub enum ObjectStoreError {
     MissingObject,
     #[error("Viceroy's ObjectStore lock was poisoned")]
     PoisonedLock,
+    /// An Object Store with the given name was not found.
+    #[error("Unknown object-store: {0}")]
+    UnknownObjectStore(String),
 }
 
 impl From<&ObjectStoreError> for FastlyStatus {
@@ -112,6 +115,7 @@ impl From<&ObjectStoreError> for FastlyStatus {
         match e {
             MissingObject => FastlyStatus::None,
             PoisonedLock => panic!("{}", e),
+            UnknownObjectStore(_) => FastlyStatus::Inval,
         }
     }
 }

--- a/lib/src/wiggle_abi/obj_store_impl.rs
+++ b/lib/src/wiggle_abi/obj_store_impl.rs
@@ -14,8 +14,6 @@ use {
     wiggle::GuestPtr,
 };
 
-const INVALID_OBJECT_STORE_HANDLE: u32 = std::u32::MAX - 1;
-
 #[wiggle::async_trait]
 impl FastlyObjectStore for Session {
     fn open(&mut self, name: &GuestPtr<str>) -> Result<ObjectStoreHandle, Error> {
@@ -23,7 +21,9 @@ impl FastlyObjectStore for Session {
         if self.object_store.store_exists(&name)? {
             self.obj_store_handle(&name)
         } else {
-            Ok(ObjectStoreHandle::from(INVALID_OBJECT_STORE_HANDLE))
+            Err(Error::ObjectStoreError(
+                ObjectStoreError::UnknownObjectStore(name.to_owned()),
+            ))
         }
     }
 

--- a/test-fixtures/src/bin/object_store.rs
+++ b/test-fixtures/src/bin/object_store.rs
@@ -1,11 +1,12 @@
 //! A guest program to test that object store works properly.
 
 use fastly::ObjectStore;
+use fastly::object_store::ObjectStoreError::ObjectStoreNotFound;
 
 fn main() {
     // Check we can't get a store that does not exist
     match ObjectStore::open("non_existant") {
-        Ok(None) => {}
+        Err(ObjectStoreNotFound(_)) => {},
         _ => panic!(),
     }
 


### PR DESCRIPTION
Currently we return an invalid handle, which seems to be different behavior than what I am seeing on C@E -- I've updated the implementation to match what I see on C@E, which is to return FastlyStatus::Inval
