### PR TITLE
Enable to use the edition 2021 resolver whole the workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
     "cli",
     "lib",
 ]
+resolver = "2"
 
 # Exclude our integration test fixtures, which need to be compiled to wasm
 # (managed by the Makefile)


### PR DESCRIPTION
This fixes the warning shown on running `cargo build` at first.

> warning: virtual workspace defaulting to `resolver = "1"` despite one or more workspace members being on edition 2021 which implies `resolver = "2"`
> note: to keep the current resolver, specify `workspace.resolver = "1"` in the workspace root's manifest
> note: to use the edition 2021 resolver, specify `workspace.resolver = "2"` in the workspace root's manifest
> note: for more details see https://doc.rust-lang.org/cargo/reference/resolver.html#resolver-versions

[lib/Cargo.toml](https://github.com/fastly/Viceroy/blob/fe29d2e5354681d750f93897074b356757a11328/lib/Cargo.toml#L6) uses rust edition 2021 for a long time.

So I think `resolver = "2"` is nice to suppress this warning.



