### PR TITLE
fix clippy errors that fail CI builds

### DIFF
--- a/lib/src/config/dictionaries.rs
+++ b/lib/src/config/dictionaries.rs
@@ -56,7 +56,7 @@ impl Dictionary {
     /// Reads the contents of a JSON dictionary file.
     fn read_json_contents(file: &Path) -> Result<HashMap<String, String>, DictionaryConfigError> {
         // Read the contents of the given file.
-        let data = fs::read_to_string(&file).map_err(DictionaryConfigError::IoError)?;
+        let data = fs::read_to_string(file).map_err(DictionaryConfigError::IoError)?;
 
         // Deserialize the contents of the given JSON file.
         let json = match serde_json::from_str(&data)

--- a/lib/src/config/object_store.rs
+++ b/lib/src/config/object_store.rs
@@ -70,7 +70,7 @@ impl TryFrom<Table> for ObjectStoreConfig {
                                 err: ObjectStoreConfigError::PathNotAString(key.to_string()),
                             }
                         })?;
-                        fs::read(&path).map_err(|e| {
+                        fs::read(path).map_err(|e| {
                             FastlyConfigError::InvalidObjectStoreDefinition {
                                 name: store.to_string(),
                                 err: ObjectStoreConfigError::IoError(e),

--- a/lib/src/wiggle_abi/req_impl.rs
+++ b/lib/src/wiggle_abi/req_impl.rs
@@ -202,7 +202,7 @@ impl FastlyHttpReq for Session {
                 .as_array(config.host_override_len)
                 .as_slice()?;
 
-            Some(HeaderValue::from_bytes(&*byte_slice)?)
+            Some(HeaderValue::from_bytes(&byte_slice)?)
         } else {
             None
         };


### PR DESCRIPTION
```
cargo clippy --all -- -D warnings
    Checking viceroy-lib v0.3.2 (/Users/jshaw/src/fastly/Viceroy/lib)
error: the borrowed expression implements the required traits
  --> lib/src/config/dictionaries.rs:59:39
   |
59 |         let data = fs::read_to_string(&file).map_err(DictionaryConfigError::IoError)?;
   |                                       ^^^^^ help: change this to: `file`
   |
   = note: `-D clippy::needless-borrow` implied by `-D warnings`
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow

error: the borrowed expression implements the required traits
  --> lib/src/config/object_store.rs:73:34
   |
73 |                         fs::read(&path).map_err(|e| {
   |                                  ^^^^^ help: change this to: `path`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow

error: deref which would be done by auto-deref
   --> lib/src/wiggle_abi/req_impl.rs:205:42
    |
205 |             Some(HeaderValue::from_bytes(&*byte_slice)?)
    |                                          ^^^^^^^^^^^^ help: try this: `&byte_slice`
    |
    = note: `-D clippy::explicit-auto-deref` implied by `-D warnings`
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#explicit_auto_deref

error: could not compile `viceroy-lib` due to 3 previous errors
make: *** [clippy] Error 101
```
