### PR TITLE
Warn instead of fail when certificates can't be loaded

### DIFF
--- a/lib/src/upstream.rs
+++ b/lib/src/upstream.rs
@@ -47,7 +47,9 @@ impl TlsConfig {
         match rustls_native_certs::load_native_certs() {
             Ok(certs) => {
                 for cert in certs {
-                    roots.add(&rustls::Certificate(cert.0)).unwrap();
+                    if let Err(e) = roots.add(&rustls::Certificate(cert.0)) {
+                        warn!("failed to load certificate: {e}");
+                    }
                 }
             }
             Err(err) => return Err(Error::BadCerts(err)),


### PR DESCRIPTION
A user running Viceroy on Windows hit this `unwrap()` call when trying out the rust compute starter kit:

```
c:\dev\source\fastly-from-scratch>fastly compute serve
✓ Verifying fastly.toml
✓ Identifying package name
✓ Identifying toolchain
✓ Running [scripts.build]
✓ Creating package archive

SUCCESS: Built package (pkg\fastly-from-scratch.tar.gz)

✓ Running local server

INFO: Listening on http://127.0.0.1:7676/

INFO: Command output:
--------------------------------------------------------------------------------
thread 'main' panicked at lib\src\upstream.rs:50:61:
called `Result::unwrap()` on an `Err` value: InvalidCertificate(BadEncoding)
stack backtrace:
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
--------------------------------------------------------------------------------

ERROR: error during execution process (see 'command output' above): exit status 101.

If you believe this error is the result of a bug, please file an issue: https://github.com/fastly/cli/issues/new?labels=bug&template=bug_report.md
```

It seems that their system has a locally-installed certificate that rustls doesn't like. Viceroy should probably just warn in these cases and continue loading certificates, since it's only a problem if that specific cert ends up being needed to talk to an origin.