### PR TITLE
🎁 prepare release 0.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
-## Unreleased
+## 0.9.1 (2023-10-09)
+
+- Match the number of memories to the number of core instances ([#322](https://github.com/fastly/Viceroy/pull/322))
 
 ## 0.9.0 (2023-10-09)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,9 +30,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea5d730647d4fadd988536d06fecce94b7b4f2a7efdae548f1cf4b63205518ab"
+checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
 dependencies = [
  "memchr",
 ]
@@ -1614,9 +1614,9 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustix"
-version = "0.38.17"
+version = "0.38.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f25469e9ae0f3d0047ca8b93fc56843f38e6774f0914a107ff8b41be8be8e0b7"
+checksum = "5a74ee2d7c2581cd139b42447d7d9389b889bdaad3a73f1ebb16f2a3237bb19c"
 dependencies = [
  "bitflags 2.4.0",
  "errno",

--- a/cli/tests/trap-test/Cargo.lock
+++ b/cli/tests/trap-test/Cargo.lock
@@ -30,9 +30,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea5d730647d4fadd988536d06fecce94b7b4f2a7efdae548f1cf4b63205518ab"
+checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
 dependencies = [
  "memchr",
 ]
@@ -1660,9 +1660,9 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustix"
-version = "0.38.17"
+version = "0.38.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f25469e9ae0f3d0047ca8b93fc56843f38e6774f0914a107ff8b41be8be8e0b7"
+checksum = "5a74ee2d7c2581cd139b42447d7d9389b889bdaad3a73f1ebb16f2a3237bb19c"
 dependencies = [
  "bitflags 2.4.0",
  "errno",


### PR DESCRIPTION
Cutting a new release, this currently contains steps 1 through to 5 of [Releasing Viceroy](https://github.com/fastly/Viceroy/blob/main/doc/RELEASING.md#releasing-viceroy).


> Below are the steps needed to do a Viceroy release:
> 
> 1. Make sure the Viceroy version has been bumped up to the current release
>    version. You might need to bump the minor version (e.g. 0.2.0 to 0.3.0) if
>    there are any semver breaking changes. Review the changes since the last
>    release just to be sure.
> 1. Update the `Cargo.lock` files by running `make generate-lockfile`.
> 1. Update `CHANGELOG.md` so that it contains all of the updates since the
>    previous version as its own commit.
> 1. Create a local branch in the form `release-x.y.z` where `x`, `y`, and `z` are
>    the major, minor, and patch versions of Viceroy and have the tip of the
>    branch contain the Changelog commit.
> 1. Run `make ci` locally to make sure that everything will pass before pushing
>    the branch and opening up a PR.
> 1. After you get approval, run `git tag vx.y.z HEAD && git push origin --tags`.
>    Pushing this tag will kick off a build for all of the release artifacts.
> 1. After CI completes, we should publish each crate in the workspace to the
>    crates.io registry. Note that we must do this in order of dependencies. So,
>   1. `(cd lib && cargo publish)`
>   1. `(cd cli && cargo publish)`
> 1. Now, we should return to our release PR.
>   1. Update the version fields in `lib/Cargo.toml` and `cli/Cargo.toml` to the
>      next patch version (so `z + 1`).
>   1. Update the dependency on `viceroy-lib` in `cli/Cargo.toml` to the next
>      patch version.
>   1. Update all the lockfiles by running `make generate-lockfile`.
>   1. Restore the `## Unreleased` header at the top of `CHANGELOG.md`.
> 1. Get another approval and merge when CI passes.
> 