### PR TITLE
Polish

### DIFF
--- a/test-fixtures/src/bin/env-vars.rs
+++ b/test-fixtures/src/bin/env-vars.rs
@@ -3,33 +3,31 @@
 use std::env;
 
 fn main() {
-    let id: u64 = env::var("FASTLY_CACHE_GENERATION")
+    let _generation: u64 = env::var("FASTLY_CACHE_GENERATION")
         .expect("cache generation available")
         .parse()
         .expect("parses as u64");
 
-    let sid = env::var("FASTLY_CUSTOMER_ID").expect("customer ID available");
-    assert_eq!(sid, "0000000000000000000000");
+    let cid = env::var("FASTLY_CUSTOMER_ID").expect("customer ID available");
+    assert_eq!(cid, "0000000000000000000000");
 
-    let sid = env::var("FASTLY_POP").expect("POP available");
-    assert_eq!(sid, "XXX");
+    let pop = env::var("FASTLY_POP").expect("POP available");
+    assert_eq!(pop, "XXX");
 
-    let sid = env::var("FASTLY_REGION").expect("region available");
-    assert_eq!(sid, "Somewhere");
+    let region = env::var("FASTLY_REGION").expect("region available");
+    assert_eq!(region, "Somewhere");
 
     let sid = env::var("FASTLY_SERVICE_ID").expect("service ID available");
     assert_eq!(sid, "0000000000000000000000");
 
-    let id: u64 = env::var("FASTLY_SERVICE_VERSION")
+    let version: u64 = env::var("FASTLY_SERVICE_VERSION")
         .expect("service version available")
         .parse()
         .expect("parses as u64");
+    assert_eq!(version, 0);
 
-    let id: u64 = env::var("FASTLY_TRACE_ID")
-        .expect("trace ID available")
-        .parse()
-        .expect("parses as u64");
-    assert_eq!(id, 0);
+    let id = env::var("FASTLY_TRACE_ID").expect("trace ID available");
+    assert_eq!(u64::from_str_radix(&id, 16).expect("parses as u64"), 0);
 
     let host_name = env::var("FASTLY_HOSTNAME").expect("host name available");
     assert_eq!(host_name, "localhost");


### PR DESCRIPTION
Improve naming and correct the trace ID parsing. While the latter is not important in this case, the actual value can contain hex digits so use from_str_radix for correctness.