### PR TITLE
return an empty result when geolocation data is not found

### DIFF
--- a/lib/src/error.rs
+++ b/lib/src/error.rs
@@ -93,9 +93,6 @@ pub enum Error {
     DeviceDetectionError(#[from] crate::wiggle_abi::DeviceDetectionError),
 
     #[error(transparent)]
-    GeolocationError(#[from] crate::wiggle_abi::GeolocationError),
-
-    #[error(transparent)]
     ObjectStoreError(#[from] crate::object_store::ObjectStoreError),
 
     #[error(transparent)]
@@ -184,7 +181,6 @@ impl Error {
             // We delegate to some error types' own implementation of `to_fastly_status`.
             Error::DictionaryError(e) => e.to_fastly_status(),
             Error::DeviceDetectionError(e) => e.to_fastly_status(),
-            Error::GeolocationError(e) => e.to_fastly_status(),
             Error::ObjectStoreError(e) => e.into(),
             Error::SecretStoreError(e) => e.into(),
             Error::Again => FastlyStatus::Again,

--- a/lib/src/wiggle_abi.rs
+++ b/lib/src/wiggle_abi.rs
@@ -14,7 +14,6 @@ pub use self::dictionary_impl::DictionaryError;
 pub use self::secret_store_impl::SecretStoreError;
 
 pub use self::device_detection_impl::DeviceDetectionError;
-pub use self::geo_impl::GeolocationError;
 
 use {
     self::{


### PR DESCRIPTION
This matches the Fastly Compute behavior.

As a result, we don't need the `GeolocationError` type anymore and this
commit also removes it.

Fixes #339.
