### PR TITLE
Publish releases atomically

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,8 @@ jobs:
             rust_arch: x86_64
 
     runs-on: ${{ matrix.os }}
+    outputs:
+      draft_release_id: ${{ steps.release.outputs.id }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -74,9 +76,27 @@ jobs:
           tar czf viceroy_${{ steps.tagName.outputs.tag }}_${{ matrix.name }}-${{ matrix.arch }}.tar.gz viceroy${{ matrix.extension }}
 
       - name: Release
-        uses: softprops/action-gh-release@v1 # TODO: https://github.com/softprops/action-gh-release/pull/264
+        id: release
+        uses: softprops/action-gh-release@v1
         with:
+          draft: true
           files: |
             target/${{ matrix.rust_arch }}-${{ matrix.rust_abi }}/release/viceroy_${{ steps.tagName.outputs.tag }}_${{ matrix.name }}-${{ matrix.arch }}.tar.gz
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  publish:
+    needs: build
+    runs-on: ubuntu-20.04
+    steps:
+      - name: publish
+        uses: actions/github-script@v6
+        with:
+          script: |
+            github.rest.repos.updateRelease({
+              release_id: ${{ needs.build.outputs.draft_release_id }},
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              draft: false
+            })
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Fixes #112.

This adds another job to the release action, called "publish", which depends on the "build" job. The release will remain in a draft state until the entire build matrix succeeds, at which point it will get published. A successful run will look something like this:
<img width="762" alt="image" src="https://user-images.githubusercontent.com/844493/214123603-218c053f-91a9-4bb0-a485-5c01adf46911.png">
