### PR TITLE
Finish release process for 0.9.1 by bumping to next patch and updating lockfiles and changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## Unreleased
+
 ## 0.9.1 (2023-10-09)
 
 - Match the number of memories to the number of core instances ([#322](https://github.com/fastly/Viceroy/pull/322))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2241,7 +2241,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "viceroy"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "base64",
@@ -2268,7 +2268,7 @@ dependencies = [
 
 [[package]]
 name = "viceroy-lib"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "bytes",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "viceroy"
 description = "Viceroy is a local testing daemon for Compute@Edge."
-version = "0.9.1"
+version = "0.9.2"
 authors = ["Fastly"]
 readme = "../README.md"
 edition = "2021"
@@ -44,7 +44,7 @@ tokio-rustls = { workspace = true }
 tracing = { workspace = true }
 tracing-futures = { workspace = true }
 tracing-subscriber = { version = "^0.3.16", features = ["env-filter", "fmt"] }
-viceroy-lib = { path = "../lib", version = "^0.9.1" }
+viceroy-lib = { path = "../lib", version = "^0.9.2" }
 wat = "^1.0.38"
 wasi-common = { workspace = true }
 wasmtime = { workspace = true }

--- a/cli/tests/trap-test/Cargo.lock
+++ b/cli/tests/trap-test/Cargo.lock
@@ -2287,7 +2287,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "viceroy-lib"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "bytes",

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "viceroy-lib"
-version = "0.9.1"
+version = "0.9.2"
 description = "Viceroy implementation details."
 authors = ["Fastly"]
 edition = "2021"


### PR DESCRIPTION
https://github.com/fastly/Viceroy/pull/323 was merged before the second half of the release process was completed - this pull request contains that second half of the process