### PR TITLE
🪆 separate behavior into sub-commands, with serve being the default 

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -60,7 +60,7 @@ pub async fn main() -> ExitCode {
             }
         }
         Commands::Serve(serve_args) => {
-            install_tracing_subscriber(std::cmp::max(1, serve_args.verbosity()));
+            install_tracing_subscriber(serve_args.verbosity());
             match {
                 tokio::select! {
                     _ = tokio::signal::ctrl_c() => {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -60,7 +60,7 @@ pub async fn main() -> ExitCode {
             }
         }
         Commands::Serve(serve_args) => {
-            install_tracing_subscriber(serve_args.verbosity());
+            install_tracing_subscriber(std::cmp::max(1, serve_args.verbosity()));
             match {
                 tokio::select! {
                     _ = tokio::signal::ctrl_c() => {

--- a/cli/src/opts.rs
+++ b/cli/src/opts.rs
@@ -61,8 +61,7 @@ pub struct RunArgs {
     #[command(flatten)]
     shared: SharedArgs,
 
-    /// [EXPERIMENTAL] Args to pass along to the binary being executed. This is
-    /// only used when run_mode=true
+    /// Args to pass along to the binary being executed.
     #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
     wasm_args: Vec<String>,
 }

--- a/cli/src/opts.rs
+++ b/cli/src/opts.rs
@@ -1,7 +1,7 @@
 //! Command line arguments.
 
 use {
-    clap::{Parser, ValueEnum},
+    clap::{Args, Parser, Subcommand, ValueEnum},
     std::net::{IpAddr, Ipv4Addr},
     std::{
         collections::HashSet,
@@ -20,67 +20,114 @@ use {
 /// Viceroy is a local testing daemon for Compute@Edge.
 #[derive(Parser, Debug)]
 #[command(name = "viceroy", author, version, about)]
+#[command(propagate_version = true)]
+#[command(args_conflicts_with_subcommands = true)]
 pub struct Opts {
+    #[command(subcommand)]
+    pub command: Option<Commands>,
+
+    #[command(flatten)]
+    pub serve: ServeArgs,
+}
+
+#[derive(Subcommand, Debug, Clone)]
+pub enum Commands {
+    /// Run the wasm in a Viceroy server. This is the default if no subcommand
+    /// is given.
+    Serve(ServeArgs),
+
+    /// Run the input wasm once and then exit.
+    Run(RunArgs),
+}
+
+#[derive(Debug, Args, Clone)]
+pub struct ServeArgs {
     /// The IP address that the service should be bound to.
     #[arg(long = "addr")]
     socket_addr: Option<SocketAddr>,
+
+    /// Verbosity of logs for Viceroy. `-v` sets the log level to DEBUG and
+    /// `-vv` to TRACE. This option will not take effect if you set RUST_LOG
+    /// to a value before starting Viceroy
+    #[arg(short = 'v', action = clap::ArgAction::Count)]
+    verbosity: u8,
+
+    #[command(flatten)]
+    shared: SharedArgs,
+}
+
+#[derive(Args, Debug, Clone)]
+pub struct RunArgs {
+    #[command(flatten)]
+    shared: SharedArgs,
+
+    /// [EXPERIMENTAL] Args to pass along to the binary being executed. This is
+    /// only used when run_mode=true
+    #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+    wasm_args: Vec<String>,
+}
+
+#[derive(Args, Debug, Clone)]
+pub struct SharedArgs {
     /// The path to the service's Wasm module.
-    #[arg(value_parser = check_module)]
-    input: PathBuf,
+    #[arg(value_parser = check_module, required=true)]
+    input: Option<String>,
     /// The path to a TOML file containing `local_server` configuration.
     #[arg(short = 'C', long = "config")]
     config_path: Option<PathBuf>,
-    /// [EXPERIMENTAL] Use Viceroy to run a module's _start function once,
-    /// rather than in a web server loop. This is experimental and the specific
-    /// interface for this is going to change in the near future.
-    #[arg(short = 'r', long = "run", default_value = "false", hide = true)]
-    run_mode: bool,
     /// Whether to treat stdout as a logging endpoint
     #[arg(long = "log-stdout", default_value = "false")]
     log_stdout: bool,
     /// Whether to treat stderr as a logging endpoint
     #[arg(long = "log-stderr", default_value = "false")]
     log_stderr: bool,
-    /// Verbosity of logs for Viceroy. `-v` sets the log level to DEBUG and
-    /// `-vv` to TRACE. This option will not take effect if you set RUST_LOG
-    /// to a value before starting Viceroy
-    #[arg(short = 'v', action = clap::ArgAction::Count)]
-    verbosity: u8,
     // Whether to enable wasmtime's builtin profiler.
     #[arg(long = "profiler", value_parser = check_wasmtime_profiler_mode)]
     profiler: Option<ProfilingStrategy>,
     /// Set of experimental WASI modules to link against.
     #[arg(value_enum, long = "experimental_modules", required = false)]
     experimental_modules: Vec<ExperimentalModuleArg>,
-    /// Don't log viceroy events to stdout or stderr
-    #[arg(short = 'q', long = "quiet", default_value = "false")]
-    quiet: bool,
-    /// [EXPERIMENTAL] Args to pass along to the binary being executed. This is
-    /// only used when run_mode=true
-    #[arg(trailing_var_arg = true, allow_hyphen_values = true, hide = true)]
-    wasm_args: Vec<String>,
 }
 
-impl Opts {
+impl ServeArgs {
     /// The address that the service should be bound to.
     pub fn addr(&self) -> SocketAddr {
         self.socket_addr
             .unwrap_or_else(|| SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 7878))
     }
 
+    /// Verbosity of logs for Viceroy. `-v` sets the log level to DEBUG and
+    /// `-vv` to TRACE. This option will not take effect if you set RUST_LOG
+    /// to a value before starting Viceroy
+    pub fn verbosity(&self) -> u8 {
+        self.verbosity
+    }
+
+    pub fn shared(&self) -> &SharedArgs {
+        &self.shared
+    }
+}
+
+impl RunArgs {
+    /// The arguments to pass to the underlying binary when run_mode=true
+    pub fn wasm_args(&self) -> &Vec<String> {
+        &self.wasm_args
+    }
+
+    pub fn shared(&self) -> &SharedArgs {
+        &self.shared
+    }
+}
+
+impl SharedArgs {
     /// The path to the service's Wasm binary.
-    pub fn input(&self) -> &Path {
-        self.input.as_ref()
+    pub fn input(&self) -> PathBuf {
+        PathBuf::from(self.input.as_ref().unwrap())
     }
 
     /// The path to a `local_server` configuration file.
     pub fn config_path(&self) -> Option<&Path> {
         self.config_path.as_deref()
-    }
-
-    /// Whether Viceroy should run the input once and then exit
-    pub fn run_mode(&self) -> bool {
-        self.run_mode
     }
 
     /// Whether to treat stdout as a logging endpoint
@@ -93,27 +140,9 @@ impl Opts {
         self.log_stderr
     }
 
-    /// Verbosity of logs for Viceroy. `-v` sets the log level to DEBUG and
-    /// `-vv` to TRACE. This option will not take effect if you set RUST_LOG
-    /// to a value before starting Viceroy
-    pub fn verbosity(&self) -> u8 {
-        self.verbosity
-    }
-
     // Whether to enable wasmtime's builtin profiler.
     pub fn profiling_strategy(&self) -> ProfilingStrategy {
         self.profiler.unwrap_or(ProfilingStrategy::None)
-    }
-
-    /// The arguments to pass to the underlying binary when run_mode=true
-    pub fn wasm_args(&self) -> &[String] {
-        self.wasm_args.as_ref()
-    }
-
-    /// Prevents Viceroy from logging to stdout and stderr (note: any logs
-    /// emitted by the INPUT program will still go to stdout/stderr)
-    pub fn quiet(&self) -> bool {
-        self.quiet
     }
 
     // Set of experimental wasi modules to link against.
@@ -164,11 +193,11 @@ impl From<&ExperimentalModule> for ExperimentalModuleArg {
 /// binary or text format.
 ///
 /// [opts]: struct.Opts.html
-fn check_module(s: &str) -> Result<PathBuf, Error> {
+fn check_module(s: &str) -> Result<String, Error> {
     let path = PathBuf::from(s);
     let contents = std::fs::read(&path)?;
     match wat::parse_bytes(&contents) {
-        Ok(_) => Ok(path),
+        Ok(_) => Ok(s.to_string()),
         _ => Err(Error::FileFormat),
     }
 }
@@ -194,7 +223,7 @@ fn check_wasmtime_profiler_mode(s: &str) -> Result<ProfilingStrategy, Error> {
 #[cfg(test)]
 mod opts_tests {
     use {
-        super::Opts,
+        super::{Commands, Opts},
         clap::{error::ErrorKind, Parser},
         std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
         std::path::PathBuf,
@@ -217,8 +246,11 @@ mod opts_tests {
     fn default_addr_works() -> TestResult {
         let empty_args = &["dummy-program-name", &test_file("minimal.wat")];
         let opts = Opts::try_parse_from(empty_args)?;
+        let cmd = opts.command.unwrap_or(Commands::Serve(opts.serve));
         let expected = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 7878);
-        assert_eq!(opts.addr(), expected);
+        if let Commands::Serve(serve_args) = cmd {
+            assert_eq!(serve_args.addr(), expected);
+        }
         Ok(())
     }
 
@@ -253,9 +285,12 @@ mod opts_tests {
             &test_file("minimal.wat"),
         ];
         let opts = Opts::try_parse_from(args_with_ipv6_addr)?;
+        let cmd = opts.command.unwrap_or(Commands::Serve(opts.serve));
         let addr_v6 = IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1));
         let expected = SocketAddr::new(addr_v6, 7878);
-        assert_eq!(opts.addr(), expected);
+        if let Commands::Serve(serve_args) = cmd {
+            assert_eq!(serve_args.addr(), expected);
+        }
         Ok(())
     }
 
@@ -358,16 +393,23 @@ mod opts_tests {
 
     /// Test that trailing arguments are collected successfully
     #[test]
-    fn trailing_args_are_collected() -> TestResult {
+    fn trailing_args_are_collected_in_run_mode() -> TestResult {
         let args = &[
             "dummy-program-name",
+            "run",
             &test_file("minimal.wat"),
             "--",
             "--trailing-arg",
             "--trailing-arg-2",
         ];
         let opts = Opts::try_parse_from(args)?;
-        assert_eq!(opts.wasm_args(), &["--trailing-arg", "--trailing-arg-2"]);
+        let cmd = opts.command.unwrap_or(Commands::Serve(opts.serve));
+        if let Commands::Run(run_args) = cmd {
+            assert_eq!(
+                run_args.wasm_args(),
+                &["--trailing-arg", "--trailing-arg-2"]
+            );
+        }
         Ok(())
     }
 
@@ -377,6 +419,7 @@ mod opts_tests {
     fn input_accepted_after_double_dash() -> TestResult {
         let args = &[
             "dummy-program-name",
+            "run",
             "--",
             &test_file("minimal.wat"),
             "--trailing-arg",
@@ -386,8 +429,17 @@ mod opts_tests {
             Ok(opts) => opts,
             res => panic!("unexpected result: {:?}", res),
         };
-        assert_eq!(opts.input().to_str().unwrap(), &test_file("minimal.wat"));
-        assert_eq!(opts.wasm_args(), &["--trailing-arg", "--trailing-arg-2"]);
+        let cmd = opts.command.unwrap_or(Commands::Serve(opts.serve));
+        if let Commands::Run(run_args) = cmd {
+            assert_eq!(
+                run_args.shared.input().to_str().unwrap(),
+                &test_file("minimal.wat")
+            );
+            assert_eq!(
+                run_args.wasm_args(),
+                &["--trailing-arg", "--trailing-arg-2"]
+            );
+        }
         Ok(())
     }
 }

--- a/lib/src/execute.rs
+++ b/lib/src/execute.rs
@@ -355,7 +355,11 @@ impl ExecuteCtx {
         outcome
     }
 
-    pub async fn run_main(self, program_name: &str, args: &[String]) -> Result<(), anyhow::Error> {
+    pub async fn run_main(
+        self,
+        program_name: &str,
+        args: &Vec<String>,
+    ) -> Result<(), anyhow::Error> {
         // placeholders for request, result sender channel, and remote IP
         let req = Request::get("http://example.com/").body(Body::empty())?;
         let req_id = 0;

--- a/lib/src/execute.rs
+++ b/lib/src/execute.rs
@@ -355,11 +355,7 @@ impl ExecuteCtx {
         outcome
     }
 
-    pub async fn run_main(
-        self,
-        program_name: &str,
-        args: &Vec<String>,
-    ) -> Result<(), anyhow::Error> {
+    pub async fn run_main(self, program_name: &str, args: &[String]) -> Result<(), anyhow::Error> {
         // placeholders for request, result sender channel, and remote IP
         let req = Request::get("http://example.com/").body(Body::empty())?;
         let req_id = 0;


### PR DESCRIPTION
Addresses #222.

The structure here is somewhat complex in order to get clap to behave how we want it to. Specifically:
- We would like behavior separated into `serve` and `run` subcommands, but if neither of those is provided the default behavior should be `serve` (to maintain backwards compatibility)
- Some options are only valid in `serve` mode and some are only valid in `run` mode
- Some shared options are valid in both modes
- There is a shared argument, `input`,  that is *required* regardless of the mode

### 🍽️  set `serve` as the default subcommand
The way that we accomplish having a default subcommand with clap is like this:
- Make the top level command struct contain just two arguments, one for the subcommand and one for the args for whichever subcommand is the default (`serve` in this case)
- Add `args_conflicts_with_subcommands = true` to our top-level struct, so that those two arguments are mutually exclusive
- Create separate structs for our sub-command-specific arguments (`ServeArgs`, and `RunArgs`)

```rust
#[derive(Parser)]
#[command(args_conflicts_with_subcommands = true)]
struct Opts {
    #[command(subcommand)]
    pub command: Option<Commands>,

    #[command(flatten)]
    pub serve: ServeArgs,
}

#[derive(Subcommand)]
pub enum Commands {
    Serve(ServeArgs),
    Run(RunArgs),
}

#[derive(Args)]
pub struct ServeArgs {
   /* <serve-specific args> */
}

pub struct RunArgs {
 /* <run-specific args> */
}
```
see the [example in the clap documentation](https://docs.rs/clap/latest/clap/_derive/_cookbook/git_derive/index.html) and [this comment](https://github.com/clap-rs/clap/issues/3857#issuecomment-1161796261) for more context

### 🤝  specify shared arguments
Normally we would put options that are valid in both modes into our top-level `Opts` struct. This unfortunately doesn't work because we need to specify `args_conflicts_with_subcommands` in order to get the default-subcommand behavior. So to specify arguments that are valid in both modes without a ton of duplication, we can create another struct `SharedArgs` and include it as a `flatten`ed field on each of our subcommand args structs:

```rust
...
#[derive(Args)]
pub struct ServeArgs {
  #[command(flatten)]
  shared: SharedArgs
   /* <serve-specific args> */
}

pub struct RunArgs {
  #[command(flatten)]
  shared: SharedArgs
 /* <run-specific args> */
}

#[derive(Args)]
pub struct SharedArgs {
  /* shared args */
}
```

### 🔴  specify `input` as a required arg
Finally, in order to make one of our shared arguments, `input`, *required* regardless of the mode we are in we need to:
- Specify it as `Option<String>` rather than just `String` (normally this would mean an arg is optional)
- Add `required = true` to it. 

```rust
#[derive(Args)]
pub struct SharedArgs {
    /// The path to the service's Wasm module.
    #[arg(value_parser = check_module, required = true)]
    input: Option<String>,
   /* other shared args */
```

see [this comment](https://github.com/clap-rs/clap/issues/3857#issuecomment-1239419407) for some context

### 📜  other things
- I merged the behavior for `quiet` into the verbosity flag and as a result verbosity isn't entirely backwards compatible as-is. In order to make `0` mean `off`, I had to bump `info`, `debug`, and `trace` each up a number. I'm unsure what behavior we would like here (ie. if someone using Viceroy right now is used to seeing `info` level logs, it would make sense to have that be the default in `serve` mode while also providing some way to specify `off` if they would like)
- I've been staring at this too long to have a good sense as to whether it's a maintenance nightmare or not. It's unfortunate to not have one clean struct that specifies the CLI behavior and documentation strings, but I think that might be a necessary tradeoff to accomplish the above. Thoughts around this are most welcome.