### PR TITLE
Add a stub for downstream_client_request_id

### DIFF
--- a/lib/compute-at-edge-abi/compute-at-edge.witx
+++ b/lib/compute-at-edge-abi/compute-at-edge.witx
@@ -107,6 +107,13 @@
         (result $err (expected $num_bytes (error $fastly_status)))
     )
 
+    (@interface func (export "downstream_client_request_id")
+        (param $reqid_out (@witx pointer (@witx char8)))
+        (param $reqid_max_len (@witx usize))
+        (param $nwritten_out (@witx pointer (@witx usize)))
+        (result $err (expected (error $fastly_status)))
+    )
+
     (@interface func (export "downstream_tls_cipher_openssl_name")
         (param $cipher_out (@witx pointer (@witx char8)))
         (param $cipher_max_len (@witx usize))

--- a/lib/src/linking.rs
+++ b/lib/src/linking.rs
@@ -152,6 +152,12 @@ fn link_legacy_aliases(linker: &mut Linker<WasmCtx>) -> Result<(), Error> {
     )?;
     linker.alias(
         req,
+        "downstream_client_request_id",
+        "env",
+        "xqd_req_downstream_client_request_id",
+    )?;
+    linker.alias(
+        req,
         "downstream_tls_cipher_openssl_name",
         "env",
         "xqd_req_downstream_tls_cipher_openssl_name",

--- a/lib/src/wiggle_abi/req_impl.rs
+++ b/lib/src/wiggle_abi/req_impl.rs
@@ -89,6 +89,16 @@ impl FastlyHttpReq for Session {
         }
     }
 
+    #[allow(unused_variables)] // FIXME FGS 2023-06-14: Remove this directive once implemented.
+    fn downstream_client_request_id(
+        &mut self,
+        reqid_out: &GuestPtr<u8>,
+        reqid_max_len: u32,
+        nwritten_out: &GuestPtr<u32>,
+    ) -> Result<(), Error> {
+        Ok(())
+    }
+
     #[allow(unused_variables)] // FIXME KTM 2020-06-25: Remove this directive once implemented.
     fn downstream_tls_cipher_openssl_name<'a>(
         &mut self,

--- a/lib/src/wiggle_abi/req_impl.rs
+++ b/lib/src/wiggle_abi/req_impl.rs
@@ -96,6 +96,7 @@ impl FastlyHttpReq for Session {
         reqid_max_len: u32,
         nwritten_out: &GuestPtr<u32>,
     ) -> Result<(), Error> {
+        nwritten_out.write(0)?;
         Ok(())
     }
 


### PR DESCRIPTION
This PR adds a stub for downstream_client_request_id to avoid crashing Viceroy.

I'm not sure if it'd be better to return something meaningful. Open to suggestions.