### PR TITLE
feat: allow config-stores to be defined using `[local_server.config_stores]`

### DIFF
--- a/cli/tests/integration/config_store_lookup.rs
+++ b/cli/tests/integration/config_store_lookup.rs
@@ -1,0 +1,80 @@
+use crate::common::{Test, TestResult};
+use hyper::{body::to_bytes, StatusCode};
+
+#[tokio::test(flavor = "multi_thread")]
+async fn json_config_store_lookup_works() -> TestResult {
+    const FASTLY_TOML: &str = r#"
+        name = "json-config_store-lookup"
+        description = "json config_store lookup test"
+        authors = ["Jill Bryson <jbryson@fastly.com>", "Rose McDowall <rmcdowall@fastly.com>"]
+        language = "rust"
+        [local_server]
+        [local_server.config_stores]
+        [local_server.config_stores.animals]
+        file = "../test-fixtures/data/json-config_store.json"
+        format = "json"
+    "#;
+
+    let resp = Test::using_fixture("config_store-lookup.wasm")
+        .using_fastly_toml(FASTLY_TOML)?
+        .against_empty()
+        .await;
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    assert!(to_bytes(resp.into_body())
+        .await
+        .expect("can read body")
+        .to_vec()
+        .is_empty());
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn inline_toml_config_store_lookup_works() -> TestResult {
+    const FASTLY_TOML: &str = r#"
+        name = "inline-toml-config_store-lookup"
+        description = "inline toml config_store lookup test"
+        authors = ["Jill Bryson <jbryson@fastly.com>", "Rose McDowall <rmcdowall@fastly.com>"]
+        language = "rust"
+        [local_server]
+        [local_server.config_stores]
+        [local_server.config_stores.animals]
+        format = "inline-toml"
+        [local_server.config_stores.animals.contents]
+        dog = "woof"
+        cat = "meow"
+    "#;
+
+    let resp = Test::using_fixture("config_store-lookup.wasm")
+        .using_fastly_toml(FASTLY_TOML)?
+        .against_empty()
+        .await;
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    assert!(to_bytes(resp.into_body())
+        .await
+        .expect("can read body")
+        .to_vec()
+        .is_empty());
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn missing_config_store_works() -> TestResult {
+    const FASTLY_TOML: &str = r#"
+        name = "missing-config_store-config"
+        description = "missing config_store test"
+        language = "rust"
+    "#;
+
+    let resp = Test::using_fixture("config_store-lookup.wasm")
+        .using_fastly_toml(FASTLY_TOML)?
+        .against_empty()
+        .await;
+
+    assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+
+    Ok(())
+}

--- a/lib/src/config.rs
+++ b/lib/src/config.rs
@@ -202,6 +202,7 @@ pub enum ExperimentalModule {
 struct RawLocalServerConfig {
     backends: Option<Table>,
     geolocation: Option<Table>,
+    #[serde(alias = "config_stores")]
     dictionaries: Option<Table>,
     #[serde(alias = "object_store")]
     object_stores: Option<Table>,

--- a/test-fixtures/data/json-config_store.json
+++ b/test-fixtures/data/json-config_store.json
@@ -1,0 +1,4 @@
+{
+    "cat": "meow",
+    "dog": "woof"
+}


### PR DESCRIPTION
Currently they can be defined using `[local_server.dictionaries]`, this patch adds an alias for `[local_server.config_stores]` which matches the way we defined object and secret stores (`local_server.object_stores` and `local_server.secret_stores`)