### PR TITLE
Match the number of memories to the number of core instances

### DIFF
--- a/lib/src/execute.rs
+++ b/lib/src/execute.rs
@@ -520,7 +520,7 @@ fn configure_wasmtime(profiling_strategy: ProfilingStrategy) -> wasmtime::Config
     pooling_allocation_config.max_core_instance_size(MB);
 
     // Core wasm programs have 1 memory
-    pooling_allocation_config.total_memories(1);
+    pooling_allocation_config.total_memories(100);
     pooling_allocation_config.max_memories_per_module(1);
 
     // allow for up to 128MiB of linear memory. Wasm pages are 64k


### PR DESCRIPTION
Fix a bug introduced with the upgrade to wasmtime-13.0.0 where the maximum number of memories was set to `1`. This should have matched the number of core instances we allow, as we permit one memory per core instance.

Fixes #321 