### PR TITLE
object & secret store config naming changes for consistency

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -195,7 +195,7 @@ async fn create_execution_context(opts: &Opts) -> Result<ExecuteCtx, anyhow::Err
         let backends = config.backends();
         let geolocation = config.geolocation();
         let dictionaries = config.dictionaries();
-        let object_store = config.object_store();
+        let object_stores = config.object_stores();
         let secret_stores = config.secret_stores();
         let backend_names = itertools::join(backends.keys(), ", ");
 
@@ -203,7 +203,7 @@ async fn create_execution_context(opts: &Opts) -> Result<ExecuteCtx, anyhow::Err
             .with_backends(backends.clone())
             .with_geolocation(geolocation.clone())
             .with_dictionaries(dictionaries.clone())
-            .with_object_store(object_store.clone())
+            .with_object_stores(object_stores.clone())
             .with_secret_stores(secret_stores.clone())
             .with_config_path(config_path.into());
 

--- a/cli/tests/integration/common.rs
+++ b/cli/tests/integration/common.rs
@@ -12,7 +12,7 @@ use tracing_subscriber::filter::EnvFilter;
 use viceroy_lib::{
     body::Body,
     config::{
-        Backend, Backends, Dictionaries, FastlyConfig, Geolocation, ObjectStore, SecretStores,
+        Backend, Backends, Dictionaries, FastlyConfig, Geolocation, ObjectStores, SecretStores,
     },
     ExecuteCtx, ProfilingStrategy, ViceroyService,
 };
