### PR TITLE
Add stubbed-out values for remaining `FASTLY_` environment variables.

### DIFF
--- a/lib/src/linking.rs
+++ b/lib/src/linking.rs
@@ -115,10 +115,17 @@ pub(crate) fn create_store(
 fn make_wasi_ctx(ctx: &ExecuteCtx, session: &Session) -> Result<WasiCtx, anyhow::Error> {
     let mut wasi_ctx = WasiCtxBuilder::new();
 
-    // Viceroy provides a subset of the `FASTLY_*` environment variables that the production
+    // Viceroy provides the same `FASTLY_*` environment variables that the production
     // Compute platform provides:
 
     wasi_ctx
+        // These variables are stubbed out for compatibility
+        .env("FASTLY_CACHE_GENERATION", "0")?
+        .env("FASTLY_CUSTOMER_ID", "0000000000000000000000")?
+        .env("FASTLY_POP", "XXX")?
+        .env("FASTLY_REGION", "Somewhere")?
+        .env("FASTLY_SERVICE_ID", "0000000000000000000000")?
+        .env("FASTLY_SERVICE_VERSION", "0")?
         // signal that we're in a local testing environment
         .env("FASTLY_HOSTNAME", "localhost")?
         // request IDs start at 0 and increment, rather than being UUIDs, for ease of testing

--- a/test-fixtures/src/bin/env-vars.rs
+++ b/test-fixtures/src/bin/env-vars.rs
@@ -3,12 +3,34 @@
 use std::env;
 
 fn main() {
-    let host_name = env::var("FASTLY_HOSTNAME").expect("host name available");
-    assert_eq!(host_name, "localhost");
+    let id: u64 = env::var("FASTLY_CACHE_GENERATION")
+        .expect("cache generation available")
+        .parse()
+        .expect("parses as u64");
+
+    let sid = env::var("FASTLY_CUSTOMER_ID").expect("customer ID available");
+    assert_eq!(sid, "0000000000000000000000");
+
+    let sid = env::var("FASTLY_POP").expect("POP available");
+    assert_eq!(sid, "XXX");
+
+    let sid = env::var("FASTLY_REGION").expect("region available");
+    assert_eq!(sid, "Somewhere");
+
+    let sid = env::var("FASTLY_SERVICE_ID").expect("service ID available");
+    assert_eq!(sid, "0000000000000000000000");
+
+    let id: u64 = env::var("FASTLY_SERVICE_VERSION")
+        .expect("service version available")
+        .parse()
+        .expect("parses as u64");
 
     let id: u64 = env::var("FASTLY_TRACE_ID")
         .expect("trace ID available")
         .parse()
         .expect("parses as u64");
     assert_eq!(id, 0);
+
+    let host_name = env::var("FASTLY_HOSTNAME").expect("host name available");
+    assert_eq!(host_name, "localhost");
 }


### PR DESCRIPTION
We already had a few here, with values that make sense. I expect these ones were missing because their values don't make sense, I'm just hardcoding something reasonable. What matters for me is that they're present at all, and to match production ecp in what's present.

My intention is that a user would then be able to override these stub values by explicitly setting things from the config file (see https://github.com/fastly/Viceroy/issues/336 about that), but that there's no way to ever have these not set. Because that matches production.