### PR TITLE
fix: remove dictionary count limit from viceroy

### DIFF
--- a/lib/src/config/dictionaries.rs
+++ b/lib/src/config/dictionaries.rs
@@ -101,9 +101,7 @@ mod deserialization {
     use {
         super::{DictionariesConfig, Dictionary, DictionaryName},
         crate::{
-            config::limits::{
-                DICTIONARY_ITEM_KEY_MAX_LEN, DICTIONARY_ITEM_VALUE_MAX_LEN, DICTIONARY_MAX_LEN,
-            },
+            config::limits::{DICTIONARY_ITEM_KEY_MAX_LEN, DICTIONARY_ITEM_VALUE_MAX_LEN},
             error::{DictionaryConfigError, FastlyConfigError},
         },
         std::{collections::HashMap, path::PathBuf, str::FromStr},
@@ -225,11 +223,6 @@ mod deserialization {
         dict: &HashMap<String, String>,
     ) -> Result<(), DictionaryConfigError> {
         info!("checking if dictionary adheres to Fastly's API",);
-        if dict.len() > DICTIONARY_MAX_LEN {
-            return Err(DictionaryConfigError::DictionaryCountTooLong {
-                size: DICTIONARY_MAX_LEN.try_into().unwrap(),
-            });
-        }
 
         for (key, value) in dict.iter() {
             if key.chars().count() > DICTIONARY_ITEM_KEY_MAX_LEN {

--- a/lib/src/config/limits.rs
+++ b/lib/src/config/limits.rs
@@ -1,4 +1,3 @@
 // From https://docs.fastly.com/en/guides/resource-limits#vcl-and-configuration-limits
-pub const DICTIONARY_MAX_LEN: usize = 1000;
 pub const DICTIONARY_ITEM_KEY_MAX_LEN: usize = 256;
 pub const DICTIONARY_ITEM_VALUE_MAX_LEN: usize = 8000;


### PR DESCRIPTION
this limit can be raised per service on c-at-e. if the limit was raised on a customers service, then the customer could no longer run their application locally with viceroy. by removing he limit in viceroy, customers who have a himit dictionary limit would be able to run their application locally.

I hit this issue in my own project which uses a dictionary containing ~3400 keys