### PR TITLE
remove clippy from CI checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ trap-test-ci: trap-test
 # The main `ci` target runs everything except `trap-test`.
 .PHONY: ci
 ci: VICEROY_CARGO=cargo --locked
-ci: format-check clippy test-crates
+ci: format-check test-crates
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
A followup to #201, this removes Clippy from CI checks completely.

As @pchickey says, it's "unstable and creates a lot of CI churn."
