### PR TITLE
fix: make is_healthy always return `Unknown` instead of an unsupported error

### DIFF
--- a/lib/src/wiggle_abi/backend_impl.rs
+++ b/lib/src/wiggle_abi/backend_impl.rs
@@ -30,10 +30,7 @@ impl FastlyBackend for Session {
     ) -> Result<super::types::BackendHealth, Error> {
         // just doing this to get a different error if the backend doesn't exist
         let _ = lookup_backend_definition(self, backend)?;
-        // health checks are not enabled in Viceroy :(
-        Err(Error::Unsupported {
-            msg: "backend healthchecking is not configured in Viceroy",
-        })
+        Ok(super::types::BackendHealth::Unknown)
     }
 
     fn is_dynamic(


### PR DESCRIPTION
This enables applications to use is_healthy during local development without it erroring, but also without it marking backends and healthy or unhealthy