### PR TITLE
⏫ Bump up the Fastly SDK to latest version and uncomment the test for the Edge Rate Limiting API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -194,9 +194,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.15.2"
+version = "3.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3b1be7772ee4501dba05acbe66bb1e8760f6a6c474a36035631638e4415f130"
+checksum = "8ea184aa71bb362a1157c896979544cc23974e08fd265f29ea96b59f0b4a555b"
 
 [[package]]
 name = "byteorder"
@@ -1858,12 +1858,12 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.5.5"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b5fac59a5cb5dd637972e5fca70daf0523c9067fcdc4842f053dae04a18f8e9"
+checksum = "05ffd9c0a93b7543e062e759284fcf5f5e3b098501104bfbdde4d404db792871"
 dependencies = [
  "libc",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2017,7 +2017,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.5.5",
+ "socket2 0.5.6",
  "tokio-macros",
  "windows-sys 0.48.0",
 ]

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -29,7 +29,7 @@ bytesize = "^1.1.0"
 cfg-if = "^1.0"
 clap = { workspace = true }
 cranelift-entity = "^0.88.1"
-fastly-shared = "^0.9.3"
+fastly-shared = "^0.9.11"
 flate2 = "^1.0.24"
 futures = { workspace = true }
 http = "^0.2.8"

--- a/test-fixtures/Cargo.toml
+++ b/test-fixtures/Cargo.toml
@@ -9,9 +9,9 @@ publish = false
 
 [dependencies]
 base64 = "0.21.2"
-fastly = "^0.9.7"
-fastly-shared = "^0.9.7"
-fastly-sys = "^0.9.8"
+fastly = "0.9.11"
+fastly-shared = "0.9.11"
+fastly-sys = "0.9.11"
 bytes = "1.0.0"
 http = "0.2.9"
 rustls-pemfile = "1.0.3"

--- a/test-fixtures/src/bin/edge-rate-limiting.rs
+++ b/test-fixtures/src/bin/edge-rate-limiting.rs
@@ -1,33 +1,33 @@
 //! A guest program to test that edge-rate-limiting API is implemented.
 
-//use std::time::Duration;
+use std::time::Duration;
 
-//use fastly::erl::{CounterDuration, Penaltybox, RateCounter, RateWindow, ERL};
+use fastly::erl::{CounterDuration, Penaltybox, RateCounter, RateWindow, ERL};
 
 fn main() {
-//    let entry = "entry";
+   let entry = "entry";
 
-//    let rc = RateCounter::open("rc");
-//    let pb = Penaltybox::open("pb");
-//    let erl = ERL::open(rc, pb);
+   let rc = RateCounter::open("rc");
+   let pb = Penaltybox::open("pb");
+   let erl = ERL::open(rc, pb);
 
-//    let not_blocked = erl
-//        .check_rate(entry, 1, RateWindow::TenSecs, 100, Duration::from_secs(300))
-//        .unwrap();
-//    assert_eq!(not_blocked, false);
+   let not_blocked = erl
+       .check_rate(entry, 1, RateWindow::TenSecs, 100, Duration::from_secs(300))
+       .unwrap();
+   assert_eq!(not_blocked, false);
 
-//    let rc2 = RateCounter::open("rc");
-//    let rate_1 = rc2.lookup_rate(entry, RateWindow::OneSec).unwrap();
-//    assert_eq!(rate_1, 0);
+   let rc2 = RateCounter::open("rc");
+   let rate_1 = rc2.lookup_rate(entry, RateWindow::OneSec).unwrap();
+   assert_eq!(rate_1, 0);
 
-//    let count10 = rc2.lookup_count(entry, CounterDuration::TenSec).unwrap();
-//    assert_eq!(count10, 0);
+   let count10 = rc2.lookup_count(entry, CounterDuration::TenSec).unwrap();
+   assert_eq!(count10, 0);
 
-//    assert!(rc2.increment(entry, 600).is_ok());
+   assert!(rc2.increment(entry, 600).is_ok());
 
-//    let pb2 = Penaltybox::open("pb");
-//    let not_in_pb = pb2.has(entry).unwrap();
-//    assert_eq!(not_in_pb, false);
+   let pb2 = Penaltybox::open("pb");
+   let not_in_pb = pb2.has(entry).unwrap();
+   assert_eq!(not_in_pb, false);
 
-//    assert!(pb2.add(entry, Duration::from_secs(300)).is_ok());
+   assert!(pb2.add(entry, Duration::from_secs(300)).is_ok());
 }


### PR DESCRIPTION
This test was originally landed in the ERL (Edge Rate Limiting) [pull-request](https://github.com/fastly/Viceroy/pull/333) but commented out as the SDK with the feature implemented had not yet been released.

Now that the SDK has been released, we can bump up the minimum version of the SDK used in the tests and uncomment the ERL test to confirm that it is working as expected (and to catch any possible future regressions)