### PR TITLE
Pin test and release runners to ubuntu-20.04

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         rust-toolchain: [stable]
-        os: [ubuntu-20.04, macos-11, windows-latest]
+        os: [ubuntu-20.04, macos-11, windows-2022]
         arch: [amd64, arm64]
         exclude:
           - os: windows-latest
@@ -22,7 +22,7 @@ jobs:
           - os: macos-11
             name: darwin
             rust_abi: apple-darwin
-          - os: windows-latest
+          - os: windows-2022
             name: windows
             rust_abi: pc-windows-msvc
             extension: .exe

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,13 +10,13 @@ jobs:
     strategy:
       matrix:
         rust-toolchain: [stable]
-        os: [ubuntu-latest, macos-11, windows-latest]
+        os: [ubuntu-20.04, macos-11, windows-latest]
         arch: [amd64, arm64]
         exclude:
           - os: windows-latest
             arch: arm64
         include:
-          - os: ubuntu-latest
+          - os: ubuntu-20.04
             name: linux
             rust_abi: unknown-linux-gnu
           - os: macos-11

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
   test:
     strategy:
       matrix:
-        platform: [ubuntu-20.04, windows-latest, macos-latest]
+        platform: [ubuntu-20.04, windows-2022, macos-11]
     runs-on: ${{ matrix.platform }}
     steps:
     - name: Checkout code
@@ -48,7 +48,7 @@ jobs:
   trap-test:
     strategy:
       matrix:
-        platform: [ubuntu-20.04, windows-latest, macos-latest]
+        platform: [ubuntu-20.04, windows-2022, macos-11]
     runs-on: ${{ matrix.platform }}
     steps:
     - name: Checkout code

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
   test:
     strategy:
       matrix:
-        platform: [ubuntu-latest, windows-latest, macos-latest]
+        platform: [ubuntu-20.04, windows-latest, macos-latest]
     runs-on: ${{ matrix.platform }}
     steps:
     - name: Checkout code
@@ -48,7 +48,7 @@ jobs:
   trap-test:
     strategy:
       matrix:
-        platform: [ubuntu-latest, windows-latest, macos-latest]
+        platform: [ubuntu-20.04, windows-latest, macos-latest]
     runs-on: ${{ matrix.platform }}
     steps:
     - name: Checkout code
@@ -76,7 +76,7 @@ jobs:
       shell: bash
 
   package-check:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
This should avoid pulling in breaking versions of glibc until we address #120.