### PR TITLE
Prepare release 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## Unreleased
+
 ## 0.4.0 (2023-03-17)
 - Add a run-mode that executes the input program once and then exits ([#211](https://github.com/fastly/Viceroy/pull/211))
 - Update to Wasmtime 6.0.0 ([#226](https://github.com/fastly/Viceroy/pull/226))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2041,9 +2041,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.11"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524b68aca1d05e03fdf03fcdce2c6c94b6daf6d16861ddaa7e4f2b6638a9052c"
+checksum = "7d502c968c6a838ead8e69b2ee18ec708802f99db92a0d156705ec9ef801993b"
 
 [[package]]
 name = "unicode-ident"
@@ -2103,7 +2103,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "viceroy"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -2122,7 +2122,7 @@ dependencies = [
 
 [[package]]
 name = "viceroy-lib"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "bytes",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "viceroy"
 description = "Viceroy is a local testing daemon for Compute@Edge."
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Fastly"]
 readme = "../README.md"
 edition = "2021"
@@ -39,7 +39,7 @@ tokio = { version = "^1.21.2", features = ["full"] }
 tracing = "^0.1.37"
 tracing-futures = "^0.2.5"
 tracing-subscriber = { version = "^0.3.16", features = ["env-filter", "fmt"] }
-viceroy-lib = { path = "../lib", version = "^0.4.0" }
+viceroy-lib = { path = "../lib", version = "^0.4.1" }
 wat = "^1.0.38"
 
 [dev-dependencies]

--- a/cli/tests/trap-test/Cargo.lock
+++ b/cli/tests/trap-test/Cargo.lock
@@ -2090,9 +2090,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.11"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524b68aca1d05e03fdf03fcdce2c6c94b6daf6d16861ddaa7e4f2b6638a9052c"
+checksum = "7d502c968c6a838ead8e69b2ee18ec708802f99db92a0d156705ec9ef801993b"
 
 [[package]]
 name = "unicode-ident"
@@ -2152,7 +2152,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "viceroy-lib"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "bytes",

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "viceroy-lib"
-version = "0.4.0"
+version = "0.4.1"
 description = "Viceroy implementation details."
 authors = ["Fastly"]
 edition = "2021"

--- a/test-fixtures/Cargo.lock
+++ b/test-fixtures/Cargo.lock
@@ -369,9 +369,9 @@ checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.11"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524b68aca1d05e03fdf03fcdce2c6c94b6daf6d16861ddaa7e4f2b6638a9052c"
+checksum = "7d502c968c6a838ead8e69b2ee18ec708802f99db92a0d156705ec9ef801993b"
 
 [[package]]
 name = "unicode-ident"


### PR DESCRIPTION
I think the [secret store change](https://github.com/fastly/Viceroy/pull/206) necessitates a minor version bump if I'm understanding correctly.