### PR TITLE
⏩ none should not be defined in cache_override_tag witx

### DIFF
--- a/lib/compute-at-edge-abi/typenames.witx
+++ b/lib/compute-at-edge-abi/typenames.witx
@@ -119,10 +119,9 @@
 (typename $multi_value_cursor_result s64)
 
 ;;; An override for response caching behavior.
+;;; A zero value indicates that the origin response's cache control headers should be used.
 (typename $cache_override_tag
     (flags (@witx repr u32)
-        ;;; Do not override the behavior specified in the origin response's cache control headers.
-        $none
         ;;; Do not cache the response to this request, regardless of the origin response's headers.
         $pass
         $ttl


### PR DESCRIPTION
The ABI expects `$none` to have a value of 0, and `$pass` to have a
value of 1.  However, flags in witx start with a value of 1.  Putting
`$none` in the list erroneously defines it to have a value of 1.

Fastly's SDKs do things correctly, but tools like https://github.com/jedisct1/witx-codegen
which generate bindings from witx will generate code that is off by one
bit position.
