### PR TITLE
🎁 prepare release 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## Unreleased
+
 ## 0.6.0 (2023-07-12)
 
 - ⏱️ Add cross-platform ability to profile guest code in run mode ([#280](https://github.com/fastly/Viceroy/pull/280))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,18 @@
-## Unreleased
+## 0.6.0 (2023-07-12)
+
+- ⏱️ Add cross-platform ability to profile guest code in run mode ([#280](https://github.com/fastly/Viceroy/pull/280))
+- pin to hyper 0.14.26 for the time being ([#285](https://github.com/fastly/Viceroy/pull/285))
+- 😯 Add support for the new secret from_bytes extension. ([#283](https://github.com/fastly/Viceroy/pull/283))
+- feat: Add a stub for downstream_client_h2_fingerprint ([#277](https://github.com/fastly/Viceroy/pull/277))
+- Fill downstream_client_request_id in ([#282](https://github.com/fastly/Viceroy/pull/282))
+- Bump to wasmtime-10.0.0 ([#279](https://github.com/fastly/Viceroy/pull/279))
+- Add a stub for downstream_client_request_id ([#276](https://github.com/fastly/Viceroy/pull/276))
+-  Fix various warnings ([#271](https://github.com/fastly/Viceroy/pull/271))
+- ⛽ -> ⏲️ Switch from fuel to epoch interruptions. ([#273](https://github.com/fastly/Viceroy/pull/273))
+- Bump wasmtime dependencies to 9.0.1 ([#272](https://github.com/fastly/Viceroy/pull/272))
+- ⏩ none should not be defined in cache_override_tag witx ([#269](https://github.com/fastly/Viceroy/pull/269))
+- in single run mode, keep the response receiver alive during execution ([#270](https://github.com/fastly/Viceroy/pull/270))
+- Return appropriate exit code in run-mode, rather than just 0 or 1 ([#224](https://github.com/fastly/Viceroy/pull/224))
 
 ## 0.5.1 (2023-05-17)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2326,7 +2326,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "viceroy"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -2348,7 +2348,7 @@ dependencies = [
 
 [[package]]
 name = "viceroy-lib"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "bytes",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -39,7 +39,7 @@ tokio = { workspace = true }
 tracing = { workspace = true }
 tracing-futures = { workspace = true }
 tracing-subscriber = { version = "^0.3.16", features = ["env-filter", "fmt"] }
-viceroy-lib = { path = "../lib", version = "0.6.0" }
+viceroy-lib = { path = "../lib", version = "^0.6.0" }
 wat = "^1.0.38"
 wasi-common = { workspace = true }
 wasmtime = { workspace = true }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "viceroy"
 description = "Viceroy is a local testing daemon for Compute@Edge."
-version = "0.6.0"
+version = "0.6.1"
 authors = ["Fastly"]
 readme = "../README.md"
 edition = "2021"
@@ -39,7 +39,7 @@ tokio = { workspace = true }
 tracing = { workspace = true }
 tracing-futures = { workspace = true }
 tracing-subscriber = { version = "^0.3.16", features = ["env-filter", "fmt"] }
-viceroy-lib = { path = "../lib", version = "^0.6.0" }
+viceroy-lib = { path = "../lib", version = "^0.6.1" }
 wat = "^1.0.38"
 wasi-common = { workspace = true }
 wasmtime = { workspace = true }

--- a/cli/tests/trap-test/Cargo.lock
+++ b/cli/tests/trap-test/Cargo.lock
@@ -2265,7 +2265,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "viceroy-lib"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "bytes",

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "viceroy-lib"
-version = "0.6.0"
+version = "0.6.1"
 description = "Viceroy implementation details."
 authors = ["Fastly"]
 edition = "2021"


### PR DESCRIPTION
Note: I've bumped from 0.5.1 to 0.6.0 due to upgrading wasmtime to a new major version (10.0.0)

Cutting a new release, this currently contains steps 1 through to 5 of [Releasing Viceroy](https://github.com/fastly/Viceroy/blob/main/doc/RELEASING.md#releasing-viceroy).


> Below are the steps needed to do a Viceroy release:
> 
> 1. Make sure the Viceroy version has been bumped up to the current release
>    version. You might need to bump the minor version (e.g. 0.2.0 to 0.3.0) if
>    there are any semver breaking changes. Review the changes since the last
>    release just to be sure.
> 1. Update the `Cargo.lock` files by running `make generate-lockfile`.
> 1. Update `CHANGELOG.md` so that it contains all of the updates since the
>    previous version as its own commit.
> 1. Create a local branch in the form `release-x.y.z` where `x`, `y`, and `z` are
>    the major, minor, and patch versions of Viceroy and have the tip of the
>    branch contain the Changelog commit.
> 1. Run `make ci` locally to make sure that everything will pass before pushing
>    the branch and opening up a PR.
> 1. After you get approval, run `git tag vx.y.z HEAD && git push origin --tags`.
>    Pushing this tag will kick off a build for all of the release artifacts.
> 1. After CI completes, we should publish each crate in the workspace to the
>    crates.io registry. Note that we must do this in order of dependencies. So,
>   1. `(cd lib && cargo publish)`
>   1. `(cd cli && cargo publish)`
> 1. Now, we should return to our release PR.
>   1. Update the version fields in `lib/Cargo.toml` and `cli/Cargo.toml` to the
>      next patch version (so `z + 1`).
>   1. Update the dependency on `viceroy-lib` in `cli/Cargo.toml` to the next
>      patch version.
>   1. Update all the lockfiles by running `make generate-lockfile`.
>   1. Restore the `## Unreleased` header at the top of `CHANGELOG.md`.
> 1. Get another approval and merge when CI passes.
> 