@@ -53,7 +53,7 @@ pub struct Test {
     backends: Backends,
     dictionaries: Dictionaries,
     geolocation: Geolocation,
-    object_store: ObjectStore,
+    object_stores: ObjectStores,
     secret_stores: SecretStores,
     hosts: Vec<HostSpec>,
     log_stdout: bool,
@@ -72,7 +72,7 @@ impl Test {
             backends: Backends::new(),
             dictionaries: Dictionaries::new(),
             geolocation: Geolocation::new(),
-            object_store: ObjectStore::new(),
+            object_stores: ObjectStores::new(),
             secret_stores: SecretStores::new(),
             hosts: Vec::new(),
             log_stdout: false,
@@ -91,7 +91,7 @@ impl Test {
             backends: Backends::new(),
             dictionaries: Dictionaries::new(),
             geolocation: Geolocation::new(),
-            object_store: ObjectStore::new(),
+            object_stores: ObjectStores::new(),
             secret_stores: SecretStores::new(),
             hosts: Vec::new(),
             log_stdout: false,
@@ -107,7 +107,7 @@ impl Test {
             backends: config.backends().to_owned(),
             dictionaries: config.dictionaries().to_owned(),
             geolocation: config.geolocation().to_owned(),
-            object_store: config.object_store().to_owned(),
+            object_stores: config.object_stores().to_owned(),
             secret_stores: config.secret_stores().to_owned(),
             ..self
         })
@@ -211,7 +211,7 @@ impl Test {
             .with_backends(self.backends.clone())
             .with_dictionaries(self.dictionaries.clone())
             .with_geolocation(self.geolocation.clone())
-            .with_object_store(self.object_store.clone())
+            .with_object_stores(self.object_stores.clone())
             .with_secret_stores(self.secret_stores.clone())
             .with_log_stderr(self.log_stderr)
             .with_log_stdout(self.log_stdout);

--- a/cli/tests/integration/object_store.rs
+++ b/cli/tests/integration/object_store.rs
@@ -9,8 +9,8 @@ async fn object_store() -> TestResult {
         authors = ["Jill Bryson <jbryson@fastly.com>", "Rose McDowall <rmcdowall@fastly.com>"]
         language = "rust"
         [local_server]
-        object_store.empty_store = []
-        object_store.store_one = [{key = "first", data = "This is some data"},{key = "second", path = "../test-fixtures/data/object-store.txt"}]
+        object_stores.empty_store = []
+        object_stores.store_one = [{key = "first", data = "This is some data"},{key = "second", file = "../test-fixtures/data/object-store.txt"}]
     "#;
 
     let resp = Test::using_fixture("object_store.wasm")
@@ -36,7 +36,7 @@ async fn object_store_bad_configs() -> TestResult {
         authors = ["Jill Bryson <jbryson@fastly.com>", "Rose McDowall <rmcdowall@fastly.com>"]
         language = "rust"
         [local_server]
-        object_store.store_one = [{key = 3, data = "This is some data"}]
+        object_stores.store_one = [{key = 3, data = "This is some data"}]
     "#;
     match Test::using_fixture("object_store.wasm").using_fastly_toml(BAD_1_FASTLY_TOML) {
         Err(e) => assert_eq!(
@@ -52,7 +52,7 @@ async fn object_store_bad_configs() -> TestResult {
         authors = ["Jill Bryson <jbryson@fastly.com>", "Rose McDowall <rmcdowall@fastly.com>"]
         language = "rust"
         [local_server]
-        object_store.store_one = [{key = "first", data = 3}]
+        object_stores.store_one = [{key = "first", data = 3}]
     "#;
     match Test::using_fixture("object_store.wasm").using_fastly_toml(BAD_2_FASTLY_TOML) {
       Err(e) => assert_eq!("invalid configuration for 'store_one': The `data` value for the object `first` is not a string.", &e.to_string()),
@@ -65,10 +65,10 @@ async fn object_store_bad_configs() -> TestResult {
         authors = ["Jill Bryson <jbryson@fastly.com>", "Rose McDowall <rmcdowall@fastly.com>"]
         language = "rust"
         [local_server]
-        object_store.store_one = [{key = "first", data = "This is some data", path = "../test-fixtures/data/object-store.txt"}]
+        object_stores.store_one = [{key = "first", data = "This is some data", file = "../test-fixtures/data/object-store.txt"}]
     "#;
     match Test::using_fixture("object_store.wasm").using_fastly_toml(BAD_3_FASTLY_TOML) {
-      Err(e) => assert_eq!("invalid configuration for 'store_one': The `path` and `data` keys for the object `first` are set. Only one can be used.", &e.to_string()),
+      Err(e) => assert_eq!("invalid configuration for 'store_one': The `file` and `data` keys for the object `first` are set. Only one can be used.", &e.to_string()),
       _ => panic!(),
     }
 
@@ -78,10 +78,10 @@ async fn object_store_bad_configs() -> TestResult {
         authors = ["Jill Bryson <jbryson@fastly.com>", "Rose McDowall <rmcdowall@fastly.com>"]
         language = "rust"
         [local_server]
-        object_store.store_one = [{key = "first", path = 3}]
+        object_stores.store_one = [{key = "first", file = 3}]
     "#;
     match Test::using_fixture("object_store.wasm").using_fastly_toml(BAD_4_FASTLY_TOML) {
-      Err(e) => assert_eq!("invalid configuration for 'store_one': The `path` value for the object `first` is not a string.", &e.to_string()),
+      Err(e) => assert_eq!("invalid configuration for 'store_one': The `file` value for the object `first` is not a string.", &e.to_string()),
       _ => panic!(),
     }
 
@@ -91,7 +91,7 @@ async fn object_store_bad_configs() -> TestResult {
         authors = ["Jill Bryson <jbryson@fastly.com>", "Rose McDowall <rmcdowall@fastly.com>"]
         language = "rust"
         [local_server]
-        object_store.store_one = [{key = "first", path = "../path/does/not/exist"}]
+        object_stores.store_one = [{key = "first", file = "../path/does/not/exist"}]
     "#;
 
     // For CI to pass we need to include the specific message for each platform
@@ -116,10 +116,10 @@ async fn object_store_bad_configs() -> TestResult {
         authors = ["Jill Bryson <jbryson@fastly.com>", "Rose McDowall <rmcdowall@fastly.com>"]
         language = "rust"
         [local_server]
-        object_store.store_one = [{key = "first"}]
+        object_stores.store_one = [{key = "first"}]
     "#;
     match Test::using_fixture("object_store.wasm").using_fastly_toml(BAD_6_FASTLY_TOML) {
-      Err(e) => assert_eq!("invalid configuration for 'store_one': The `path` or `data` key for the object `first` is not set. One must be used.", &e.to_string()),
+      Err(e) => assert_eq!("invalid configuration for 'store_one': The `file` or `data` key for the object `first` is not set. One must be used.", &e.to_string()),
       _ => panic!(),
     }
 
@@ -129,7 +129,7 @@ async fn object_store_bad_configs() -> TestResult {
         authors = ["Jill Bryson <jbryson@fastly.com>", "Rose McDowall <rmcdowall@fastly.com>"]
         language = "rust"
         [local_server]
-        object_store.store_one = [{data = "This is some data"}]
+        object_stores.store_one = [{data = "This is some data"}]
     "#;
     match Test::using_fixture("object_store.wasm").using_fastly_toml(BAD_7_FASTLY_TOML) {
       Err(e) => assert_eq!("invalid configuration for 'store_one': The `key` key for an object is not set. It must be used.", &e.to_string()),
@@ -142,7 +142,7 @@ async fn object_store_bad_configs() -> TestResult {
         authors = ["Jill Bryson <jbryson@fastly.com>", "Rose McDowall <rmcdowall@fastly.com>"]
         language = "rust"
         [local_server]
-        object_store.store_one = "lol lmao"
+        object_stores.store_one = "lol lmao"
     "#;
     match Test::using_fixture("object_store.wasm").using_fastly_toml(BAD_8_FASTLY_TOML) {
       Err(e) => assert_eq!("invalid configuration for 'store_one': There is no array of objects for the given store.", &e.to_string()),
@@ -155,7 +155,7 @@ async fn object_store_bad_configs() -> TestResult {
         authors = ["Jill Bryson <jbryson@fastly.com>", "Rose McDowall <rmcdowall@fastly.com>"]
         language = "rust"
         [local_server]
-        object_store.store_one = ["This is some data"]
+        object_stores.store_one = ["This is some data"]
     "#;
     match Test::using_fixture("object_store.wasm").using_fastly_toml(BAD_9_FASTLY_TOML) {
       Err(e) => assert_eq!("invalid configuration for 'store_one': There is an object in the given store that is not a table of keys.", &e.to_string()),
@@ -173,7 +173,7 @@ async fn object_store_bad_key_values() -> TestResult {
         authors = ["Jill Bryson <jbryson@fastly.com>", "Rose McDowall <rmcdowall@fastly.com>"]
         language = "rust"
         [local_server]
-        object_store.store_one = [{key = "", data = "This is some data"}]
+        object_stores.store_one = [{key = "", data = "This is some data"}]
     "#;
     match Test::using_fixture("object_store.wasm").using_fastly_toml(BAD_1_FASTLY_TOML) {
         Err(e) => assert_eq!("invalid configuration for 'store_one': Invalid `key` value used: Keys for objects cannot be empty.", &e.to_string()),
@@ -186,7 +186,7 @@ async fn object_store_bad_key_values() -> TestResult {
         authors = ["Jill Bryson <jbryson@fastly.com>", "Rose McDowall <rmcdowall@fastly.com>"]
         language = "rust"
         [local_server]
-        object_store.store_one = [{key = "LOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOoooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong,looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong,keeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeEEEEEEEEEEEEEEEEEEEEEEEEEEEEEeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeey", data = "This is some data"}]
+        object_stores.store_one = [{key = "LOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOoooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong,looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong,keeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeEEEEEEEEEEEEEEEEEEEEEEEEEEEEEeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeey", data = "This is some data"}]
     "#;
     match Test::using_fixture("object_store.wasm").using_fastly_toml(BAD_2_FASTLY_TOML) {
         Err(e) => assert_eq!(
@@ -202,7 +202,7 @@ async fn object_store_bad_key_values() -> TestResult {
         authors = ["Jill Bryson <jbryson@fastly.com>", "Rose McDowall <rmcdowall@fastly.com>"]
         language = "rust"
         [local_server]
-        object_store.store_one = [{key = ".well-known/acme-challenge/wheeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee", data = "This is some data"}]
+        object_stores.store_one = [{key = ".well-known/acme-challenge/wheeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee", data = "This is some data"}]
     "#;
     match Test::using_fixture("object_store.wasm").using_fastly_toml(BAD_3_FASTLY_TOML) {
         Err(e) => assert_eq!(
@@ -218,7 +218,7 @@ async fn object_store_bad_key_values() -> TestResult {
         authors = ["Jill Bryson <jbryson@fastly.com>", "Rose McDowall <rmcdowall@fastly.com>"]
         language = "rust"
         [local_server]
-        object_store.store_one = [{key = ".", data = "This is some data"}]
+        object_stores.store_one = [{key = ".", data = "This is some data"}]
     "#;
     match Test::using_fixture("object_store.wasm").using_fastly_toml(BAD_4_FASTLY_TOML) {
         Err(e) => assert_eq!("invalid configuration for 'store_one': Invalid `key` value used: Keys for objects cannot be named `.`.", &e.to_string()),
@@ -231,7 +231,7 @@ async fn object_store_bad_key_values() -> TestResult {
         authors = ["Jill Bryson <jbryson@fastly.com>", "Rose McDowall <rmcdowall@fastly.com>"]
         language = "rust"
         [local_server]
-        object_store.store_one = [{key = "..", data = "This is some data"}]
+        object_stores.store_one = [{key = "..", data = "This is some data"}]
     "#;
     match Test::using_fixture("object_store.wasm").using_fastly_toml(BAD_5_FASTLY_TOML) {
         Err(e) => assert_eq!("invalid configuration for 'store_one': Invalid `key` value used: Keys for objects cannot be named `..`.", &e.to_string()),
@@ -244,7 +244,7 @@ async fn object_store_bad_key_values() -> TestResult {
         authors = ["Jill Bryson <jbryson@fastly.com>", "Rose McDowall <rmcdowall@fastly.com>"]
         language = "rust"
         [local_server]
-        object_store.store_one = [{key = "carriage\rreturn", data = "This is some data"}]
+        object_stores.store_one = [{key = "carriage\rreturn", data = "This is some data"}]
     "#;
     match Test::using_fixture("object_store.wasm").using_fastly_toml(BAD_6_FASTLY_TOML) {
         Err(e) => assert_eq!("invalid configuration for 'store_one': Invalid `key` value used: Keys for objects cannot contain a `\r`.", &e.to_string()),
@@ -257,7 +257,7 @@ async fn object_store_bad_key_values() -> TestResult {
         authors = ["Jill Bryson <jbryson@fastly.com>", "Rose McDowall <rmcdowall@fastly.com>"]
         language = "rust"
         [local_server]
-        object_store.store_one = [{key = "newlines\nin\nthis\neconomy?", data = "This is some data"}]
+        object_stores.store_one = [{key = "newlines\nin\nthis\neconomy?", data = "This is some data"}]
     "#;
     match Test::using_fixture("object_store.wasm").using_fastly_toml(BAD_7_FASTLY_TOML) {
         Err(e) => assert_eq!("invalid configuration for 'store_one': Invalid `key` value used: Keys for objects cannot contain a `\n`.", &e.to_string()),
@@ -270,7 +270,7 @@ async fn object_store_bad_key_values() -> TestResult {
         authors = ["Jill Bryson <jbryson@fastly.com>", "Rose McDowall <rmcdowall@fastly.com>"]
         language = "rust"
         [local_server]
-        object_store.store_one = [{key = "howdy[", data = "This is some data"}]
+        object_stores.store_one = [{key = "howdy[", data = "This is some data"}]
     "#;
     match Test::using_fixture("object_store.wasm").using_fastly_toml(BAD_8_FASTLY_TOML) {
         Err(e) => assert_eq!("invalid configuration for 'store_one': Invalid `key` value used: Keys for objects cannot contain a `[`.", &e.to_string()),
@@ -283,7 +283,7 @@ async fn object_store_bad_key_values() -> TestResult {
         authors = ["Jill Bryson <jbryson@fastly.com>", "Rose McDowall <rmcdowall@fastly.com>"]
         language = "rust"
         [local_server]
-        object_store.store_one = [{key = "hello]", data = "This is some data"}]
+        object_stores.store_one = [{key = "hello]", data = "This is some data"}]
     "#;
     match Test::using_fixture("object_store.wasm").using_fastly_toml(BAD_9_FASTLY_TOML) {
         Err(e) => assert_eq!("invalid configuration for 'store_one': Invalid `key` value used: Keys for objects cannot contain a `]`.", &e.to_string()),
@@ -296,7 +296,7 @@ async fn object_store_bad_key_values() -> TestResult {
         authors = ["Jill Bryson <jbryson@fastly.com>", "Rose McDowall <rmcdowall@fastly.com>"]
         language = "rust"
         [local_server]
-        object_store.store_one = [{key = "yoohoo*", data = "This is some data"}]
+        object_stores.store_one = [{key = "yoohoo*", data = "This is some data"}]
     "#;
     match Test::using_fixture("object_store.wasm").using_fastly_toml(BAD_10_FASTLY_TOML) {
         Err(e) => assert_eq!("invalid configuration for 'store_one': Invalid `key` value used: Keys for objects cannot contain a `*`.", &e.to_string()),
@@ -309,7 +309,7 @@ async fn object_store_bad_key_values() -> TestResult {
         authors = ["Jill Bryson <jbryson@fastly.com>", "Rose McDowall <rmcdowall@fastly.com>"]
         language = "rust"
         [local_server]
-        object_store.store_one = [{key = "hey?", data = "This is some data"}]
+        object_stores.store_one = [{key = "hey?", data = "This is some data"}]
     "#;
     match Test::using_fixture("object_store.wasm").using_fastly_toml(BAD_11_FASTLY_TOML) {
         Err(e) => assert_eq!("invalid configuration for 'store_one': Invalid `key` value used: Keys for objects cannot contain a `?`.", &e.to_string()),
@@ -322,7 +322,7 @@ async fn object_store_bad_key_values() -> TestResult {
         authors = ["Jill Bryson <jbryson@fastly.com>", "Rose McDowall <rmcdowall@fastly.com>"]
         language = "rust"
         [local_server]
-        object_store.store_one = [{key = "ello ello#", data = "This is some data"}]
+        object_stores.store_one = [{key = "ello ello#", data = "This is some data"}]
     "#;
     match Test::using_fixture("object_store.wasm").using_fastly_toml(BAD_12_FASTLY_TOML) {
         Err(e) => assert_eq!("invalid configuration for 'store_one': Invalid `key` value used: Keys for objects cannot contain a `#`.", &e.to_string()),

--- a/lib/src/config.rs
+++ b/lib/src/config.rs
@@ -203,6 +203,7 @@ struct RawLocalServerConfig {
     backends: Option<Table>,
     geolocation: Option<Table>,
     dictionaries: Option<Table>,
+    #[serde(alias = "object_store")]
     object_stores: Option<Table>,
     secret_store: Option<Table>,
 }

--- a/lib/src/config.rs
+++ b/lib/src/config.rs
@@ -41,7 +41,7 @@ pub use self::geolocation::Geolocation;
 /// Types and deserializers for object store configuration settings.
 mod object_store;
 
-pub use crate::object_store::ObjectStore;
+pub use crate::object_store::ObjectStores;
 
 /// Types and deserializers for secret store configuration settings.
 mod secret_store;
@@ -95,8 +95,8 @@ impl FastlyConfig {
     }
 
     /// Get the object store configuration.
-    pub fn object_store(&self) -> &ObjectStore {
-        &self.local_server.object_store.0
+    pub fn object_stores(&self) -> &ObjectStores {
+        &self.local_server.object_stores.0
     }
 
     /// Get the secret store configuration.
@@ -184,7 +184,7 @@ pub struct LocalServerConfig {
     backends: BackendsConfig,
     geolocation: Geolocation,
     dictionaries: DictionariesConfig,
-    object_store: ObjectStoreConfig,
+    object_stores: ObjectStoreConfig,
     secret_store: SecretStoreConfig,
 }
 
@@ -203,8 +203,7 @@ struct RawLocalServerConfig {
     backends: Option<Table>,
     geolocation: Option<Table>,
     dictionaries: Option<Table>,
-    #[serde(rename = "object_stores")]
-    object_store: Option<Table>,
+    object_stores: Option<Table>,
     secret_store: Option<Table>,
 }
 
@@ -215,7 +214,7 @@ impl TryInto<LocalServerConfig> for RawLocalServerConfig {
             backends,
             geolocation,
             dictionaries,
-            object_store,
+            object_stores,
             secret_store,
         } = self;
         let backends = if let Some(backends) = backends {
@@ -233,7 +232,7 @@ impl TryInto<LocalServerConfig> for RawLocalServerConfig {
         } else {
             DictionariesConfig::default()
         };
-        let object_store = if let Some(object_store) = object_store {
+        let object_stores = if let Some(object_store) = object_stores {
             object_store.try_into()?
         } else {
             ObjectStoreConfig::default()
@@ -248,7 +247,7 @@ impl TryInto<LocalServerConfig> for RawLocalServerConfig {
             backends,
             geolocation,
             dictionaries,
-            object_store,
+            object_stores,
             secret_store,
         })
     }

--- a/lib/src/config.rs
+++ b/lib/src/config.rs
@@ -203,6 +203,7 @@ struct RawLocalServerConfig {
     backends: Option<Table>,
     geolocation: Option<Table>,
     dictionaries: Option<Table>,
+    #[serde(rename = "object_stores")]
     object_store: Option<Table>,
     secret_store: Option<Table>,
 }

--- a/lib/src/config.rs
+++ b/lib/src/config.rs
@@ -101,7 +101,7 @@ impl FastlyConfig {
 
     /// Get the secret store configuration.
     pub fn secret_stores(&self) -> &SecretStores {
-        &self.local_server.secret_store.0
+        &self.local_server.secret_stores.0
     }
 
     /// Parse a `fastly.toml` file into a `FastlyConfig`.
@@ -185,7 +185,7 @@ pub struct LocalServerConfig {
     geolocation: Geolocation,
     dictionaries: DictionariesConfig,
     object_stores: ObjectStoreConfig,
-    secret_store: SecretStoreConfig,
+    secret_stores: SecretStoreConfig,
 }
 
 /// Enum of available (experimental) wasi modules
@@ -205,7 +205,7 @@ struct RawLocalServerConfig {
     dictionaries: Option<Table>,
     #[serde(alias = "object_store")]
     object_stores: Option<Table>,
-    secret_store: Option<Table>,
+    secret_stores: Option<Table>,
 }
 
 impl TryInto<LocalServerConfig> for RawLocalServerConfig {
@@ -216,7 +216,7 @@ impl TryInto<LocalServerConfig> for RawLocalServerConfig {
             geolocation,
             dictionaries,
             object_stores,
-            secret_store,
+            secret_stores,
         } = self;
         let backends = if let Some(backends) = backends {
             backends.try_into()?
@@ -238,7 +238,7 @@ impl TryInto<LocalServerConfig> for RawLocalServerConfig {
         } else {
             ObjectStoreConfig::default()
         };
-        let secret_store = if let Some(secret_store) = secret_store {
+        let secret_stores = if let Some(secret_store) = secret_stores {
             secret_store.try_into()?
         } else {
             SecretStoreConfig::default()
@@ -249,7 +249,7 @@ impl TryInto<LocalServerConfig> for RawLocalServerConfig {
             geolocation,
             dictionaries,
             object_stores,
-            secret_store,
+            secret_stores,
         })
     }
 }

--- a/lib/src/config/object_store.rs
+++ b/lib/src/config/object_store.rs
@@ -50,24 +50,24 @@ impl TryFrom<Table> for ObjectStoreConfig {
                         name: store.to_string(),
                         err: ObjectStoreConfigError::KeyNotAString,
                     })?;
-                let bytes = match (item.get("path"), item.get("data")) {
+                let bytes = match (item.get("file"), item.get("data")) {
                     (None, None) => {
                         return Err(FastlyConfigError::InvalidObjectStoreDefinition {
                             name: store.to_string(),
-                            err: ObjectStoreConfigError::NoPathOrData(key.to_string()),
+                            err: ObjectStoreConfigError::NoFileOrData(key.to_string()),
                         })
                     }
                     (Some(_), Some(_)) => {
                         return Err(FastlyConfigError::InvalidObjectStoreDefinition {
                             name: store.to_string(),
-                            err: ObjectStoreConfigError::PathAndData(key.to_string()),
+                            err: ObjectStoreConfigError::FileAndData(key.to_string()),
                         })
                     }
                     (Some(path), None) => {
                         let path = path.as_str().ok_or_else(|| {
                             FastlyConfigError::InvalidObjectStoreDefinition {
                                 name: store.to_string(),
-                                err: ObjectStoreConfigError::PathNotAString(key.to_string()),
+                                err: ObjectStoreConfigError::FileNotAString(key.to_string()),
                             }
                         })?;
                         fs::read(path).map_err(|e| {

--- a/lib/src/config/object_store.rs
+++ b/lib/src/config/object_store.rs
@@ -1,19 +1,19 @@
 use {
     crate::{
         error::{FastlyConfigError, ObjectStoreConfigError},
-        object_store::{ObjectKey, ObjectStore, ObjectStoreKey},
+        object_store::{ObjectKey, ObjectStoreKey, ObjectStores},
     },
     std::fs,
     toml::value::Table,
 };
 
 #[derive(Clone, Debug, Default)]
-pub struct ObjectStoreConfig(pub(crate) ObjectStore);
+pub struct ObjectStoreConfig(pub(crate) ObjectStores);
 
 impl TryFrom<Table> for ObjectStoreConfig {
     type Error = FastlyConfigError;
     fn try_from(toml: Table) -> Result<Self, Self::Error> {
-        let obj_store = ObjectStore::new();
+        let obj_store = ObjectStores::new();
         for (store, items) in toml.iter() {
             let items = items.as_array().ok_or_else(|| {
                 FastlyConfigError::InvalidObjectStoreDefinition {

--- a/lib/src/config/secret_store.rs
+++ b/lib/src/config/secret_store.rs
@@ -58,24 +58,24 @@ impl TryFrom<Table> for SecretStoreConfig {
                     });
                 }
 
-                let bytes = match (item.get("path"), item.get("data")) {
+                let bytes = match (item.get("file"), item.get("data")) {
                     (None, None) => {
                         return Err(FastlyConfigError::InvalidSecretStoreDefinition {
                             name: store_name.to_string(),
-                            err: SecretStoreConfigError::NoPathOrData(key.to_string()),
+                            err: SecretStoreConfigError::NoFileOrData(key.to_string()),
                         })
                     }
                     (Some(_), Some(_)) => {
                         return Err(FastlyConfigError::InvalidSecretStoreDefinition {
                             name: store_name.to_string(),
-                            err: SecretStoreConfigError::PathAndData(key.to_string()),
+                            err: SecretStoreConfigError::FileAndData(key.to_string()),
                         })
                     }
                     (Some(path), None) => {
                         let path = path.as_str().ok_or_else(|| {
                             FastlyConfigError::InvalidSecretStoreDefinition {
                                 name: store_name.to_string(),
-                                err: SecretStoreConfigError::PathNotAString(key.to_string()),
+                                err: SecretStoreConfigError::FileNotAString(key.to_string()),
                             }
                         })?;
                         fs::read(&path)

--- a/lib/src/error.rs
+++ b/lib/src/error.rs
@@ -547,14 +547,14 @@ pub enum SecretStoreConfigError {
     #[error(transparent)]
     IoError(std::io::Error),
 
-    #[error("The `path` and `data` keys for the object `{0}` are set. Only one can be used.")]
-    PathAndData(String),
-    #[error("The `path` or `data` key for the object `{0}` is not set. One must be used.")]
-    NoPathOrData(String),
+    #[error("The `file` and `data` keys for the object `{0}` are set. Only one can be used.")]
+    FileAndData(String),
+    #[error("The `file` or `data` key for the object `{0}` is not set. One must be used.")]
+    NoFileOrData(String),
     #[error("The `data` value for the object `{0}` is not a string.")]
     DataNotAString(String),
-    #[error("The `path` value for the object `{0}` is not a string.")]
-    PathNotAString(String),
+    #[error("The `file` value for the object `{0}` is not a string.")]
+    FileNotAString(String),
 
     #[error("The `key` key for an object is not set. It must be used.")]
     NoKey,

--- a/lib/src/error.rs
+++ b/lib/src/error.rs
@@ -518,14 +518,14 @@ pub enum ObjectStoreConfigError {
     /// An I/O error that occured while reading the file.
     #[error(transparent)]
     IoError(std::io::Error),
-    #[error("The `path` and `data` keys for the object `{0}` are set. Only one can be used.")]
-    PathAndData(String),
-    #[error("The `path` or `data` key for the object `{0}` is not set. One must be used.")]
-    NoPathOrData(String),
+    #[error("The `file` and `data` keys for the object `{0}` are set. Only one can be used.")]
+    FileAndData(String),
+    #[error("The `file` or `data` key for the object `{0}` is not set. One must be used.")]
+    NoFileOrData(String),
     #[error("The `data` value for the object `{0}` is not a string.")]
     DataNotAString(String),
-    #[error("The `path` value for the object `{0}` is not a string.")]
-    PathNotAString(String),
+    #[error("The `file` value for the object `{0}` is not a string.")]
+    FileNotAString(String),
     #[error("The `key` key for an object is not set. It must be used.")]
     NoKey,
     #[error("The `key` value for an object is not a string.")]

--- a/lib/src/execute.rs
+++ b/lib/src/execute.rs
@@ -9,7 +9,7 @@ use {
         downstream::prepare_request,
         error::ExecutionError,
         linking::{create_store, dummy_store, link_host_functions, WasmCtx},
-        object_store::ObjectStore,
+        object_store::ObjectStores,
         secret_store::SecretStores,
         session::Session,
         upstream::TlsConfig,
@@ -58,7 +58,7 @@ pub struct ExecuteCtx {
     /// The ID to assign the next incoming request
     next_req_id: Arc<AtomicU64>,
     /// The ObjectStore associated with this instance of Viceroy
-    object_store: Arc<ObjectStore>,
+    object_store: Arc<ObjectStores>,
     /// The secret stores for this execution.
     secret_stores: Arc<SecretStores>,
 }
@@ -90,7 +90,7 @@ impl ExecuteCtx {
             log_stdout: false,
             log_stderr: false,
             next_req_id: Arc::new(AtomicU64::new(0)),
-            object_store: Arc::new(ObjectStore::new()),
+            object_store: Arc::new(ObjectStores::new()),
             secret_stores: Arc::new(SecretStores::new()),
         })
     }
@@ -140,7 +140,7 @@ impl ExecuteCtx {
     }
 
     /// Set the object store for this execution context.
-    pub fn with_object_store(self, object_store: ObjectStore) -> Self {
+    pub fn with_object_stores(self, object_store: ObjectStores) -> Self {
         Self {
             object_store: Arc::new(object_store),
             ..self

--- a/lib/src/object_store.rs
+++ b/lib/src/object_store.rs
@@ -7,12 +7,12 @@ use {
 };
 
 #[derive(Clone, Debug, Default)]
-pub struct ObjectStore {
+pub struct ObjectStores {
     #[allow(clippy::type_complexity)]
     stores: Arc<RwLock<BTreeMap<ObjectStoreKey, BTreeMap<ObjectKey, Vec<u8>>>>>,
 }
 
-impl ObjectStore {
+impl ObjectStores {
     pub fn new() -> Self {
         Self {
             stores: Arc::new(RwLock::new(BTreeMap::new())),

--- a/lib/src/session.rs
+++ b/lib/src/session.rs
@@ -12,7 +12,7 @@ use {
         config::{Backend, Backends, Dictionaries, Dictionary, DictionaryName, Geolocation},
         error::{Error, HandleError},
         logging::LogEndpoint,
-        object_store::{ObjectKey, ObjectStore, ObjectStoreError, ObjectStoreKey},
+        object_store::{ObjectKey, ObjectStoreError, ObjectStoreKey, ObjectStores},
         secret_store::{SecretLookup, SecretStores},
         streaming_body::StreamingBody,
         upstream::{PendingRequest, SelectTarget, TlsConfig},
@@ -94,7 +94,7 @@ pub struct Session {
     /// The ObjectStore configured for this execution.
     ///
     /// Populated prior to guest execution and can be modified during requests.
-    pub(crate) object_store: Arc<ObjectStore>,
+    pub(crate) object_store: Arc<ObjectStores>,
     /// The object stores configured for this execution.
     ///
     /// Populated prior to guest execution.
@@ -132,7 +132,7 @@ impl Session {
         tls_config: TlsConfig,
         dictionaries: Arc<Dictionaries>,
         config_path: Arc<Option<PathBuf>>,
-        object_store: Arc<ObjectStore>,
+        object_store: Arc<ObjectStores>,
         secret_stores: Arc<SecretStores>,
     ) -> Session {
         let (parts, body) = req.into_parts();
@@ -189,7 +189,7 @@ impl Session {
             TlsConfig::new().unwrap(),
             Arc::new(HashMap::new()),
             Arc::new(None),
-            Arc::new(ObjectStore::new()),
+            Arc::new(ObjectStores::new()),
             Arc::new(SecretStores::new()),
         )
     }


### PR DESCRIPTION
`object_store` becomes `object_stores` for consistency with `backends`
and `dictionaries`.  `path` becomes `file` for consistency with
dictionaries and geolocation config.

An example object store in the fastly.toml file might now look something
like:

```
[local_server]
object_stores.store_one = [{key = "one", file = "/path/to/something"}]
```

or

```
[local_server]
[local_server.object_stores]
store_one = [{key = "one", file = "/path/to/something"}]
```

or

```
[local_server]
[local_server.object_stores]
[[local_server.object_stores.store_one]]
key = "one"
file = "/path/to/something"
```

Backwards compatibility is maintained.

The Secret Store is updated to match the new Object Store conventions, but backwards compatibility is not maintained (because it's brand new and doesn't need to be).