### PR TITLE
🏞 Use an environment variable to muck with the root certs in tests

### DIFF
--- a/cli/tests/integration/client_certs.rs
+++ b/cli/tests/integration/client_certs.rs
@@ -130,6 +130,10 @@ fn build_server_tls_config() -> ServerConfig {
 #[tokio::test(flavor = "multi_thread")]
 async fn client_certs_work() -> TestResult {
     // Set up the test harness
+    std::env::set_var(
+        "SSL_CERT_FILE",
+        concat!(env!("CARGO_MANIFEST_DIR"), "/../test-fixtures/data/ca.pem"),
+    );
     let test = Test::using_fixture("mutual-tls.wasm");
     let server_addr: SocketAddr = "127.0.0.1:0".parse().expect("localhost parses");
     let incoming = AddrIncoming::bind(&server_addr).expect("bind");

--- a/lib/src/upstream.rs
+++ b/lib/src/upstream.rs
@@ -56,21 +56,6 @@ impl TlsConfig {
             warn!("no CA certificates available");
         }
 
-        static TEST_CA_PEM: &[u8] = include_bytes!(concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/../test-fixtures/data/ca.pem"
-        ));
-        let mut test_ca_cursor = std::io::Cursor::new(TEST_CA_PEM);
-        // we're OK with all of the rest of this failing, because it could just be an odd build
-        // and this is only used in testing. obviously, if this doesn't work during a testing
-        // run, then the test will fail (with an invalid peer certificate), so we're covered on
-        // that side.
-        if let Ok(certs) = rustls_pemfile::certs(&mut test_ca_cursor) {
-            for cert in certs {
-                let _ = roots.add(&rustls::Certificate(cert));
-            }
-        }
-
         let partial_config = rustls::ClientConfig::builder()
             .with_safe_defaults()
             .with_root_certificates(roots);


### PR DESCRIPTION
Thanks to @acfoltzer for this idea.

A lagging problem with #297 was that it required baking in a certificate, which worked fine in normal testing but broke when trying to build or validate packages. Rather than fighting getting the inclusion to work, @acfoltzer pointed out that `rustls_native_certs`'s default source for certificates can be overridden by an environment variable. So this PR deletes the old baked-in approach, and instead has the client certificate test set the environment variable before starting.