### PR TITLE
🪀 Add `fastly_backend` interfaces for backend introspection

### DIFF
--- a/lib/compute-at-edge-abi/compute-at-edge.witx
+++ b/lib/compute-at-edge-abi/compute-at-edge.witx
@@ -529,6 +529,98 @@
     )
 )
 
+(module $fastly_backend
+    ;; Returns 1 if a backend with this name exists.
+    (@interface func (export "exists")
+        (param $backend string)
+        (result $err (expected
+                $backend_exists
+                (error $fastly_status)))
+    )
+
+    (@interface func (export "is_healthy")
+        (param $backend string)
+        (result $err (expected $backend_health (error $fastly_status)))
+    )
+
+    ;; Returns 1 if the backend is a "dynamic" backend.
+    (@interface func (export "is_dynamic")
+        (param $backend string)
+        (result $err (expected $is_dynamic (error $fastly_status)))
+    )
+
+    ;; Get the host of this backend.
+    (@interface func (export "get_host")
+        (param $backend string)
+        (param $value (@witx pointer (@witx char8)))
+        (param $value_max_len (@witx usize))
+        (param $nwritten_out (@witx pointer (@witx usize)))
+        (result $err (expected (error $fastly_status)))
+    )
+
+    ;; Get the "override host" for this backend.
+    ;;
+    ;; This is used to change the `Host` header sent to the backend. See the Fastly documentation
+    ;; on this topic here: https://docs.fastly.com/en/guides/specifying-an-override-host
+    (@interface func (export "get_override_host")
+        (param $backend string)
+        (param $value (@witx pointer (@witx char8)))
+        (param $value_max_len (@witx usize))
+        (param $nwritten_out (@witx pointer (@witx usize)))
+        (result $err (expected (error $fastly_status)))
+    )
+
+    ;; Get the remote TCP port of the backend connection for the request.
+    (@interface func (export "get_port")
+        (param $backend string)
+        (result $err (expected
+                $port
+                (error $fastly_status)))
+    )
+
+    ;; Get the connection timeout of the backend.
+    (@interface func (export "get_connect_timeout_ms")
+        (param $backend string)
+        (result $err (expected
+                $timeout_ms
+                (error $fastly_status)))
+    )
+
+    ;; Get the first byte timeout of the backend.
+    (@interface func (export "get_first_byte_timeout_ms")
+        (param $backend string)
+        (result $err (expected
+                $timeout_ms
+                (error $fastly_status)))
+    )
+
+    ;; Get the between byte timeout of the backend.
+    (@interface func (export "get_between_bytes_timeout_ms")
+        (param $backend string)
+        (result $err (expected
+                $timeout_ms
+                (error $fastly_status)))
+    )
+
+    ;; Returns 1 if the backend is configured to use SSL.
+    (@interface func (export "is_ssl")
+        (param $backend string)
+        (result $err (expected $is_ssl (error $fastly_status)))
+    )
+
+    ;; Get the minimum SSL version this backend will use.
+    (@interface func (export "get_ssl_min_version")
+        (param $backend string)
+        (result $err (expected $tls_version (error $fastly_status)))
+    )
+
+    ;; Get the maximum SSL version this backend will use.
+    (@interface func (export "get_ssl_max_version")
+        (param $backend string)
+        (result $err (expected $tls_version (error $fastly_status)))
+    )
+)
+
 (module $fastly_async_io
     ;;; Blocks until one of the given objects is ready for I/O, or the optional timeout expires.
     ;;;

--- a/lib/compute-at-edge-abi/typenames.witx
+++ b/lib/compute-at-edge-abi/typenames.witx
@@ -135,6 +135,17 @@
 (typename $inserted u32)
 (typename $ready_idx u32)
 
+(typename $port u16)
+(typename $timeout_ms u32)
+(typename $backend_exists u32)
+(typename $is_dynamic u32)
+(typename $is_ssl u32)
+(typename $backend_health
+    (enum (@witx tag u32)
+        $unknown
+        $healthy
+        $unhealthy))
+
 (typename $content_encodings
     (flags (@witx repr u32)
         $gzip))

--- a/lib/compute-at-edge-abi/typenames.witx
+++ b/lib/compute-at-edge-abi/typenames.witx
@@ -164,7 +164,8 @@
        $cert_hostname
        $ca_cert
        $ciphers
-       $sni_hostname))
+       $sni_hostname
+       $dont_pool))
 
 (typename $dynamic_backend_config
   (record

--- a/lib/src/error.rs
+++ b/lib/src/error.rs
@@ -127,6 +127,12 @@ pub enum Error {
 
     #[error("Shared memory not supported yet")]
     SharedMemory,
+
+    #[error("Value absent from structure")]
+    ValueAbsent,
+
+    #[error("String conversion error")]
+    ToStr(#[from] http::header::ToStrError),
 }
 
 impl Error {
@@ -139,7 +145,7 @@ impl Error {
     pub fn to_fastly_status(&self) -> FastlyStatus {
         match self {
             Error::BufferLengthError { .. } => FastlyStatus::Buflen,
-            Error::InvalidArgument => FastlyStatus::Inval,
+            Error::InvalidArgument | Error::ValueAbsent => FastlyStatus::Inval,
             Error::Unsupported { .. } => FastlyStatus::Unsupported,
             Error::HandleError { .. } => FastlyStatus::Badf,
             Error::InvalidStatusCode { .. } => FastlyStatus::Inval,
@@ -181,7 +187,8 @@ impl Error {
             | Error::UnknownObjectStore(_)
             | Error::ObjectStoreKeyValidationError(_)
             | Error::UnfinishedStreamingBody
-            | Error::SharedMemory => FastlyStatus::Error,
+            | Error::SharedMemory
+            | Error::ToStr(_) => FastlyStatus::Error,
         }
     }
 

--- a/lib/src/session.rs
+++ b/lib/src/session.rs
@@ -548,6 +548,11 @@ impl Session {
             .or_else(|| self.dynamic_backends.get(name))
     }
 
+    /// Look up a dynamic backend (only) by name.
+    pub fn dynamic_backend(&self, name: &str) -> Option<&Arc<Backend>> {
+        self.dynamic_backends.get(name)
+    }
+
     /// Return the full list of static and dynamic backend names as an [`Iterator`].
     pub fn backend_names(&self) -> impl Iterator<Item = &String> {
         self.backends.keys().chain(self.dynamic_backends.keys())

--- a/lib/src/wiggle_abi.rs
+++ b/lib/src/wiggle_abi.rs
@@ -47,6 +47,7 @@ macro_rules! multi_value_result {
     }};
 }
 
+mod backend_impl;
 mod body_impl;
 mod dictionary_impl;
 mod entity;

--- a/lib/src/wiggle_abi/backend_impl.rs
+++ b/lib/src/wiggle_abi/backend_impl.rs
@@ -1,0 +1,207 @@
+use super::fastly_backend::FastlyBackend;
+use crate::{config::Backend, error::Error, session::Session};
+
+fn lookup_backend_definition<'sess>(
+    session: &'sess Session,
+    backend: &wiggle::GuestPtr<str>,
+) -> Result<&'sess Backend, Error> {
+    let name = backend.as_str()?.ok_or(Error::SharedMemory)?;
+    session
+        .backend(&name)
+        .map(AsRef::as_ref)
+        .ok_or(Error::InvalidArgument)
+}
+
+impl FastlyBackend for Session {
+    fn exists(
+        &mut self,
+        backend: &wiggle::GuestPtr<str>,
+    ) -> Result<super::types::BackendExists, Error> {
+        if lookup_backend_definition(self, backend).is_ok() {
+            Ok(1)
+        } else {
+            Ok(0)
+        }
+    }
+
+    fn is_healthy(
+        &mut self,
+        backend: &wiggle::GuestPtr<str>,
+    ) -> Result<super::types::BackendHealth, Error> {
+        // just doing this to get a different error if the backend doesn't exist
+        let _ = lookup_backend_definition(self, backend)?;
+        // health checks are not enabled in Viceroy :(
+        Err(Error::Unsupported {
+            msg: "backend healthchecking is not configured in Viceroy",
+        })
+    }
+
+    fn is_dynamic(
+        &mut self,
+        backend: &wiggle::GuestPtr<str>,
+    ) -> Result<super::types::IsDynamic, Error> {
+        let name = backend.as_str()?.ok_or(Error::SharedMemory)?;
+
+        if self.dynamic_backend(&name).is_some() {
+            Ok(1)
+        } else if self.backend(&name).is_some() {
+            Ok(0)
+        } else {
+            Err(Error::InvalidArgument)
+        }
+    }
+
+    fn get_host(
+        &mut self,
+        backend: &wiggle::GuestPtr<str>,
+        value: &wiggle::GuestPtr<u8>,
+        value_max_len: u32,
+        nwritten_out: &wiggle::GuestPtr<u32>,
+    ) -> Result<(), Error> {
+        let backend = lookup_backend_definition(self, backend)?;
+        let mut value = value
+            .as_array(value_max_len)
+            .as_slice_mut()?
+            .ok_or(Error::SharedMemory)?;
+        let value_max_len: usize = value_max_len
+            .try_into()
+            .map_err(|_| Error::InvalidArgument)?;
+        let host = backend.uri.host().expect("backend uri has host");
+
+        match host.len() {
+            len_needed if len_needed > value_max_len => {
+                let len_needed = len_needed.try_into().expect("host.len() must fit in u32");
+                nwritten_out.write(len_needed)?;
+                Err(Error::BufferLengthError {
+                    buf: "host",
+                    len: "host.len()",
+                })
+            }
+
+            len => {
+                let host = host.as_bytes();
+                value[0..len].copy_from_slice(host);
+                let len = len.try_into().expect("host.len() must fit in u32");
+                nwritten_out.write(len)?;
+                Ok(())
+            }
+        }
+    }
+
+    fn get_override_host<'a>(
+        &mut self,
+        backend: &wiggle::GuestPtr<'a, str>,
+        value: &wiggle::GuestPtr<'a, u8>,
+        value_max_len: u32,
+        nwritten_out: &wiggle::GuestPtr<'a, u32>,
+    ) -> Result<(), Error> {
+        let backend = lookup_backend_definition(self, backend)?;
+        let mut value = value
+            .as_array(value_max_len)
+            .as_slice_mut()?
+            .ok_or(Error::SharedMemory)?;
+        let value_max_len: usize = value_max_len
+            .try_into()
+            .map_err(|_| Error::InvalidArgument)?;
+        let host = backend
+            .override_host
+            .as_ref()
+            .ok_or(Error::ValueAbsent)?
+            .to_str()?;
+
+        match host.len() {
+            len_needed if len_needed > value_max_len => {
+                let len_needed = len_needed.try_into().expect("host.len() must fit in u32");
+                nwritten_out.write(len_needed)?;
+                Err(Error::BufferLengthError {
+                    buf: "host",
+                    len: "host.len()",
+                })
+            }
+
+            len => {
+                let host = host.as_bytes();
+                value[0..len].copy_from_slice(host);
+                let len = len.try_into().expect("host.len() must fit in u32");
+                nwritten_out.write(len)?;
+                Ok(())
+            }
+        }
+    }
+
+    fn get_port(&mut self, backend: &wiggle::GuestPtr<str>) -> Result<super::types::Port, Error> {
+        let backend = lookup_backend_definition(self, backend)?;
+
+        match backend.uri.port_u16() {
+            Some(port) => Ok(port),
+            None if backend.uri.scheme() == Some(&http::uri::Scheme::HTTPS) => Ok(443),
+            _ => Ok(80),
+        }
+    }
+
+    fn get_connect_timeout_ms(
+        &mut self,
+        backend: &wiggle::GuestPtr<str>,
+    ) -> Result<super::types::TimeoutMs, Error> {
+        // just doing this to get a different error if the backend doesn't exist
+        let _ = lookup_backend_definition(self, backend)?;
+        // health checks are not enabled in Viceroy :(
+        Err(Error::Unsupported {
+            msg: "connection timing is not actually supported in Viceroy",
+        })
+    }
+
+    fn get_first_byte_timeout_ms(
+        &mut self,
+        backend: &wiggle::GuestPtr<str>,
+    ) -> Result<super::types::TimeoutMs, Error> {
+        // just doing this to get a different error if the backend doesn't exist
+        let _ = lookup_backend_definition(self, backend)?;
+        // health checks are not enabled in Viceroy :(
+        Err(Error::Unsupported {
+            msg: "connection timing is not actually supported in Viceroy",
+        })
+    }
+
+    fn get_between_bytes_timeout_ms(
+        &mut self,
+        backend: &wiggle::GuestPtr<str>,
+    ) -> Result<super::types::TimeoutMs, Error> {
+        // just doing this to get a different error if the backend doesn't exist
+        let _ = lookup_backend_definition(self, backend)?;
+        // health checks are not enabled in Viceroy :(
+        Err(Error::Unsupported {
+            msg: "connection timing is not actually supported in Viceroy",
+        })
+    }
+
+    fn get_ssl_min_version(
+        &mut self,
+        backend: &wiggle::GuestPtr<str>,
+    ) -> Result<super::types::TlsVersion, Error> {
+        // just doing this to get a different error if the backend doesn't exist
+        let _ = lookup_backend_definition(self, backend)?;
+        // health checks are not enabled in Viceroy :(
+        Err(Error::Unsupported {
+            msg: "ssl version flags are not supported in Viceroy",
+        })
+    }
+
+    fn get_ssl_max_version(
+        &mut self,
+        backend: &wiggle::GuestPtr<str>,
+    ) -> Result<super::types::TlsVersion, Error> {
+        // just doing this to get a different error if the backend doesn't exist
+        let _ = lookup_backend_definition(self, backend)?;
+        // health checks are not enabled in Viceroy :(
+        Err(Error::Unsupported {
+            msg: "ssl version flags are not supported in Viceroy",
+        })
+    }
+
+    fn is_ssl(&mut self, backend: &wiggle::GuestPtr<str>) -> Result<super::types::IsSsl, Error> {
+        lookup_backend_definition(self, backend)
+            .map(|x| x.uri.scheme() == Some(&http::uri::Scheme::HTTPS))
+            .map(|x| if x { 1 } else { 0 })
+    }
+}

--- a/lib/src/wiggle_abi/req_impl.rs
+++ b/lib/src/wiggle_abi/req_impl.rs
@@ -191,12 +191,6 @@ impl FastlyHttpReq for Session {
             return Err(Error::InvalidArgument);
         }
 
-        // If someone has set any bits we don't know about, let's also return false,
-        // as there's either bad data or an API compatibility problem.
-        if backend_info_mask != BackendConfigOptions::from_bits_truncate(backend_info_mask.bits()) {
-            return Err(Error::InvalidArgument);
-        }
-
         let override_host = if backend_info_mask.contains(BackendConfigOptions::HOST_OVERRIDE) {
             if config.host_override_len == 0 {
                 return Err(Error::InvalidArgument);

--- a/lib/src/wiggle_abi/req_impl.rs
+++ b/lib/src/wiggle_abi/req_impl.rs
@@ -191,6 +191,12 @@ impl FastlyHttpReq for Session {
             return Err(Error::InvalidArgument);
         }
 
+        // If someone has set any bits we don't know about, let's also return false,
+        // as there's either bad data or an API compatibility problem.
+        if backend_info_mask != BackendConfigOptions::from_bits_truncate(backend_info_mask.bits()) {
+            return Err(Error::InvalidArgument);
+        }
+
         let override_host = if backend_info_mask.contains(BackendConfigOptions::HOST_OVERRIDE) {
             if config.host_override_len == 0 {
                 return Err(Error::InvalidArgument);


### PR DESCRIPTION
This doesn't actually implement any interesting functionality -- it's not clear what pooling would mean within the context of Viceroy -- but it allows programs that use this flag to function properly.

Because this just bit me, I've also removed the bit of code that checks for unknown flags and errors. I think it actually makes more sense for old versions of Viceroy to ignore flags they don't understand. Admittedly, I'm betting that future changes will be like this one (in that they don't change any, or change very little, Viceroy behavior), and not settings which will totally change behavior.