### PR TITLE
Lower Hostcall error log level to DEBUG

### DIFF
--- a/lib/src/wiggle_abi.rs
+++ b/lib/src/wiggle_abi.rs
@@ -158,6 +158,9 @@ impl UserErrorConversion for Session {
                     event!(Level::DEBUG, "Hostcall yielded an error: {}", err);
                 }
             },
+            Error::BufferLengthError { .. } => {
+                event!(Level::DEBUG, "Hostcall yielded an error: {}", e)
+            }
             _ => event!(Level::ERROR, "Hostcall yielded an error: {}", e),
         }
 

--- a/lib/src/wiggle_abi.rs
+++ b/lib/src/wiggle_abi.rs
@@ -158,10 +158,7 @@ impl UserErrorConversion for Session {
                     event!(Level::DEBUG, "Hostcall yielded an error: {}", err);
                 }
             },
-            Error::BufferLengthError { .. } => {
-                event!(Level::DEBUG, "Hostcall yielded an error: {}", e)
-            }
-            _ => event!(Level::ERROR, "Hostcall yielded an error: {}", e),
+            _ => event!(Level::DEBUG, "Hostcall yielded an error: {}", e),
         }
 
         match e {


### PR DESCRIPTION
The Fastly CLI executes Viceroy with a [`-v`](https://github.com/fastly/cli/blob/24761dcccd81d16e3873c1fa65e03fd83486442f/pkg/commands/compute/serve.go#L534) argument, which corresponds to `INFO` log level. This change drops the log level of hostcall errors to `DEBUG`, so that they're not displayed to users running apps via `fastly compute serve`.

As an example, `BufferLengthError` is a sentinel error used to indicate to the caller that the passed in buffer was [too small](https://github.com/fastly/Viceroy/blob/f62eb94c470f39df1d25cba3ffb028a3289bbf15/lib/src/wiggle_abi/secret_store_impl.rs#L110-L113). The caller can then try again with an appropriately sized buffer.