### PR TITLE
🎬 Update github actions to avoid deprecation warnings

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,17 +34,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: true
 
-      - name: Install latest Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: ${{ matrix.rust-toolchain }}
-          target: ${{ matrix.rust_arch }}-${{ matrix.rust_abi }}
-          default: true
-          override: true
+      - name: Install Rust
+        run: rustup toolchain install --target ${{ matrix.rust_arch }}-${{ matrix.rust_abi }} ${{ matrix.rust-toolchain }}
+        shell: bash
 
       - name: Install C cross-compilation toolchain
         if: ${{ matrix.name == 'linux' && matrix.arch != 'amd64' }}
@@ -55,14 +51,12 @@ jobs:
           echo RUSTFLAGS='-C linker=${{ matrix.rust_arch }}-linux-gnu-gcc' >> $GITHUB_ENV
 
       - name: Extract tag name
-        uses: olegtarasov/get-tag@v2.1
+        uses: olegtarasov/get-tag@v2.1.2
         id: tagName
 
       - name: Build
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --release --all --locked --target=${{ matrix.rust_arch }}-${{ matrix.rust_abi }}
+        run: |
+          cargo build --release --all --locked --target=${{ matrix.rust_arch }}-${{ matrix.rust_abi }}
 
       - name: Strip symbols (linux)
         if: ${{ matrix.name == 'linux' }}
@@ -80,7 +74,7 @@ jobs:
           tar czf viceroy_${{ steps.tagName.outputs.tag }}_${{ matrix.name }}-${{ matrix.arch }}.tar.gz viceroy${{ matrix.extension }}
 
       - name: Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v1 # TODO: https://github.com/softprops/action-gh-release/pull/264
         with:
           files: |
             target/${{ matrix.rust_arch }}-${{ matrix.rust_abi }}/release/viceroy_${{ steps.tagName.outputs.tag }}_${{ matrix.name }}-${{ matrix.arch }}.tar.gz

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,16 +13,16 @@ jobs:
     runs-on: ${{ matrix.platform }}
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         submodules: true
     - name: Install Rust
-      id: toolchain
-      uses: actions-rs/toolchain@v1
+      run: rustup update stable && rustup default stable
+      shell: bash
     - name: Add wasm32-wasi Rust target
       run: rustup target add wasm32-wasi
     - name: Cache cargo
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: |
           ~/.cargo/bin/
@@ -52,16 +52,16 @@ jobs:
     runs-on: ${{ matrix.platform }}
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         submodules: true
     - name: Install Rust
-      uses: actions-rs/toolchain@v1
-      id: toolchain
+      run: rustup update stable && rustup default stable
+      shell: bash
     - name: Add wasm32-wasi Rust target
       run: rustup target add wasm32-wasi
     - name: Cache cargo
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: |
           ~/.cargo/bin/
@@ -79,15 +79,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: true
-      - name: Install latest Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          default: true
-          override: true
+      - name: Install Rust
+        run: rustup update stable && rustup default stable
+        shell: bash
       - name: Check crates can be published
         run: make package-check
         shell: bash


### PR DESCRIPTION
Partially addresses #193. `action-gh-release` seems to be sporadically maintained (the author merged PRs as recently as July, but the project hasn't had a release in ~a year) so it may be worth finding an alternative.

We are currently getting two deprecation warnings:
1. node12 deprecation
2. [`set-output` and `save-state` deprecation](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

Both of these warnings are coming in transitively through actions that we depend on:

## node12 -> node16
- The Github provided actions that were still depending on node12 ([`actions/checkout`](https://github.com/actions/checkout/blob/main/CHANGELOG.md#v300) and [`actions/cache`](https://github.com/actions/cache#v3)) have been upgraded to `v3`
- `olegtarasov/get-tag` [has been updated to v2.1.2](https://github.com/olegtarasov/get-tag/issues/228)
- `softprops/action-gh-release` does not yet have an upgraded version published ([relevant PR](https://github.com/softprops/action-gh-release/pull/264))
- The rust-related actions (`actions-rs/toolchain` and `actions-rs/cargo`) don't have upgraded versions published, and it seems like the [actions-rs organization is no longer maintained](https://github.com/actions-rs/toolchain/issues/216). This is less of a problem because apparently `rustup` is part of the default Github Actions environment now, so we can install the toolchain without depending on the `actions-rs` actions.

## `set-output`/`save-state`
- `softprops/action-gh-release` does not yet have an upgraded version published ([relevant issue](https://github.com/softprops/action-gh-release/issues/268))
- `actions/cache` has been upgraded to `v3`