### PR TITLE
switch default log level to "error", add -v to run

### DIFF
--- a/cli/src/opts.rs
+++ b/cli/src/opts.rs
@@ -46,12 +46,6 @@ pub struct ServeArgs {
     #[arg(long = "addr")]
     socket_addr: Option<SocketAddr>,
 
-    /// Verbosity of logs for Viceroy. `-v` sets the log level to DEBUG and
-    /// `-vv` to TRACE. This option will not take effect if you set RUST_LOG
-    /// to a value before starting Viceroy
-    #[arg(short = 'v', action = clap::ArgAction::Count)]
-    verbosity: u8,
-
     #[command(flatten)]
     shared: SharedArgs,
 }
@@ -91,6 +85,11 @@ pub struct SharedArgs {
     /// Set of experimental WASI modules to link against.
     #[arg(value_enum, long = "experimental_modules", required = false)]
     experimental_modules: Vec<ExperimentalModuleArg>,
+    /// Verbosity of logs for Viceroy. `-v` sets the log level to DEBUG and
+    /// `-vv` to TRACE. This option will not take effect if you set RUST_LOG
+    /// to a value before starting Viceroy
+    #[arg(short = 'v', action = clap::ArgAction::Count)]
+    verbosity: u8,
 }
 
 impl ServeArgs {
@@ -98,13 +97,6 @@ impl ServeArgs {
     pub fn addr(&self) -> SocketAddr {
         self.socket_addr
             .unwrap_or_else(|| SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 7676))
-    }
-
-    /// Verbosity of logs for Viceroy. `-v` sets the log level to DEBUG and
-    /// `-vv` to TRACE. This option will not take effect if you set RUST_LOG
-    /// to a value before starting Viceroy
-    pub fn verbosity(&self) -> u8 {
-        self.verbosity
     }
 
     pub fn shared(&self) -> &SharedArgs {
@@ -157,6 +149,13 @@ impl SharedArgs {
     // Set of experimental wasi modules to link against.
     pub fn wasi_modules(&self) -> HashSet<ExperimentalModule> {
         self.experimental_modules.iter().map(|x| x.into()).collect()
+    }
+
+    /// Verbosity of logs for Viceroy. `-v` sets the log level to DEBUG and
+    /// `-vv` to TRACE. This option will not take effect if you set RUST_LOG
+    /// to a value before starting Viceroy
+    pub fn verbosity(&self) -> u8 {
+        self.verbosity
     }
 }
 

--- a/cli/src/opts.rs
+++ b/cli/src/opts.rs
@@ -85,9 +85,9 @@ pub struct SharedArgs {
     /// Set of experimental WASI modules to link against.
     #[arg(value_enum, long = "experimental_modules", required = false)]
     experimental_modules: Vec<ExperimentalModuleArg>,
-    /// Verbosity of logs for Viceroy. `-v` sets the log level to DEBUG and
-    /// `-vv` to TRACE. This option will not take effect if you set RUST_LOG
-    /// to a value before starting Viceroy
+    /// Verbosity of logs for Viceroy. `-v` sets the log level to INFO,
+    /// `-vv` to DEBUG, and `-vvv` to TRACE. This option will not take
+    /// effect if you set RUST_LOG to a value before starting Viceroy
     #[arg(short = 'v', action = clap::ArgAction::Count)]
     verbosity: u8,
 }


### PR DESCRIPTION
The previous default log level was "off", which meant that errors
encountered during startup with `viceroy run` were not printed and the
process silently failed.  For example, this might happen if you had an
invalid path in your `fastly.toml` file.

In addition, there was no way to turn on verbose log output with
`viceroy run`, only in serve mode.

This commit moves the default log level to "error", and moves the `-v`
flag into the common set.

Making "error" the default meant that processes that called `proc_exit`
would print WASM stacktraces as errors on exit, but this isn't really an
error from the user's perspective, so we check for that (`I32Exit`) and
suppress the error message in that case only.
