### PR TITLE
Support the new config store hostcalls.

### DIFF
--- a/lib/compute-at-edge-abi/compute-at-edge.witx
+++ b/lib/compute-at-edge-abi/compute-at-edge.witx
@@ -1,5 +1,6 @@
 (use "typenames.witx")
 (use "cache.witx")
+(use "config-store.witx")
 
 (module $fastly_abi
     (@interface func (export "init")

--- a/lib/compute-at-edge-abi/config-store.witx
+++ b/lib/compute-at-edge-abi/config-store.witx
@@ -1,0 +1,19 @@
+;; Config Store ABI
+
+;;; A handle to an Config Store.
+(typename $config_store_handle (handle))
+
+(module $fastly_config_store
+    (@interface func (export "open")
+        (param $name string)
+        (result $err (expected $config_store_handle (error $fastly_status)))
+    )
+
+    (@interface func (export "get")
+        (param $h $config_store_handle)
+        (param $key string)
+        (param $value (@witx pointer (@witx char8)))
+        (param $value_max_len (@witx usize))
+        (result $err (expected $num_bytes (error $fastly_status)))
+    )
+)

--- a/lib/src/linking.rs
+++ b/lib/src/linking.rs
@@ -112,6 +112,7 @@ pub fn link_host_functions(
     wasmtime_wasi::add_to_linker(linker, WasmCtx::wasi)?;
     wiggle_abi::fastly_abi::add_to_linker(linker, WasmCtx::session)?;
     wiggle_abi::fastly_cache::add_to_linker(linker, WasmCtx::session)?;
+    wiggle_abi::fastly_config_store::add_to_linker(linker, WasmCtx::session)?;
     wiggle_abi::fastly_dictionary::add_to_linker(linker, WasmCtx::session)?;
     wiggle_abi::fastly_geo::add_to_linker(linker, WasmCtx::session)?;
     wiggle_abi::fastly_http_body::add_to_linker(linker, WasmCtx::session)?;

--- a/lib/src/wiggle_abi.rs
+++ b/lib/src/wiggle_abi.rs
@@ -51,6 +51,7 @@ macro_rules! multi_value_result {
 mod backend_impl;
 mod body_impl;
 mod cache;
+mod config_store;
 mod dictionary_impl;
 mod entity;
 mod fastly_purge_impl;

--- a/lib/src/wiggle_abi/config_store.rs
+++ b/lib/src/wiggle_abi/config_store.rs
@@ -1,0 +1,24 @@
+use super::{
+    fastly_config_store::FastlyConfigStore,
+    types::{ConfigStoreHandle, DictionaryHandle},
+};
+use crate::{session::Session, wiggle_abi::fastly_dictionary::FastlyDictionary, Error};
+use wiggle::GuestPtr;
+
+impl FastlyConfigStore for Session {
+    fn open(&mut self, name: &GuestPtr<str>) -> Result<ConfigStoreHandle, Error> {
+        let dict_answer = <Self as FastlyDictionary>::open(self, name)?;
+        Ok(ConfigStoreHandle::from(unsafe { dict_answer.inner() }))
+    }
+
+    fn get(
+        &mut self,
+        config_store: ConfigStoreHandle,
+        key: &GuestPtr<str>,
+        buf: &GuestPtr<u8>,
+        buf_len: u32,
+    ) -> Result<u32, Error> {
+        let dict_handle = DictionaryHandle::from(unsafe { config_store.inner() });
+        <Self as FastlyDictionary>::get(self, dict_handle, key, buf, buf_len)
+    }
+}


### PR DESCRIPTION
These work by naively just forwarding the new hostcalls into the underlying dictionary system; these pass the tests, but I'd love someone to confirm (preferably someone named @acfoltzer) that this is intended behavior.