### PR TITLE
Remove validation on config store and dictionary names

### DIFF
--- a/lib/src/config/dictionaries.rs
+++ b/lib/src/config/dictionaries.rs
@@ -245,16 +245,8 @@ mod deserialization {
     impl FromStr for DictionaryName {
         type Err = DictionaryConfigError;
         fn from_str(name: &str) -> Result<Self, Self::Err> {
-            // Name must start with alphabetical and contain only alphanumeric, underscore, and whitespace
-            if name.starts_with(char::is_alphabetic)
-                && name
-                    .chars()
-                    .all(|c| char::is_alphanumeric(c) || c == '_' || char::is_whitespace(c))
-            {
-                Ok(Self(name.to_owned()))
-            } else {
-                Err(DictionaryConfigError::InvalidName(name.to_owned()))
-            }
+            // We do not do any validation on the name as Config Stores and Dictionaries have different validation rules
+            Ok(Self(name.to_owned()))
         }
     }
 }

--- a/lib/src/config/unit_tests.rs
+++ b/lib/src/config/unit_tests.rs
@@ -569,56 +569,6 @@ mod json_dictionary_config_tests {
         }
     }
 
-    /// Check that dictionary definitions must include a *valid* `name` field.
-    #[test]
-    fn dictionary_configs_must_provide_a_valid_name() {
-        use DictionaryConfigError::InvalidName;
-        let dir = tempdir().unwrap();
-        let file_path = dir.path().join("secrets.json");
-        let mut file = File::create(&file_path).unwrap();
-        writeln!(file, "{{}}").unwrap();
-
-        let bad_name_field = format!(
-            r#"
-            [dictionaries]
-            "1" = {{ file = '{}', format = "json" }}
-        "#,
-            file_path.to_str().unwrap()
-        );
-        match read_local_server_config(&bad_name_field) {
-            Err(InvalidDictionaryDefinition {
-                err: InvalidName(_),
-                ..
-            }) => {}
-            res => panic!("unexpected result: {:?}", res),
-        }
-    }
-
-    /// Check that config_store definitions must include a *valid* `name` field.
-    #[test]
-    fn config_store_configs_must_provide_a_valid_name() {
-        use DictionaryConfigError::InvalidName;
-        let dir = tempdir().unwrap();
-        let file_path = dir.path().join("secrets.json");
-        let mut file = File::create(&file_path).unwrap();
-        writeln!(file, "{{}}").unwrap();
-
-        let bad_name_field = format!(
-            r#"
-            [config_stores]
-            "1" = {{ file = '{}', format = "json" }}
-        "#,
-            file_path.to_str().unwrap()
-        );
-        match read_local_server_config(&bad_name_field) {
-            Err(InvalidDictionaryDefinition {
-                err: InvalidName(_),
-                ..
-            }) => {}
-            res => panic!("unexpected result: {:?}", res),
-        }
-    }
-
     /// Check that file field is a string.
     #[test]
     fn dictionary_configs_must_provide_file_as_a_string() {
@@ -890,42 +840,6 @@ mod inline_toml_dictionary_config_tests {
         match read_local_server_config(&missing_contents) {
             Err(InvalidDictionaryDefinition {
                 err: MissingContents,
-                ..
-            }) => {}
-            res => panic!("unexpected result: {:?}", res),
-        }
-    }
-
-    /// Check that dictionary definitions must include a *valid* `name` field.
-    #[test]
-    fn dictionary_configs_must_provide_a_valid_name() {
-        use DictionaryConfigError::InvalidName;
-        let bad_name_field = r#"
-            [dictionaries."1"]
-            format = "inline-toml"
-            contents = { apple = "fruit", potato = "vegetable" }
-        "#;
-        match read_local_server_config(&bad_name_field) {
-            Err(InvalidDictionaryDefinition {
-                err: InvalidName(_),
-                ..
-            }) => {}
-            res => panic!("unexpected result: {:?}", res),
-        }
-    }
-
-    /// Check that config_store definitions must include a *valid* `name` field.
-    #[test]
-    fn config_store_configs_must_provide_a_valid_name() {
-        use DictionaryConfigError::InvalidName;
-        let bad_name_field = r#"
-            [config_stores."1"]
-            format = "inline-toml"
-            contents = { apple = "fruit", potato = "vegetable" }
-        "#;
-        match read_local_server_config(&bad_name_field) {
-            Err(InvalidDictionaryDefinition {
-                err: InvalidName(_),
                 ..
             }) => {}
             res => panic!("unexpected result: {:?}", res),

--- a/lib/src/error.rs
+++ b/lib/src/error.rs
@@ -407,9 +407,6 @@ pub enum DictionaryConfigError {
     #[error("definition was not provided as a TOML table")]
     InvalidEntryType,
 
-    #[error("invalid string: {0}")]
-    InvalidName(String),
-
     #[error("'name' field was not a string")]
     InvalidNameEntry,
 


### PR DESCRIPTION
The validation rules for names of Config Stores and Dictionaries are different. Config Stores have very relaxed rules, the name can contain any character, even just whitespace characters.

This patch removes the validation rules for names, this does mean an invalid Dictionary name could be used locally, but the customer will see the issue when they deploy to Fastly Compute