### PR TITLE
🏃  Add a run-mode that executes the input program once and then exits

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -30,6 +30,7 @@ name = "viceroy"
 path = "src/main.rs"
 
 [dependencies]
+anyhow = "^1.0.31"
 hyper = { version = "^0.14.20", features = ["full"] }
 itertools = "^0.10.5"
 serde_json = "^1.0.59"

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -251,7 +251,7 @@ impl<'a> MakeWriter<'a> for StdWriter {
 }
 
 async fn create_execution_context(opts: &Opts) -> Result<ExecuteCtx, anyhow::Error> {
-    let mut ctx = ExecuteCtx::new(opts.input(), opts.profiling_strategy())?
+    let mut ctx = ExecuteCtx::new(opts.input(), opts.profiling_strategy(), opts.wasi_modules())?
         .with_log_stderr(opts.log_stderr())
         .with_log_stdout(opts.log_stdout());
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -13,9 +13,7 @@
 #![cfg_attr(not(debug_assertions), doc(test(attr(allow(dead_code)))))]
 #![cfg_attr(not(debug_assertions), doc(test(attr(allow(unused_variables)))))]
 
-use itertools::Itertools;
 use std::process::ExitCode;
-use viceroy_lib::TestStatus;
 
 mod opts;
 
@@ -31,9 +29,7 @@ use {
     tokio::time::timeout,
     tracing::{event, Level, Metadata},
     tracing_subscriber::{filter::EnvFilter, fmt::writer::MakeWriter, FmtSubscriber},
-    viceroy_lib::{
-        config::FastlyConfig, BackendConnector, Error, ExecuteCtx, TestResult, ViceroyService,
-    },
+    viceroy_lib::{config::FastlyConfig, BackendConnector, Error, ExecuteCtx, ViceroyService},
 };
 
 /// Starts up a Viceroy server.
@@ -121,11 +117,10 @@ pub async fn serve(opts: Opts) -> Result<(), Error> {
 pub async fn main() -> ExitCode {
     // Parse the command-line options, exiting if there are any errors
     let opts = Opts::parse();
-
     install_tracing_subscriber(&opts);
-    if opts.test_mode() {
-        println!("Using Viceroy to run tests...");
-        match run_wasm_tests(opts).await {
+    if opts.run_mode() {
+        // println!("Using Viceroy to run tests...");
+        match run_wasm_main(opts).await {
             Ok(_) => ExitCode::SUCCESS,
             Err(_) => ExitCode::FAILURE,
         }
@@ -149,86 +144,11 @@ pub async fn main() -> ExitCode {
     }
 }
 
-const GREEN_OK: &str = "\x1b[32mok\x1b[0m";
-const RED_FAILED: &str = "\x1b[31mFAILED\x1b[0m";
-const YELLOW_IGNORED: &str = "\x1b[33mignored\x1b[0m";
 /// Execute a Wasm program in the Viceroy environment.
-pub async fn run_wasm_tests(opts: Opts) -> Result<(), anyhow::Error> {
+pub async fn run_wasm_main(opts: Opts) -> Result<(), anyhow::Error> {
     // Load the wasm module into an execution context
-    let ctx = create_execution_context(opts)?;
-
-    // Call the wasm module with the `--list` argument to get test names
-    let tests = ctx.clone().list_test_names(false).await?;
-    // Call the wasm module with `--list --ignored`to get ignored tests
-    let ignored_tests = ctx.clone().list_test_names(true).await?;
-
-    // Run the tests
-    println!("running {} tests", tests.len());
-    let mut results: Vec<TestResult> = Vec::new();
-    for test in &tests {
-        if ignored_tests.contains(test) {
-            // todo: diff these lists more efficiently
-            println!("test {} ... {YELLOW_IGNORED}", test);
-            results.push(TestResult::new(
-                test.clone(),
-                TestStatus::IGNORED,
-                String::new(),
-                String::new(),
-            ));
-            continue;
-        }
-        print!("test {} ... ", test);
-        let result = ctx.clone().execute_test(&test).await?;
-        print!(
-            "{}\n",
-            if result.status == TestStatus::PASSED {
-                GREEN_OK
-            } else {
-                RED_FAILED
-            }
-        );
-        results.push(result);
-    }
-
-    print_test_results(results);
-    Ok(())
-}
-
-fn print_test_results(results: Vec<TestResult>) {
-    let counts = results.iter().counts_by(|r| r.status);
-    let failed = results
-        .iter()
-        .filter(|r| r.status == TestStatus::FAILED)
-        .collect::<Vec<&TestResult>>();
-
-    // Get the stderr output for each failing test
-    let stderr_block = failed
-        .iter()
-        .map(|f| format!("---- {} stderr ----\n{}", f.name, f.stderr))
-        .join("\n");
-
-    // Get the list of names of failing tests
-    let failure_list = failed.iter().map(|f| format!("\t{}", f.name)).join("\n");
-
-    let result_summary = format!(
-        "test result: {}. {} passed; {} failed; {} ignored",
-        if counts.contains_key(&TestStatus::FAILED) {
-            RED_FAILED
-        } else {
-            GREEN_OK
-        },
-        counts.get(&TestStatus::PASSED).unwrap_or(&0),
-        counts.get(&TestStatus::FAILED).unwrap_or(&0),
-        counts.get(&TestStatus::IGNORED).unwrap_or(&0)
-    );
-
-    if failed.len() > 0 {
-        print!("\nfailures:\n\n");
-        print!("{stderr_block}");
-        print!("\nfailures:\n");
-        print!("{failure_list}\n");
-    }
-    println!("\n{result_summary}");
+    let ctx = create_execution_context(&opts).await?;
+    ctx.run_main(opts.run()).await
 }
 
 fn install_tracing_subscriber(opts: &Opts) {
@@ -325,19 +245,24 @@ impl<'a> MakeWriter<'a> for StdWriter {
     }
 }
 
-fn create_execution_context(opts: Opts) -> Result<ExecuteCtx, anyhow::Error> {
+async fn create_execution_context(opts: &Opts) -> Result<ExecuteCtx, anyhow::Error> {
     let mut ctx = ExecuteCtx::new(opts.input(), opts.profiling_strategy())?
         .with_log_stderr(opts.log_stderr())
         .with_log_stdout(opts.log_stdout());
+
     if let Some(config_path) = opts.config_path() {
         let config = FastlyConfig::from_file(config_path)?;
         let backends = config.backends();
+        let geolocation = config.geolocation();
         let dictionaries = config.dictionaries();
+        let object_store = config.object_store();
         let backend_names = itertools::join(backends.keys(), ", ");
 
         ctx = ctx
             .with_backends(backends.clone())
+            .with_geolocation(geolocation.clone())
             .with_dictionaries(dictionaries.clone())
+            .with_object_store(object_store.clone())
             .with_config_path(config_path.into());
 
         if backend_names.is_empty() {
@@ -346,6 +271,42 @@ fn create_execution_context(opts: Opts) -> Result<ExecuteCtx, anyhow::Error> {
                 "no backend definitions found in {}",
                 config_path.display()
             );
+        }
+        if !opts.run_mode() {
+            for (name, backend) in backends.iter() {
+                let client = Client::builder().build(BackendConnector::new(
+                    backend.clone(),
+                    ctx.tls_config().clone(),
+                ));
+                let req = Request::get(&backend.uri).body(Body::empty()).unwrap();
+
+                event!(Level::INFO, "checking if backend '{}' is up", name);
+                match timeout(Duration::from_secs(5), client.request(req)).await {
+                    // In the case that we don't time out but we have an error, we
+                    // check that it's specifically a connection error as this is
+                    // the only one that happens if the server is not up.
+                    //
+                    // We can't combine this with the case above due to needing the
+                    // inner error to check if it's a connection error. The type
+                    // checker complains about it.
+                    Ok(Err(ref e)) if e.is_connect() => event!(
+                        Level::WARN,
+                        "backend '{}' on '{}' is not up right now",
+                        name,
+                        backend.uri
+                    ),
+                    // In the case we timeout we assume the backend is not up as 5
+                    // seconds to do a simple get should be enough for a healthy
+                    // service
+                    Err(_) => event!(
+                        Level::WARN,
+                        "backend '{}' on '{}' is not up right now",
+                        name,
+                        backend.uri
+                    ),
+                    Ok(_) => event!(Level::INFO, "backend '{}' is up", name),
+                }
+            }
         }
     } else {
         event!(

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -79,11 +79,11 @@ pub async fn main() -> ExitCode {
 pub async fn run_wasm_main(opts: Opts) -> Result<(), anyhow::Error> {
     // Load the wasm module into an execution context
     let ctx = create_execution_context(&opts).await?;
-    ctx.run_main(
-        opts.input().file_stem().unwrap().to_str().unwrap(),
-        opts.wasm_args(),
-    )
-    .await
+    let program_name = match opts.input().file_stem() {
+        Some(stem) => stem.to_string_lossy(),
+        None => panic!("program cannot be a directory"),
+    };
+    ctx.run_main(&program_name, opts.wasm_args()).await
 }
 
 fn install_tracing_subscriber(opts: &Opts) {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -165,6 +165,11 @@ fn install_tracing_subscriber(opts: &Opts) {
             }
         }
     }
+    // If the quiet flag is passed in, don't log anything (this should maybe
+    // just be a verbosity setting)
+    if opts.quiet() {
+        env::set_var("RUST_LOG", "viceroy=off,viceroy-lib=off");
+    }
     // Build a subscriber, using the default `RUST_LOG` environment variable for our filter.
     let builder = FmtSubscriber::builder()
         .with_writer(StdWriter::new())

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -51,7 +51,6 @@ pub async fn main() -> ExitCode {
     let opts = Opts::parse();
     install_tracing_subscriber(&opts);
     if opts.run_mode() {
-        // println!("Using Viceroy to run tests...");
         match run_wasm_main(opts).await {
             Ok(_) => ExitCode::SUCCESS,
             Err(_) => ExitCode::FAILURE,
@@ -80,7 +79,11 @@ pub async fn main() -> ExitCode {
 pub async fn run_wasm_main(opts: Opts) -> Result<(), anyhow::Error> {
     // Load the wasm module into an execution context
     let ctx = create_execution_context(&opts).await?;
-    ctx.run_main(opts.wasm_args()).await
+    ctx.run_main(
+        opts.input().file_stem().unwrap().to_str().unwrap(),
+        opts.wasm_args(),
+    )
+    .await
 }
 
 fn install_tracing_subscriber(opts: &Opts) {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -148,7 +148,7 @@ pub async fn main() -> ExitCode {
 pub async fn run_wasm_main(opts: Opts) -> Result<(), anyhow::Error> {
     // Load the wasm module into an execution context
     let ctx = create_execution_context(&opts).await?;
-    ctx.run_main(opts.run()).await
+    ctx.run_main(opts.wasm_args()).await
 }
 
 fn install_tracing_subscriber(opts: &Opts) {

--- a/cli/src/opts.rs
+++ b/cli/src/opts.rs
@@ -51,6 +51,9 @@ pub struct Opts {
     /// Set of experimental WASI modules to link against.
     #[arg(value_enum, long = "experimental_modules", required = false)]
     experimental_modules: Vec<ExperimentalModuleArg>,
+    /// Don't log viceroy events to stdout or stderr
+    #[arg(short = 'q', long = "quiet", default_value = "false")]
+    quiet: bool,
     // Command line to start child process
     #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
     run: Vec<String>,
@@ -103,6 +106,10 @@ impl Opts {
     pub fn run(&self) -> &[String] {
         self.run.as_ref()
     }
+    pub fn quiet(&self) -> bool {
+        self.quiet
+    }
+
     // Set of experimental wasi modules to link against.
     pub fn wasi_modules(&self) -> HashSet<ExperimentalModule> {
         self.experimental_modules.iter().map(|x| x.into()).collect()

--- a/cli/src/opts.rs
+++ b/cli/src/opts.rs
@@ -30,6 +30,9 @@ pub struct Opts {
     /// The path to a TOML file containing `local_server` configuration.
     #[arg(short = 'C', long = "config")]
     config_path: Option<PathBuf>,
+    /// Whether to use Viceroy as a test runner for cargo test
+    #[arg(short = 't', long = "test", default_value = "false")]
+    test_mode: bool,
     /// Whether to treat stdout as a logging endpoint
     #[arg(long = "log-stdout", default_value = "false")]
     log_stdout: bool,
@@ -64,6 +67,11 @@ impl Opts {
     /// The path to a `local_server` configuration file.
     pub fn config_path(&self) -> Option<&Path> {
         self.config_path.as_deref()
+    }
+
+    /// Whether to run Viceroy as a test runner
+    pub fn test_mode(&self) -> bool {
+        self.test_mode
     }
 
     /// Whether to treat stdout as a logging endpoint

--- a/cli/src/opts.rs
+++ b/cli/src/opts.rs
@@ -30,9 +30,10 @@ pub struct Opts {
     /// The path to a TOML file containing `local_server` configuration.
     #[arg(short = 'C', long = "config")]
     config_path: Option<PathBuf>,
-    /// Use Viceroy to run a module's _start function once, rather than in a
-    /// web server loop
-    #[arg(short = 'r', long = "run", default_value = "false")]
+    /// [EXPERIMENTAL] Use Viceroy to run a module's _start function once,
+    /// rather than in a web server loop. This is experimental and the specific
+    /// interface for this is going to change in the near future.
+    #[arg(short = 'r', long = "run", default_value = "false", hide = true)]
     run_mode: bool,
     /// Whether to treat stdout as a logging endpoint
     #[arg(long = "log-stdout", default_value = "false")]
@@ -54,9 +55,9 @@ pub struct Opts {
     /// Don't log viceroy events to stdout or stderr
     #[arg(short = 'q', long = "quiet", default_value = "false")]
     quiet: bool,
-    /// Args to pass along to the binary being executed. This is only used when
-    /// run_mode=true
-    #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+    /// [EXPERIMENTAL] Args to pass along to the binary being executed. This is
+    /// only used when run_mode=true
+    #[arg(trailing_var_arg = true, allow_hyphen_values = true, hide = true)]
     wasm_args: Vec<String>,
 }
 

--- a/cli/src/opts.rs
+++ b/cli/src/opts.rs
@@ -30,9 +30,10 @@ pub struct Opts {
     /// The path to a TOML file containing `local_server` configuration.
     #[arg(short = 'C', long = "config")]
     config_path: Option<PathBuf>,
-    /// Whether to use Viceroy as a test runner for cargo test
-    #[arg(short = 't', long = "test", default_value = "false")]
-    test_mode: bool,
+    /// Use Viceroy to run a module's _start function once, rather than in a
+    /// web server loop
+    #[arg(short = 'r', long = "run", default_value = "false")]
+    run_mode: bool,
     /// Whether to treat stdout as a logging endpoint
     #[arg(long = "log-stdout", default_value = "false")]
     log_stdout: bool,
@@ -50,6 +51,9 @@ pub struct Opts {
     /// Set of experimental WASI modules to link against.
     #[arg(value_enum, long = "experimental_modules", required = false)]
     experimental_modules: Vec<ExperimentalModuleArg>,
+    // Command line to start child process
+    #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+    run: Vec<String>,
 }
 
 impl Opts {
@@ -70,8 +74,8 @@ impl Opts {
     }
 
     /// Whether to run Viceroy as a test runner
-    pub fn test_mode(&self) -> bool {
-        self.test_mode
+    pub fn run_mode(&self) -> bool {
+        self.run_mode
     }
 
     /// Whether to treat stdout as a logging endpoint
@@ -96,6 +100,9 @@ impl Opts {
         self.profiler.unwrap_or(ProfilingStrategy::None)
     }
 
+    pub fn run(&self) -> &[String] {
+        self.run.as_ref()
+    }
     // Set of experimental wasi modules to link against.
     pub fn wasi_modules(&self) -> HashSet<ExperimentalModule> {
         self.experimental_modules.iter().map(|x| x.into()).collect()

--- a/lib/src/execute.rs
+++ b/lib/src/execute.rs
@@ -376,6 +376,7 @@ impl ExecuteCtx {
             self.dictionaries.clone(),
             self.config_path.clone(),
             self.object_store.clone(),
+            self.secret_stores.clone(),
         );
 
         let mut store = create_store(&self, session).map_err(ExecutionError::Context)?;

--- a/lib/src/execute.rs
+++ b/lib/src/execute.rs
@@ -1,5 +1,8 @@
 //! Guest code execution.
 
+use std::net::Ipv4Addr;
+
+use anyhow::anyhow;
 use {
     crate::{
         body::Body,
@@ -27,6 +30,31 @@ use {
     wasi_common::I32Exit,
     wasmtime::{Engine, InstancePre, Linker, Module, ProfilingStrategy},
 };
+
+#[derive(Copy, Clone, PartialEq, Eq, Hash)]
+pub enum TestStatus {
+    PASSED,
+    FAILED,
+    IGNORED,
+}
+
+pub struct TestResult {
+    pub name: String,
+    pub status: TestStatus,
+    pub stdout: String,
+    pub stderr: String,
+}
+
+impl TestResult {
+    pub fn new(name: String, status: TestStatus, stdout: String, stderr: String) -> Self {
+        Self {
+            name,
+            status,
+            stdout,
+            stderr,
+        }
+    }
+}
 
 /// Execution context used by a [`ViceroyService`](struct.ViceroyService.html).
 ///
@@ -354,6 +382,175 @@ impl ExecuteCtx {
 
         outcome
     }
+
+    pub async fn list_test_names(self, only_ignored: bool) -> Result<Vec<String>, anyhow::Error> {
+        // We're just using this instance to list the test names, so we can use
+        // a mock session rather than setting up a bunch of state just to throw
+        // it away
+        let session = Session::mock();
+
+        let mut store = create_store(&self, session).map_err(ExecutionError::Context)?;
+        store.data_mut().wasi().push_arg("wasm_program")?;
+        store.data_mut().wasi().push_arg("--list")?;
+        if only_ignored {
+            store.data_mut().wasi().push_arg("--ignored")?;
+        }
+
+        let wp = wasi_common::pipe::WritePipe::new_in_memory();
+        let stdout = Box::new(wp.clone());
+        store.data_mut().wasi().set_stdout(stdout);
+
+        let instance = self
+            .instance_pre
+            .instantiate_async(&mut store)
+            .await
+            .map_err(ExecutionError::Instantiation)?;
+
+        // Pull out the `_start` function, which by convention with WASI is the main entry point for
+        // an application.
+        let main_func = instance
+            .get_typed_func::<(), (), _>(&mut store, "_start")
+            .map_err(ExecutionError::Typechecking)?;
+
+        // Invoke the entrypoint function and collect its exit code
+        if let Err(trap) = main_func.call_async(&mut store, ()).await {
+            if let Some(st) = trap.i32_exit_status() {
+                if st != 0 {
+                    Err(anyhow!("program exited with non-zero exit code: {st}"))?
+                }
+            } else {
+                Err(trap)?
+            }
+        };
+        // Ensure the downstream response channel is closed, whether or not a response was
+        // sent during execution.
+        store.data_mut().close_downstream_response_sender();
+
+        drop(store);
+
+        let output_string = String::from_utf8(
+            wp.try_into_inner()
+                .map_err(|_| anyhow!("multiple references outstanding to WritePipe"))?
+                .into_inner(),
+        )?;
+        let test_names = parse_list_output(output_string)?;
+        Ok(test_names)
+    }
+
+    pub async fn execute_test(self, name: &str) -> Result<TestResult, anyhow::Error> {
+        // placeholders for request, result sender channel, and remote IP
+        let req = Request::get("http://example.com/").body(Body::empty())?;
+        let req_id = 0;
+        let (sender, _) = oneshot::channel();
+        let remote = Ipv4Addr::LOCALHOST.into();
+
+        let session = Session::new(
+            req_id,
+            req,
+            sender,
+            remote,
+            self.backends.clone(),
+            self.geolocation.clone(),
+            self.tls_config.clone(),
+            self.dictionaries.clone(),
+            self.config_path.clone(),
+            self.object_store.clone(),
+        );
+
+        let mut store = create_store(&self, session).map_err(ExecutionError::Context)?;
+        store.data_mut().wasi().push_arg("wasm_program")?;
+        store.data_mut().wasi().push_arg("--exact")?;
+        store.data_mut().wasi().push_arg("--nocapture")?;
+        store.data_mut().wasi().push_arg(name)?;
+
+        let out_pipe = wasi_common::pipe::WritePipe::new_in_memory();
+        let err_pipe = wasi_common::pipe::WritePipe::new_in_memory();
+        let stdout = Box::new(out_pipe.clone());
+        let stderr = Box::new(err_pipe.clone());
+        store.data_mut().wasi().set_stdout(stdout);
+        store.data_mut().wasi().set_stderr(stderr);
+
+        let instance = self
+            .instance_pre
+            .instantiate_async(&mut store)
+            .await
+            .map_err(ExecutionError::Instantiation)?;
+
+        // Pull out the `_start` function, which by convention with WASI is the main entry point for
+        // an application.
+        let main_func = instance
+            .get_typed_func::<(), (), _>(&mut store, "_start")
+            .map_err(ExecutionError::Typechecking)?;
+
+        // Invoke the entrypoint function and collect its exit code
+        let test_outcome = main_func.call_async(&mut store, ()).await;
+
+        // Ensure the downstream response channel is closed, whether or not a response was
+        // sent during execution.
+        store.data_mut().close_downstream_response_sender();
+
+        // Drop the store so we can read our stdout and stderr pipes
+        drop(store);
+
+        let stdout_str = pipe_to_string(out_pipe)?;
+        let stderr_str = pipe_to_string(err_pipe)?;
+
+        match test_outcome {
+            Ok(()) => Ok(TestResult::new(
+                String::from(name),
+                TestStatus::PASSED,
+                stdout_str,
+                stderr_str,
+            )),
+            Err(_) => Ok(TestResult::new(
+                String::from(name),
+                TestStatus::FAILED,
+                stdout_str,
+                stderr_str,
+            )),
+        }
+    }
+}
+
+// This function takes a string in the following format and converts it into a
+// list of test names:
+// ```
+// test_name_1: test
+// test_name_2: test
+// test_name_3: test
+//
+// 5 tests, 0 benchmarks
+// ```
+fn parse_list_output(output_string: String) -> Result<Vec<String>, anyhow::Error> {
+    if output_string.starts_with("0 tests") {
+        return Ok(vec![]);
+    }
+    let (list_contents, _) = output_string
+        .split_once("\n\n")
+        .ok_or_else(|| anyhow!("expected double newlines in the test's --list output"))?;
+    let test_names = list_contents
+        .split("\n")
+        .map(|line| {
+            Ok::<String, anyhow::Error>(
+                line.split_once(": ")
+                    .ok_or_else(|| anyhow!("expected test line to contain the substring ': '"))?
+                    .0
+                    .to_string(),
+            )
+        })
+        .collect::<Result<Vec<String>, _>>()?;
+    Ok(test_names)
+}
+
+fn pipe_to_string(
+    pipe: wasi_common::pipe::WritePipe<std::io::Cursor<Vec<u8>>>,
+) -> Result<String, anyhow::Error> {
+    let stdout_string = String::from_utf8(
+        pipe.try_into_inner()
+            .map_err(|_| anyhow!("multiple references outstanding to WritePipe"))?
+            .into_inner(),
+    )?;
+    Ok(stdout_string)
 }
 
 fn configure_wasmtime(profiling_strategy: ProfilingStrategy) -> wasmtime::Config {

--- a/lib/src/execute.rs
+++ b/lib/src/execute.rs
@@ -393,7 +393,7 @@ impl ExecuteCtx {
         // Pull out the `_start` function, which by convention with WASI is the main entry point for
         // an application.
         let main_func = instance
-            .get_typed_func::<(), (), _>(&mut store, "_start")
+            .get_typed_func::<(), ()>(&mut store, "_start")
             .map_err(ExecutionError::Typechecking)?;
 
         // Invoke the entrypoint function and collect its exit code

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -32,6 +32,6 @@ mod upstream;
 mod wiggle_abi;
 
 pub use {
-    error::Error, execute::ExecuteCtx, service::ViceroyService, upstream::BackendConnector,
-    wasmtime::ProfilingStrategy,
+    error::Error, execute::ExecuteCtx, execute::TestResult, execute::TestStatus,
+    service::ViceroyService, upstream::BackendConnector, wasmtime::ProfilingStrategy,
 };

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -32,6 +32,6 @@ mod upstream;
 mod wiggle_abi;
 
 pub use {
-    error::Error, execute::ExecuteCtx, execute::TestResult, execute::TestStatus,
-    service::ViceroyService, upstream::BackendConnector, wasmtime::ProfilingStrategy,
+    error::Error, execute::ExecuteCtx, service::ViceroyService, upstream::BackendConnector,
+    wasmtime::ProfilingStrategy,
 };

--- a/lib/src/linking.rs
+++ b/lib/src/linking.rs
@@ -20,7 +20,7 @@ pub struct WasmCtx {
 }
 
 impl WasmCtx {
-    fn wasi(&mut self) -> &mut WasiCtx {
+    pub fn wasi(&mut self) -> &mut WasiCtx {
         &mut self.wasi
     }
 
@@ -28,7 +28,7 @@ impl WasmCtx {
         &mut self.wasi_nn
     }
 
-    fn session(&mut self) -> &mut Session {
+    pub fn session(&mut self) -> &mut Session {
         &mut self.session
     }
 }


### PR DESCRIPTION
This introduces a "run-mode" to Viceroy that will allow us to use it as a test runner. The goal is to allow developers of C@E services to use Viceroy to run unit tests that rely on things provided by Fastly's SDKs. This is based off of a proof-of-concept that @acfoltzer put together a few months ago 🙏 

# how to use it
To run a wasm program's `_start` function and then exit, the invocation looks like this:
```
$ viceroy -C fastly.toml --run my_program.wasm
```
This will set up the context described in `fastly.toml` and all the wasm context expected by a C@E service, and then run `_start`. If you would like to pass arguments to the wasm program, you can specify those after a `--` on the command line, like so:
```
$ viceroy -C fastly.toml --run my_program.wasm -- --arg-for-wasm-program
```

### as a Rust developer, to use this as a test runner you'll need to do the following:
1. Add the following to your project's `.cargo/config`:
```
[build]
target = "wasm32-wasi"

[target.wasm32-wasi]
runner = "{PATH_TO_VICEROY_BINARY} -C fastly.toml --run -q -- "
```
2. Install [cargo-nextest](https://nexte.st/book/installation.html)
3. Write tests that use the fastly crate a là:
```Rust
#[test]
fn test_using_client_request() {
    let client_req = fastly::Request::from_client();
    assert_eq!(client_req.get_method(), Method::GET);
    assert_eq!(client_req.get_path(), "/");
}

#[test]
fn test_using_bodies() {
    let mut body1 = fastly::Body::new();
    body1.write_str("hello, ");
    let mut body2 = fastly::Body::new();
    body2.write_str("Viceroy!");
    body1.append(body2);
    let appended_str = body1.into_string();
    assert_eq!(appended_str, "hello, Viceroy!");
}

#[test]
fn test_a_handler_with_fastly_types() {
    let req = fastly::Request::get("http://example.com/Viceroy");
    let resp = some_handler(req).expect("request succeeds");
    assert_eq!(resp.get_content_type(), Some(TEXT_PLAIN_UTF_8));
    assert_eq!(resp.into_body_str(), "hello, /Viceroy!");
}
```
4. Run your tests with `cargo nextest run`:
```
 % cargo nextest run
   Compiling unit-tests-test v0.1.0 (/Users/rsinclair/src/fastly/Viceroy-test-runner-example/fixture)
    Finished test [unoptimized + debuginfo] target(s) in 1.16s
    Starting 3 tests across 1 binaries
        PASS [   2.106s] unit-tests-test::bin/unit-tests-test tests::test_a_handler_with_fastly_types
        PASS [   2.225s] unit-tests-test::bin/unit-tests-test tests::test_using_bodies
        PASS [   2.223s] unit-tests-test::bin/unit-tests-test tests::test_using_client_request
------------
     Summary [   2.230s] 3 tests run: 3 passed, 0 skipped
```

### why `cargo-nextest` and not just `cargo test`?
The above example _would_ work if executed with cargo test. Where that breaks down is if any tests fail. There is no way to recover from a panic in wasm, so test execution would halt as soon as the first test failure occurs. Because of this, we need each test to be executed in its own wasm instance and have the results aggregated to report overall success/failure. As @acfoltzer pointed out below, this is [what cargo-nextest does](https://nexte.st/book/how-it-works.html#the-nextest-model).