### PR TITLE
🗳️ Add synchronization logic for upstream-async tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
       with:
         submodules: true
     - name: Install Rust
-      run: rustup self update && rustup update stable && rustup default stable
+      run: rustup update --no-self-update stable && rustup default stable
       shell: bash
     - name: Add wasm32-wasi Rust target
       run: rustup target add wasm32-wasi
@@ -56,7 +56,7 @@ jobs:
       with:
         submodules: true
     - name: Install Rust
-      run: rustup self update && rustup update stable && rustup default stable
+      run: rustup update --no-self-update stable && rustup default stable
       shell: bash
     - name: Add wasm32-wasi Rust target
       run: rustup target add wasm32-wasi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
       with:
         submodules: true
     - name: Install Rust
-      run: rustup update stable && rustup default stable
+      run: rustup self update && rustup update stable && rustup default stable
       shell: bash
     - name: Add wasm32-wasi Rust target
       run: rustup target add wasm32-wasi
@@ -56,7 +56,7 @@ jobs:
       with:
         submodules: true
     - name: Install Rust
-      run: rustup update stable && rustup default stable
+      run: rustup self update && rustup update stable && rustup default stable
       shell: bash
     - name: Add wasm32-wasi Rust target
       run: rustup target add wasm32-wasi

--- a/cli/tests/integration/upstream_async.rs
+++ b/cli/tests/integration/upstream_async.rs
@@ -1,3 +1,7 @@
+use std::sync::Arc;
+
+use tokio::sync::Semaphore;
+
 use {
     crate::common::{Test, TestResult},
     hyper::{Response, StatusCode},
@@ -5,24 +9,37 @@ use {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn upstream_async_methods() -> TestResult {
-    // Set up the test harness
+    // Set up two backends that share a semaphore that starts with zero permits. `backend1` must
+    // take a semaphore permit and then "forget" it before returning its response. `backend2` adds a
+    // permit to the semaphore and promptly returns. This relationship allows the test fixtures to
+    // examine the behavior of the various pending request operators beyond just whether they
+    // eventually return the expected response.
+    let sema_backend1 = Arc::new(Semaphore::new(0));
+    let sema_backend2 = sema_backend1.clone();
     let test = Test::using_fixture("upstream-async.wasm")
-        // Set up the backends, which just return responses with an identifying header
         .backend("backend1", "http://127.0.0.1:9000/", None)
-        .host(9000, |_| {
-            Response::builder()
-                .header("Backend-1-Response", "")
-                .status(StatusCode::OK)
-                .body(vec![])
-                .unwrap()
+        .async_host(9000, move |_| {
+            let sema_backend1 = sema_backend1.clone();
+            Box::new(async move {
+                sema_backend1.acquire().await.unwrap().forget();
+                Response::builder()
+                    .header("Backend-1-Response", "")
+                    .status(StatusCode::OK)
+                    .body(hyper::Body::empty())
+                    .unwrap()
+            })
         })
         .backend("backend2", "http://127.0.0.1:9001/", None)
-        .host(9001, |_| {
-            Response::builder()
-                .header("Backend-2-Response", "")
-                .status(StatusCode::OK)
-                .body(vec![])
-                .unwrap()
+        .async_host(9001, move |_| {
+            let sema_backend2 = sema_backend2.clone();
+            Box::new(async move {
+                sema_backend2.add_permits(1);
+                Response::builder()
+                    .header("Backend-2-Response", "")
+                    .status(StatusCode::OK)
+                    .body(hyper::Body::empty())
+                    .unwrap()
+            })
         });
 
     // The meat of the test is on the guest side; we just check that we made it through successfully


### PR DESCRIPTION
This allows us to observe that the implementation of `poll()` doesn't block, unlike its counterpart `wait()`.