### PR TITLE
Revamp profile handling CLI flags

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -13,6 +13,7 @@
 #![cfg_attr(not(debug_assertions), doc(test(attr(allow(dead_code)))))]
 #![cfg_attr(not(debug_assertions), doc(test(attr(allow(unused_variables)))))]
 
+use std::path::PathBuf;
 use std::process::ExitCode;
 
 use wasi_common::I32Exit;
@@ -233,7 +234,7 @@ impl<'a> MakeWriter<'a> for StdWriter {
 async fn create_execution_context(
     args: &SharedArgs,
     check_backends: bool,
-    guest_profile_path: Option<String>,
+    guest_profile_path: Option<PathBuf>,
 ) -> Result<ExecuteCtx, anyhow::Error> {
     let input = args.input();
     let mut ctx = ExecuteCtx::new(

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -13,7 +13,6 @@
 #![cfg_attr(not(debug_assertions), doc(test(attr(allow(dead_code)))))]
 #![cfg_attr(not(debug_assertions), doc(test(attr(allow(unused_variables)))))]
 
-use std::path::PathBuf;
 use std::process::ExitCode;
 
 use wasi_common::I32Exit;
@@ -40,12 +39,8 @@ use {
 /// Create a new server, bind it to an address, and serve responses until an error occurs.
 pub async fn serve(serve_args: ServeArgs) -> Result<(), Error> {
     // Load the wasm module into an execution context
-    let ctx = create_execution_context(
-        serve_args.shared(),
-        true,
-        serve_args.profile_guest().cloned(),
-    )
-    .await?;
+    let ctx =
+        create_execution_context(serve_args.shared(), true, serve_args.profile_guest()).await?;
 
     if let Some(guest_profile_path) = serve_args.profile_guest() {
         std::fs::create_dir_all(guest_profile_path)?;
@@ -103,8 +98,7 @@ pub async fn main() -> ExitCode {
 /// Execute a Wasm program in the Viceroy environment.
 pub async fn run_wasm_main(run_args: RunArgs) -> Result<(), anyhow::Error> {
     // Load the wasm module into an execution context
-    let ctx = create_execution_context(run_args.shared(), false, run_args.profile_guest().cloned())
-        .await?;
+    let ctx = create_execution_context(run_args.shared(), false, run_args.profile_guest()).await?;
     let input = run_args.shared().input();
     let program_name = match input.file_stem() {
         Some(stem) => stem.to_string_lossy(),
@@ -239,7 +233,7 @@ impl<'a> MakeWriter<'a> for StdWriter {
 async fn create_execution_context(
     args: &SharedArgs,
     check_backends: bool,
-    guest_profile_path: Option<PathBuf>,
+    guest_profile_path: Option<String>,
 ) -> Result<ExecuteCtx, anyhow::Error> {
     let input = args.input();
     let mut ctx = ExecuteCtx::new(

--- a/cli/src/opts.rs
+++ b/cli/src/opts.rs
@@ -87,8 +87,8 @@ pub struct SharedArgs {
     #[arg(long = "log-stderr", default_value = "false")]
     log_stderr: bool,
     /// Whether to enable wasmtime's builtin profiler.
-    #[arg(long = "profiler", value_parser = check_wasmtime_profiler_mode)]
-    profiler: Option<ProfilingStrategy>,
+    #[arg(long = "profile", value_parser = check_wasmtime_profiler_mode)]
+    profile: Option<ProfilingStrategy>,
     /// Set of experimental WASI modules to link against.
     #[arg(value_enum, long = "experimental_modules", required = false)]
     experimental_modules: Vec<ExperimentalModuleArg>,
@@ -161,7 +161,7 @@ impl SharedArgs {
 
     /// Whether to enable wasmtime's builtin profiler.
     pub fn profiling_strategy(&self) -> ProfilingStrategy {
-        self.profiler.unwrap_or(ProfilingStrategy::None)
+        self.profile.unwrap_or(ProfilingStrategy::None)
     }
 
     /// Set of experimental wasi modules to link against.
@@ -383,7 +383,7 @@ mod opts_tests {
     fn wasmtime_profiling_strategy_jitdump_is_accepted() -> TestResult {
         let args = &[
             "dummy-program-name",
-            "--profiler",
+            "--profile",
             "jitdump",
             &test_file("minimal.wat"),
         ];
@@ -398,7 +398,7 @@ mod opts_tests {
     fn wasmtime_profiling_strategy_vtune_is_accepted() -> TestResult {
         let args = &[
             "dummy-program-name",
-            "--profiler",
+            "--profile",
             "vtune",
             &test_file("minimal.wat"),
         ];
@@ -413,7 +413,7 @@ mod opts_tests {
     fn wasmtime_profiling_strategy_perfmap_is_accepted() -> TestResult {
         let args = &[
             "dummy-program-name",
-            "--profiler",
+            "--profile",
             "perfmap",
             &test_file("minimal.wat"),
         ];
@@ -428,7 +428,7 @@ mod opts_tests {
     fn invalid_wasmtime_profiling_strategy_is_rejected() -> TestResult {
         let args = &[
             "dummy-program-name",
-            "--profiler",
+            "--profile",
             "invalid_profiling_strategy",
             &test_file("minimal.wat"),
         ];

--- a/cli/src/opts.rs
+++ b/cli/src/opts.rs
@@ -124,9 +124,13 @@ impl ServeArgs {
     }
 
     /// The path to write guest profiles to
-    pub fn profile_guest(&self) -> Option<String> {
+    pub fn profile_guest(&self) -> Option<PathBuf> {
         if let Some(Profile::Guest { path }) = &self.shared.profile {
-            Some(path.clone().unwrap_or_else(|| "guest-profiles".to_string()))
+            Some(
+                path.clone()
+                    .unwrap_or_else(|| "guest-profiles".to_string())
+                    .into(),
+            )
         } else {
             None
         }
@@ -148,11 +152,12 @@ impl RunArgs {
     }
 
     /// The path to write a guest profile to
-    pub fn profile_guest(&self) -> Option<String> {
+    pub fn profile_guest(&self) -> Option<PathBuf> {
         if let Some(Profile::Guest { path }) = &self.shared.profile {
             Some(
                 path.clone()
-                    .unwrap_or_else(|| "guest-profile.json".to_string()),
+                    .unwrap_or_else(|| "guest-profile.json".to_string())
+                    .into(),
             )
         } else {
             None

--- a/lib/src/execute.rs
+++ b/lib/src/execute.rs
@@ -84,7 +84,7 @@ impl ExecuteCtx {
         module_path: impl AsRef<Path>,
         profiling_strategy: ProfilingStrategy,
         wasi_modules: HashSet<ExperimentalModule>,
-        guest_profile_path: Option<String>,
+        guest_profile_path: Option<PathBuf>,
         unknown_import_behavior: UnknownImportBehavior,
     ) -> Result<Self, Error> {
         let config = &configure_wasmtime(profiling_strategy);
@@ -112,7 +112,6 @@ impl ExecuteCtx {
                 engine_clone.increment_epoch();
             }
         })));
-        let guest_profile_path = guest_profile_path.map(PathBuf::from);
 
         Ok(Self {
             engine,

--- a/lib/src/execute.rs
+++ b/lib/src/execute.rs
@@ -84,7 +84,7 @@ impl ExecuteCtx {
         module_path: impl AsRef<Path>,
         profiling_strategy: ProfilingStrategy,
         wasi_modules: HashSet<ExperimentalModule>,
-        guest_profile_path: Option<PathBuf>,
+        guest_profile_path: Option<String>,
         unknown_import_behavior: UnknownImportBehavior,
     ) -> Result<Self, Error> {
         let config = &configure_wasmtime(profiling_strategy);
@@ -112,6 +112,7 @@ impl ExecuteCtx {
                 engine_clone.increment_epoch();
             }
         })));
+        let guest_profile_path = guest_profile_path.map(PathBuf::from);
 
         Ok(Self {
             engine,


### PR DESCRIPTION
This PR moves profiling to `--profile`, and replaces `--profile-guest=[path]` in favour of `--profile=guest[,path]`, unifying the profiling options (and matching Wasmtime). Most of the code is adapted from Wasmtime.

While here I've removed some unncessary lifetimes and polished the code, mostly courtesy of clippy (the 2 last commits).

The PR is related to and was built on top of https://github.com/fastly/Viceroy/pull/316. It might make sense to review that one first.