### PR TITLE
🕷️ Rework integration tests to allow parallel test execution

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,8 @@ exclude = [
 # commands like `cargo run` will run the CLI binary by default.
 # See: https://doc.rust-lang.org/cargo/reference/workspaces.html#package-selection
 default-members = [ "cli" ]
+
+[profile.dev]
+# Since some of the integration tests involve compiling Wasm, a little optimization goes a long way
+# toward making the test suite not take forever
+opt-level = 1

--- a/cli/tests/integration/common/backends.rs
+++ b/cli/tests/integration/common/backends.rs
@@ -1,0 +1,300 @@
+use std::collections::HashMap;
+use std::sync::{Arc, Weak};
+
+use hyper::http::uri::PathAndQuery;
+use hyper::http::HeaderValue;
+use hyper::{Body as HyperBody, Request, Response, Uri};
+use tokio::sync::Mutex;
+
+use super::{AsyncResp, TestServer, TestService};
+
+pub type BackendName = String;
+
+/// A set of test backend definitions and possibly-running test servers for those backends.
+#[derive(Clone, Debug)]
+pub struct TestBackends {
+    inner: Arc<Mutex<Inner>>,
+}
+
+impl TestBackends {
+    /// Create a new, empty set of test backends.
+    pub fn new() -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(Inner::new())),
+        }
+    }
+
+    /// Initialize a set of test backends from [`viceroy_lib::config::Backends`] that probably came
+    /// from a `fastly.toml` file.
+    ///
+    /// Note that this constructor adds backend definitions without an associated test service. A
+    /// test service must be set for each backend with [`TestBackends::set_test_service()`] or
+    /// [`TestBackends::set_async_test_service()`] before starting the test servers.
+    pub fn from_backend_configs(backend_configs: &viceroy_lib::config::Backends) -> Self {
+        let mut inner = Inner::new();
+        for (name, backend_config) in backend_configs {
+            let test_backend = TestBackend {
+                path: backend_config
+                    .uri
+                    .path_and_query()
+                    .cloned()
+                    .unwrap_or_else(|| PathAndQuery::from_static("/")),
+                override_host: backend_config.override_host.clone(),
+                cert_host: backend_config.cert_host.clone(),
+                use_sni: backend_config.use_sni,
+                test_service: None,
+                test_server: None,
+            };
+            inner.map.insert(name.clone(), test_backend);
+        }
+        Self {
+            inner: Arc::new(Mutex::new(inner)),
+        }
+    }
+
+    /// Get [`viceroy_lib::config::Backends`] for the defined test backends and their test servers.
+    ///
+    /// Panics if the test servers have not been started, as the ephemeral ports bound during test
+    /// server startup are required in order to provide complete complete backend configurations.
+    pub async fn backend_configs(&self) -> viceroy_lib::config::Backends {
+        let inner = self.inner.lock().await;
+        let mut backends = viceroy_lib::config::Backends::new();
+        for (name, backend) in inner.map.iter() {
+            let addr = backend
+                .test_server
+                .as_ref()
+                .expect("TestBackend servers must be running to get backend configurations")
+                .bound_addr;
+            let uri = format!("http://{addr}{}", backend.path)
+                .parse()
+                .expect("backend uri must be valid");
+            let backend_config = viceroy_lib::config::Backend {
+                uri,
+                override_host: backend.override_host.clone(),
+                cert_host: backend.cert_host.clone(),
+                use_sni: backend.use_sni,
+            };
+            backends.insert(name.to_string(), Arc::new(backend_config));
+        }
+        backends
+    }
+
+    /// Get a [`TestBackendBuilder`] that will add a backend of the given name when built.
+    pub fn test_backend(&self, name: &str) -> TestBackendBuilder {
+        TestBackendBuilder {
+            inner: Arc::downgrade(&self.inner),
+            name: name.to_string(),
+            path: "/".to_string(),
+            override_host: None,
+            use_sni: true,
+            test_service: None,
+        }
+    }
+
+    /// Set the test service for the backend of the given name.
+    ///
+    /// Panics if the test servers have already been started.
+    #[allow(unused)] // It's not used for now, but could be useful for advanced backend chicanery.
+    pub async fn set_test_service<TestServiceFn>(&self, name: &str, test_service: TestServiceFn)
+    where
+        TestServiceFn: Fn(Request<Vec<u8>>) -> Response<Vec<u8>>,
+        TestServiceFn: Send + Sync + 'static,
+    {
+        let mut inner = self.inner.lock().await;
+        assert!(
+            !inner.servers_are_running,
+            "cannot set a test service once servers are running"
+        );
+        inner
+            .map
+            .get_mut(name)
+            .unwrap_or_else(|| panic!("backend {name:?} not found"))
+            .test_service = Some(TestService::Sync(Arc::new(test_service)));
+    }
+
+    /// Set the asynchronous test service for the backend of the given name.
+    ///
+    /// Panics if the test servers have already been started.
+    #[allow(unused)] // It's not used for now, but could be useful for advanced backend chicanery.
+    pub async fn set_async_test_service<TestServiceFn>(
+        &self,
+        name: &str,
+        test_service: TestServiceFn,
+    ) where
+        TestServiceFn: Fn(Request<HyperBody>) -> AsyncResp,
+        TestServiceFn: Send + Sync + 'static,
+    {
+        let mut inner = self.inner.lock().await;
+        assert!(
+            !inner.servers_are_running,
+            "cannot set a test service once servers are running"
+        );
+        inner
+            .map
+            .get_mut(name)
+            .unwrap_or_else(|| panic!("backend {name:?} not found"))
+            .test_service = Some(TestService::Async(Arc::new(test_service)));
+    }
+
+    /// Are the backend test servers running?
+    pub async fn servers_are_running(&self) -> bool {
+        self.inner.lock().await.servers_are_running
+    }
+
+    /// Start the backend test servers.
+    ///
+    /// Panics if the servers are already running, or if any backend is missing a test service.
+    pub async fn start_servers(&self) {
+        let mut inner = self.inner.lock().await;
+        assert!(
+            !inner.servers_are_running,
+            "cannot start TestBackend servers more than once"
+        );
+        for (name, mut backend) in inner.map.iter_mut() {
+            let Some(service) = backend.test_service.as_ref() else {
+                panic!("no service defined for backend {name}");
+            };
+            backend.test_server = Some(Arc::new(service.spawn()));
+        }
+        inner.servers_are_running = true;
+    }
+
+    /// Get the [`Uri`] suitable for sending a request to a running backend test server.
+    ///
+    /// Specifically, this `Uri` will include the ephemeral port assigned when the test server was
+    /// started, which must be known in advance to properly test fixtures using dynamic backends.
+    ///
+    /// Panics if no backend by this name is defined, or if the backend test servers have not yet been
+    /// started.
+    pub async fn uri_for_backend_server(&self, name: &str) -> Uri {
+        let inner = self.inner.lock().await;
+        let backend = inner.map.get(name).expect("backend not found");
+        let addr = backend
+            .test_server
+            .as_ref()
+            .expect("TestBackend servers must be running to get backend configurations")
+            .bound_addr;
+        format!("http://{addr}{}", backend.path)
+            .parse()
+            .expect("backend uri must be valid")
+    }
+}
+
+#[derive(Debug)]
+struct Inner {
+    map: HashMap<BackendName, TestBackend>,
+    servers_are_running: bool,
+}
+
+impl Inner {
+    pub fn new() -> Self {
+        Self {
+            map: HashMap::new(),
+            servers_are_running: false,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct TestBackend {
+    path: PathAndQuery,
+    override_host: Option<HeaderValue>,
+    cert_host: Option<String>,
+    use_sni: bool,
+    test_service: Option<TestService>,
+    test_server: Option<Arc<TestServer>>,
+}
+
+#[derive(Debug)]
+pub struct TestBackendBuilder {
+    inner: Weak<Mutex<Inner>>,
+    name: String,
+    path: String,
+    override_host: Option<String>,
+    use_sni: bool,
+    test_service: Option<TestService>,
+}
+
+impl TestBackendBuilder {
+    /// Set the path to be prepended to requests sent to this backend (`/` by default).
+    pub fn path(mut self, path: &str) -> Self {
+        self.path = path.to_owned();
+        self
+    }
+
+    /// Set the `override_host` parameter on this backend (not set by default).
+    pub fn override_host(mut self, override_host: &str) -> Self {
+        self.override_host = Some(override_host.to_string());
+        self
+    }
+
+    /// Set the `use_sni` parameter on this backend (`true` by default).
+    pub fn use_sni(mut self, use_sni: bool) -> Self {
+        self.use_sni = use_sni;
+        self
+    }
+
+    /// Set the synchronous service function to use for this backend.
+    ///
+    /// The service function takes a request argument with a byte vector body, and returns a
+    /// response with a byte vector body. It will be called for each request sent to this backend's
+    /// test server.
+    ///
+    /// A test service (sync or async) must be set before starting the test servers.
+    pub fn test_service<TestServiceFn>(mut self, test_service: TestServiceFn) -> Self
+    where
+        TestServiceFn: Fn(Request<Vec<u8>>) -> Response<Vec<u8>>,
+        TestServiceFn: Send + Sync + 'static,
+    {
+        self.test_service = Some(TestService::Sync(Arc::new(test_service)));
+        self
+    }
+
+    /// Set the asynchronous service function to use for this backend.
+    ///
+    /// The service function takes a request argument with a `hyper::Body`, and returns a response
+    /// with a `hyper::Body`. It will be called for each request sent to this backend's test server.
+    ///
+    /// A test service (sync or async) must be set before starting the test servers.
+    pub fn async_test_service<TestServiceFn>(mut self, test_service: TestServiceFn) -> Self
+    where
+        TestServiceFn: Fn(Request<HyperBody>) -> AsyncResp,
+        TestServiceFn: Send + Sync + 'static,
+    {
+        self.test_service = Some(TestService::Async(Arc::new(test_service)));
+        self
+    }
+
+    /// Finish building this backend and add it to the [`TestBackends`] that created this builder.
+    ///
+    /// Panics if:
+    ///
+    /// * The `TestBackends` that created this builder no longer exists, or its test servers have
+    /// already been started
+    ///
+    /// * The `path` does not parse as a valid `PathAndQuery`
+    ///
+    /// * The `override_host` does not parse as a valid `HeaderValue`
+    pub async fn build(self) {
+        let inner_arc = self.inner.upgrade().expect("TestBackends dropped");
+        let path = self.path.parse().expect("invalid backend path");
+        let override_host = self
+            .override_host
+            .map(|s| s.parse().expect("can parse override_host"));
+        let mut inner = inner_arc.lock().await;
+        if inner.servers_are_running {
+            panic!("cannot add test backends after starting servers");
+        }
+        inner.map.insert(
+            self.name,
+            TestBackend {
+                path,
+                override_host,
+                cert_host: None,
+                use_sni: self.use_sni,
+                test_service: self.test_service,
+                test_server: None,
+            },
+        );
+    }
+}

--- a/cli/tests/integration/downstream_req.rs
+++ b/cli/tests/integration/downstream_req.rs
@@ -5,7 +5,7 @@ use {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn downstream_request_works() -> TestResult {
-    let req = Request::get("http://127.0.0.1:17878")
+    let req = Request::get("/")
         .header("Accept", "text/html")
         .header("X-Custom-Test", "abcdef")
         .body("Hello, world!")?;

--- a/cli/tests/integration/http_semantics.rs
+++ b/cli/tests/integration/http_semantics.rs
@@ -10,23 +10,19 @@ async fn framing_headers_are_overridden() -> TestResult {
     // Set up the test harness
     let test = Test::using_fixture("bad-framing-headers.wasm")
         // The "TheOrigin" backend checks framing headers on the request and then echos its body.
-        .backend("TheOrigin", "http://127.0.0.1:9000/", None)
-        .host(9000, |req| {
+        .backend("TheOrigin", "/", None, |req| {
             assert!(!req.headers().contains_key(header::TRANSFER_ENCODING));
             assert_eq!(
                 req.headers().get(header::CONTENT_LENGTH),
                 Some(&hyper::header::HeaderValue::from(9))
             );
             Response::new(Vec::from(&b"salutations"[..]))
-        });
+        })
+        .await;
 
     let resp = test
         .via_hyper()
-        .against(
-            Request::post("http://127.0.0.1:17878")
-                .body("greetings")
-                .unwrap(),
-        )
+        .against(Request::post("/").body("greetings").unwrap())
         .await;
 
     assert_eq!(resp.status(), StatusCode::OK);
@@ -45,15 +41,12 @@ async fn content_length_is_computed_correctly() -> TestResult {
     // Set up the test harness
     let test = Test::using_fixture("content-length.wasm")
         // The "TheOrigin" backend supplies a fixed-size body.
-        .backend("TheOrigin", "http://127.0.0.1:9000/", None)
-        .host(9000, |_| {
+        .backend("TheOrigin", "/", None, |_| {
             Response::new(Vec::from(&b"ABCDEFGHIJKLMNOPQRST"[..]))
-        });
-
-    let resp = test
-        .via_hyper()
-        .against(Request::get("http://127.0.0.1:17878").body("").unwrap())
+        })
         .await;
+
+    let resp = test.via_hyper().against_empty().await;
 
     assert_eq!(resp.status(), StatusCode::OK);
 

--- a/cli/tests/integration/memory.rs
+++ b/cli/tests/integration/memory.rs
@@ -15,7 +15,7 @@ async fn direct_wasm_works() -> TestResult {
 async fn heap_limit_test_ok() -> TestResult {
     let resp = Test::using_wat_fixture("combined_heap_limits.wat")
         .against(
-            Request::get("http://127.0.0.1:17878/")
+            Request::get("/")
                 .header("guest-kb", "235")
                 .header("header-kb", "1")
                 .header("body-kb", "16")
@@ -40,7 +40,7 @@ async fn heap_limit_test_ok() -> TestResult {
 async fn heap_limit_test_bad() -> TestResult {
     let resp = Test::using_wat_fixture("combined_heap_limits.wat")
         .against(
-            Request::get("http://127.0.0.1:17878/")
+            Request::get("/")
                 .header("guest-kb", "150000")
                 .body("")
                 .unwrap(),

--- a/cli/tests/integration/upstream_streaming.rs
+++ b/cli/tests/integration/upstream_streaming.rs
@@ -9,8 +9,8 @@ async fn upstream_streaming() -> TestResult {
     // Set up the test harness
     let test = Test::using_fixture("upstream-streaming.wasm")
         // The "origin" backend simply echos the request body
-        .backend("origin", "http://127.0.0.1:9000/", None)
-        .host(9000, |req| Response::new(req.into_body()));
+        .backend("origin", "/", None, |req| Response::new(req.into_body()))
+        .await;
 
     // Test with an empty request
     let mut resp = test.against_empty().await;

--- a/cli/tests/trap-test/src/main.rs
+++ b/cli/tests/trap-test/src/main.rs
@@ -1,16 +1,21 @@
 use std::collections::HashSet;
 use {
-    crate::common::{TestResult, RUST_FIXTURE_PATH},
     hyper::{Body, Request, StatusCode},
     viceroy_lib::{ExecuteCtx, ProfilingStrategy},
 };
 
-#[path = "../../integration/common.rs"]
-mod common;
+/// A shorthand for the path to our test fixtures' build artifacts for Rust tests.
+const RUST_FIXTURE_PATH: &str = "../../../test-fixtures/target/wasm32-wasi/debug/";
+
+/// A catch-all error, so we can easily use `?` in test cases.
+pub type Error = Box<dyn std::error::Error + Send + Sync>;
+
+/// Handy alias for the return type of async Tokio tests
+pub type TestResult = Result<(), Error>;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn fatal_error_traps() -> TestResult {
-    let module_path = format!("../../{}/response.wasm", RUST_FIXTURE_PATH);
+    let module_path = format!("{RUST_FIXTURE_PATH}/response.wasm");
     let ctx = ExecuteCtx::new(module_path, ProfilingStrategy::None, HashSet::new())?;
     let req = Request::get("http://127.0.0.1:7878/").body(Body::from(""))?;
     let resp = ctx
@@ -29,6 +34,6 @@ async fn fatal_error_traps() -> TestResult {
         body,
         "Fatal error: [A fatal error occurred in the test-only implementation of header_values_get]"
     );
-    
+
     Ok(())
 }

--- a/lib/src/config/backends.rs
+++ b/lib/src/config/backends.rs
@@ -4,8 +4,6 @@ use {
 };
 
 /// A single backend definition.
-///
-/// Currently, a backend only consists of a [`Uri`], but more fields may be added in the future.
 #[derive(Clone, Debug)]
 pub struct Backend {
     pub uri: Uri,

--- a/lib/src/execute.rs
+++ b/lib/src/execute.rs
@@ -440,7 +440,13 @@ fn configure_wasmtime(profiling_strategy: ProfilingStrategy) -> wasmtime::Config
     // Maximum number of slots in the pooling allocator to keep "warm", or those
     // to keep around to possibly satisfy an affine allocation request or an
     // instantiation of a module previously instantiated within the pool.
-    pooling_allocation_config.max_unused_warm_slots(100);
+    pooling_allocation_config.max_unused_warm_slots(10);
+
+    // Use a large pool, but one smaller than the default of 1000 to avoid runnign out of virtual
+    // memory space if multiple engines are spun up in a single process. We'll likely want to move
+    // to the on-demand allocator eventually for most purposes; see
+    // https://github.com/fastly/Viceroy/issues/255
+    pooling_allocation_config.instance_count(100);
 
     config.allocation_strategy(InstanceAllocationStrategy::Pooling(
         pooling_allocation_config,

--- a/test-fixtures/src/bin/gzipped-response.rs
+++ b/test-fixtures/src/bin/gzipped-response.rs
@@ -11,7 +11,7 @@ fn main() -> Result<(), SendError> {
 
     // Test framework sanity check: a request without the auto_decompress flag
     // should bounce back to us unchanged.
-    let standard_echo = Request::put("http://127.0.0.1:9000")
+    let standard_echo = Request::put("http://127.0.0.1")
         .with_header("Content-Encoding", "gzip")
         .with_body_octet_stream(HELLO_WORLD_GZ)
         .send(echo_server.clone())?;
@@ -27,7 +27,7 @@ fn main() -> Result<(), SendError> {
 
     // Similarly, if we set the auto_decompress flag to false, it should also
     // bounce back to us unchanged.
-    let explicit_no = Request::put("http://127.0.0.1:9000")
+    let explicit_no = Request::put("http://127.0.0.1")
         .with_header("Content-Encoding", "gzip")
         .with_body_octet_stream(HELLO_WORLD_GZ)
         .with_auto_decompress_gzip(false)
@@ -38,7 +38,7 @@ fn main() -> Result<(), SendError> {
 
     // But if we set the auto_decompress flag to true, and send a compressed
     // file, we should get the uncompressed version back
-    let mut unpacked_echo = Request::put("http://127.0.0.1:9000")
+    let mut unpacked_echo = Request::put("http://127.0.0.1")
         .with_header("Content-Encoding", "gzip")
         .with_body_octet_stream(HELLO_WORLD_GZ)
         .with_auto_decompress_gzip(true)
@@ -51,7 +51,7 @@ fn main() -> Result<(), SendError> {
 
     // This should work when the header is "x-gzip", as well; see
     // https://httpwg.org/http-core/draft-ietf-httpbis-semantics-latest.html#gzip.coding
-    let mut xunpacked_echo = Request::put("http://127.0.0.1:9000")
+    let mut xunpacked_echo = Request::put("http://127.0.0.1")
         .with_header("Content-Encoding", "x-gzip")
         .with_body_octet_stream(HELLO_WORLD_GZ)
         .with_auto_decompress_gzip(true)
@@ -63,7 +63,7 @@ fn main() -> Result<(), SendError> {
     assert_eq!(HELLO_WORLD, &xhopefully_unpacked);
 
     // The same, but now we're going to use await.
-    let unpacked_echo_pending = Request::put("http://127.0.0.1:9000")
+    let unpacked_echo_pending = Request::put("http://127.0.0.1")
         .with_header("Content-Encoding", "gzip")
         .with_body_octet_stream(HELLO_WORLD_GZ)
         .with_auto_decompress_gzip(true)
@@ -78,7 +78,7 @@ fn main() -> Result<(), SendError> {
     // The same, but now we're going to stream the data over.
     let unpacked_stream_pending = {
         // braces to force the drop on the body
-        let (mut streaming_body, pending_req) = Request::put("http://127.0.0.1:9000")
+        let (mut streaming_body, pending_req) = Request::put("http://127.0.0.1")
             .with_header("Content-Encoding", "gzip")
             .with_auto_decompress_gzip(true)
             .send_async_streaming(echo_server.clone())?;
@@ -101,7 +101,7 @@ fn main() -> Result<(), SendError> {
 
     // That being said, if we set the flag to true and send it a text file,
     // we should just get it back unchanged.
-    let mut yes_but_uncompressed = Request::put("http://127.0.0.1:9000")
+    let mut yes_but_uncompressed = Request::put("http://127.0.0.1")
         .with_body_octet_stream(HELLO_WORLD.as_bytes())
         .with_auto_decompress_gzip(true)
         .send(echo_server.clone())?;
@@ -113,7 +113,7 @@ fn main() -> Result<(), SendError> {
     // don't actually send a gzip'd file. We should get a response, and
     // it should technically be OK, but we should get an error when we
     // try to do anything with the body.
-    let mut bad_gzip = Request::put("http://127.0.0.1:9000")
+    let mut bad_gzip = Request::put("http://127.0.0.1")
         .with_header("Content-Encoding", "gzip")
         .with_body_octet_stream(HELLO_WORLD.as_bytes())
         .with_auto_decompress_gzip(true)
@@ -127,7 +127,7 @@ fn main() -> Result<(), SendError> {
 
     // Just for fun, let's return the response to the caller, and make
     // sure things come out there, as well.
-    Request::put("http://127.0.0.1:9000")
+    Request::put("http://127.0.0.1")
         .with_header("Content-Encoding", "gzip")
         .with_body_octet_stream(HELLO_WORLD_GZ)
         .with_auto_decompress_gzip(true)


### PR DESCRIPTION
No more `TEST_LOCK`! The integration tests now take less than 5 seconds to execute on my workstation, vs 79 seconds previously.

This required two main pieces of work.

## 💽 Run the Viceroy test server on an ephemeral port 

The server spun up to run incoming requests through Wasm now is bound to an ephemeral port rather than being hardcoded to port 7878, and the test requests have their URLs modified to include the ephemeral port assigned to the test.

This change technically means the `Test::against*()` methods can no longer be used to send requests to destinations other than the Viceroy that's been spun up for this test, but that's the only way they're currently used anyway.

The main concrete change here for test authors is that you no longer specify `localhost:7878` in your test requests, you instead just provide a request path.

## 🤵 Redesign test backend servers to also use ephemeral ports 

This is a broader-reaching change in a few ways:

- Backends now _must_ have a service function defined, or test setup will panic. This was already how the integration tests behaved semantically, but this does change some of the syntax around their definitions.

- Test servers for backends are spun up once per `Test`, rather than per invocation of `Test::against*()`. The existing suite of test backends was already mostly stateless, so again not a huge impact on test authors.

- A full URL can no longer be specified for backends. Instead, a path may be provided in order to exercise the backend path prefix behavior of Viceroy.

- Tests that must know dynamically how to reach a backend server now must explicitly start the backend servers before getting a URI suitable for the purpose. This only shows up in dynamic backend tests.

## 🛍️ Grab bag

- The level of parallelism made possible by this change meant that I had to tweak the default number of instances in the Wasmtime pooling allocator down from its default of 1000. I don't expect a limit of 100 to cause anyone problems, but this also raised the possibility of switching away from the pooling allocator for most use cases. A followup issue is available at https://github.com/fastly/Viceroy/issues/255.

- The additional parallelism also caused a massive CPU bottleneck when JIT compiling the test fixture Wasm modules. The main workspace now enables opt-level 1 for debug builds, substantially improving runtime performance of the tests without heavily impacting compile speed.

- The `trap-test` was using a `#[path = "..."]` mechanism to reuse code from the integration test suite. I didn't know this was a mechanism that existed, and it was cool to learn about it. But it also was incompatible with `common` now having a child module, so I inlined the very small handful of definitions that test was reusing.

- I added a couple extra functions to support cases where a test might want to define a backend config separately from its service function, for example if starting a `Test` configuration from a `fastly.toml` file. These currently go unused because none of the existing `fastly.toml`-using tests define any backends.

- The new `TestBackends` interfaces are awfully panicky. I figure this is OK for test infrastructure, but am open to suggestions if folks feel this is unwise. I tried to at least document the various expectations, and make the panic messages relevant beyond just a line number.

- The graceful shutdown logic is no longer strictly necessary unless we write enough tests with enough backends to run out of ports. But because it seems to work fine and is a tidy way to handle things, I left it in.