### PR TITLE
Change default port from 7878 to 7676, which is what the Fastly CLI defaults to

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ built by `fastly compute build`. The Fastly CLI should put the blob at
 viceroy bin/main.wasm
 ```
 
-This will start a local server (by default at: `http://127.0.0.1:7878`), which can
+This will start a local server (by default at: `http://127.0.0.1:7676`), which can
 be used to make requests to your Compute@Edge service locally. You can make requests
 by using [curl](https://curl.se/), or you can send a simple GET request by visiting
 the URL in your web browser.

--- a/cli/src/opts.rs
+++ b/cli/src/opts.rs
@@ -97,7 +97,7 @@ impl ServeArgs {
     /// The address that the service should be bound to.
     pub fn addr(&self) -> SocketAddr {
         self.socket_addr
-            .unwrap_or_else(|| SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 7878))
+            .unwrap_or_else(|| SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 7676))
     }
 
     /// Verbosity of logs for Viceroy. `-v` sets the log level to DEBUG and
@@ -256,7 +256,7 @@ mod opts_tests {
         let empty_args = &["dummy-program-name", &test_file("minimal.wat")];
         let opts = Opts::try_parse_from(empty_args)?;
         let cmd = opts.command.unwrap_or(Commands::Serve(opts.serve));
-        let expected = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 7878);
+        let expected = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 7676);
         if let Commands::Serve(serve_args) = cmd {
             assert_eq!(serve_args.addr(), expected);
         }
@@ -269,7 +269,7 @@ mod opts_tests {
         let args_with_bad_addr = &[
             "dummy-program-name",
             "--addr",
-            "999.0.0.1:7878",
+            "999.0.0.1:7676",
             &test_file("minimal.wat"),
         ];
         match Opts::try_parse_from(args_with_bad_addr) {
@@ -290,13 +290,13 @@ mod opts_tests {
         let args_with_ipv6_addr = &[
             "dummy-program-name",
             "--addr",
-            "[::1]:7878",
+            "[::1]:7676",
             &test_file("minimal.wat"),
         ];
         let opts = Opts::try_parse_from(args_with_ipv6_addr)?;
         let cmd = opts.command.unwrap_or(Commands::Serve(opts.serve));
         let addr_v6 = IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1));
-        let expected = SocketAddr::new(addr_v6, 7878);
+        let expected = SocketAddr::new(addr_v6, 7676);
         if let Commands::Serve(serve_args) = cmd {
             assert_eq!(serve_args.addr(), expected);
         }

--- a/cli/tests/trap-test/src/main.rs
+++ b/cli/tests/trap-test/src/main.rs
@@ -17,7 +17,7 @@ pub type TestResult = Result<(), Error>;
 async fn fatal_error_traps() -> TestResult {
     let module_path = format!("{RUST_FIXTURE_PATH}/response.wasm");
     let ctx = ExecuteCtx::new(module_path, ProfilingStrategy::None, HashSet::new())?;
-    let req = Request::get("http://127.0.0.1:7878/").body(Body::from(""))?;
+    let req = Request::get("http://127.0.0.1:7676/").body(Body::from(""))?;
     let resp = ctx
         .handle_request_with_runtime_error(req, "127.0.0.1".parse().unwrap())
         .await?;

--- a/lib/src/config/unit_tests.rs
+++ b/lib/src/config/unit_tests.rs
@@ -69,10 +69,10 @@ fn fastly_toml_files_with_simple_backend_configurations_can_be_read() {
             [local_server]
               [local_server.backends]
                 [local_server.backends.dog]
-                url = "http://localhost:7878/dog-mocks"
+                url = "http://localhost:7676/dog-mocks"
 
                 [local_server.backends."shark.server"]
-                url = "http://localhost:7878/shark-mocks"
+                url = "http://localhost:7676/shark-mocks"
                 override_host = "somehost.com"
 
                 [local_server.backends.detective]
@@ -85,14 +85,14 @@ fn fastly_toml_files_with_simple_backend_configurations_can_be_read() {
         .backends()
         .get("dog")
         .expect("backend configurations can be accessed");
-    assert_eq!(backend.uri, "http://localhost:7878/dog-mocks");
+    assert_eq!(backend.uri, "http://localhost:7676/dog-mocks");
     assert_eq!(backend.override_host, None);
 
     let backend = config
         .backends()
         .get("shark.server")
         .expect("backend configurations can be accessed");
-    assert_eq!(backend.uri, "http://localhost:7878/shark-mocks");
+    assert_eq!(backend.uri, "http://localhost:7676/shark-mocks");
     assert_eq!(
         backend.override_host,
         Some("somehost.com".parse().expect("can parse override_host"))
@@ -191,7 +191,7 @@ fn local_server_configs_can_be_deserialized() {
         r#"
         [backends]
           [backends.dog]
-          url = "http://localhost:7878/dog-mocks"
+          url = "http://localhost:7676/dog-mocks"
         [dictionaries]
           [dictionaries.secrets]
           file = '{}'


### PR DESCRIPTION
I think this would be viewed as a breaking change as we are changing the default behaviour of the CLI.
If that is the case, then this involves bumping from 0.6.0 to 0.7.0 when it comes to releasing this

Resolves https://github.com/fastly/Viceroy/issues/47