### PR TITLE
feat: Add a stub for downstream_client_h2_fingerprint

### DIFF
--- a/lib/compute-at-edge-abi/compute-at-edge.witx
+++ b/lib/compute-at-edge-abi/compute-at-edge.witx
@@ -107,6 +107,13 @@
         (result $err (expected $num_bytes (error $fastly_status)))
     )
 
+    (@interface func (export "downstream_client_h2_fingerprint")
+        (param $h2fp_out (@witx pointer (@witx char8)))
+        (param $h2fp_max_len (@witx usize))
+        (param $nwritten_out (@witx pointer (@witx usize)))
+        (result $err (expected (error $fastly_status)))
+    )
+
     (@interface func (export "downstream_client_request_id")
         (param $reqid_out (@witx pointer (@witx char8)))
         (param $reqid_max_len (@witx usize))

--- a/lib/src/linking.rs
+++ b/lib/src/linking.rs
@@ -152,12 +152,6 @@ fn link_legacy_aliases(linker: &mut Linker<WasmCtx>) -> Result<(), Error> {
     )?;
     linker.alias(
         req,
-        "downstream_client_h2_fingerprint",
-        "env",
-        "xqd_req_downstream_client_h2_fingerprint",
-    )?;
-    linker.alias(
-        req,
         "downstream_client_request_id",
         "env",
         "xqd_req_downstream_client_request_id",

--- a/lib/src/linking.rs
+++ b/lib/src/linking.rs
@@ -152,6 +152,12 @@ fn link_legacy_aliases(linker: &mut Linker<WasmCtx>) -> Result<(), Error> {
     )?;
     linker.alias(
         req,
+        "downstream_client_h2_fingerprint",
+        "env",
+        "xqd_req_downstream_client_h2_fingerprint",
+    )?;
+    linker.alias(
+        req,
         "downstream_client_request_id",
         "env",
         "xqd_req_downstream_client_request_id",

--- a/lib/src/wiggle_abi/req_impl.rs
+++ b/lib/src/wiggle_abi/req_impl.rs
@@ -89,6 +89,16 @@ impl FastlyHttpReq for Session {
         }
     }
 
+    #[allow(unused_variables)] // FIXME JDC 2023-06-18: Remove this directive once implemented.
+    fn downstream_client_h2_fingerprint<'a>(
+        &mut self,
+        h2fp_out: &GuestPtr<'a, u8>,
+        h2fp_max_len: u32,
+        nwritten_out: &GuestPtr<u32>,
+    ) -> Result<(), Error> {
+        Err(Error::NotAvailable("Client H2 fingerprint"))
+    }
+
     fn downstream_client_request_id(
         &mut self,
         reqid_out: &GuestPtr<u8>,


### PR DESCRIPTION
This adds a single stub for `downstream_client_h2_fingerprint` which will allow applications using this feature to be able to link in Viceroy