### PR TITLE
Consistently use Error::NotAvailable instead of Unsupported

### DIFF
--- a/lib/src/error.rs
+++ b/lib/src/error.rs
@@ -159,7 +159,7 @@ impl Error {
             Error::BufferLengthError { .. } => FastlyStatus::Buflen,
             Error::InvalidArgument => FastlyStatus::Inval,
             Error::ValueAbsent => FastlyStatus::None,
-            Error::Unsupported { .. } => FastlyStatus::Unsupported,
+            Error::Unsupported { .. } | Error::NotAvailable(_) => FastlyStatus::Unsupported,
             Error::HandleError { .. } => FastlyStatus::Badf,
             Error::InvalidStatusCode { .. } => FastlyStatus::Inval,
             Error::UnknownBackend(_) | Error::InvalidClientCert(_) => FastlyStatus::Inval,
@@ -199,7 +199,6 @@ impl Error {
             | Error::InvalidMethod(_)
             | Error::InvalidUri(_)
             | Error::IoError(_)
-            | Error::NotAvailable(_)
             | Error::Other(_)
             | Error::ProfilingStrategy
             | Error::StreamingChunkSend

--- a/lib/src/wiggle_abi/backend_impl.rs
+++ b/lib/src/wiggle_abi/backend_impl.rs
@@ -143,9 +143,7 @@ impl FastlyBackend for Session {
         // just doing this to get a different error if the backend doesn't exist
         let _ = lookup_backend_definition(self, backend)?;
         // health checks are not enabled in Viceroy :(
-        Err(Error::Unsupported {
-            msg: "connection timing is not actually supported in Viceroy",
-        })
+        Err(Error::NotAvailable("Connection timing"))
     }
 
     fn get_first_byte_timeout_ms(
@@ -155,9 +153,7 @@ impl FastlyBackend for Session {
         // just doing this to get a different error if the backend doesn't exist
         let _ = lookup_backend_definition(self, backend)?;
         // health checks are not enabled in Viceroy :(
-        Err(Error::Unsupported {
-            msg: "connection timing is not actually supported in Viceroy",
-        })
+        Err(Error::NotAvailable("Connection timing"))
     }
 
     fn get_between_bytes_timeout_ms(
@@ -167,9 +163,7 @@ impl FastlyBackend for Session {
         // just doing this to get a different error if the backend doesn't exist
         let _ = lookup_backend_definition(self, backend)?;
         // health checks are not enabled in Viceroy :(
-        Err(Error::Unsupported {
-            msg: "connection timing is not actually supported in Viceroy",
-        })
+        Err(Error::NotAvailable("Connection timing"))
     }
 
     fn get_ssl_min_version(
@@ -179,9 +173,7 @@ impl FastlyBackend for Session {
         // just doing this to get a different error if the backend doesn't exist
         let _ = lookup_backend_definition(self, backend)?;
         // health checks are not enabled in Viceroy :(
-        Err(Error::Unsupported {
-            msg: "ssl version flags are not supported in Viceroy",
-        })
+        Err(Error::NotAvailable("SSL version information"))
     }
 
     fn get_ssl_max_version(
@@ -191,9 +183,7 @@ impl FastlyBackend for Session {
         // just doing this to get a different error if the backend doesn't exist
         let _ = lookup_backend_definition(self, backend)?;
         // health checks are not enabled in Viceroy :(
-        Err(Error::Unsupported {
-            msg: "ssl version flags are not supported in Viceroy",
-        })
+        Err(Error::NotAvailable("SSL version information"))
     }
 
     fn is_ssl(&mut self, backend: &wiggle::GuestPtr<str>) -> Result<super::types::IsSsl, Error> {

--- a/lib/src/wiggle_abi/cache.rs
+++ b/lib/src/wiggle_abi/cache.rs
@@ -11,9 +11,7 @@ impl FastlyCache for Session {
         options_mask: types::CacheLookupOptionsMask,
         options: &wiggle::GuestPtr<'a, types::CacheLookupOptions>,
     ) -> Result<types::CacheHandle, Error> {
-        Err(Error::Unsupported {
-            msg: "Cache API primitives not yet supported",
-        })
+        Err(Error::NotAvailable("Cache API primitives"))
     }
 
     fn insert<'a>(
@@ -22,9 +20,7 @@ impl FastlyCache for Session {
         options_mask: types::CacheWriteOptionsMask,
         options: &wiggle::GuestPtr<'a, types::CacheWriteOptions<'a>>,
     ) -> Result<types::BodyHandle, Error> {
-        Err(Error::Unsupported {
-            msg: "Cache API primitives not yet supported",
-        })
+        Err(Error::NotAvailable("Cache API primitives"))
     }
 
     fn transaction_lookup<'a>(
@@ -33,9 +29,7 @@ impl FastlyCache for Session {
         options_mask: types::CacheLookupOptionsMask,
         options: &wiggle::GuestPtr<'a, types::CacheLookupOptions>,
     ) -> Result<types::CacheHandle, Error> {
-        Err(Error::Unsupported {
-            msg: "Cache API primitives not yet supported",
-        })
+        Err(Error::NotAvailable("Cache API primitives"))
     }
 
     fn transaction_insert<'a>(
@@ -44,9 +38,7 @@ impl FastlyCache for Session {
         options_mask: types::CacheWriteOptionsMask,
         options: &wiggle::GuestPtr<'a, types::CacheWriteOptions<'a>>,
     ) -> Result<types::BodyHandle, Error> {
-        Err(Error::Unsupported {
-            msg: "Cache API primitives not yet supported",
-        })
+        Err(Error::NotAvailable("Cache API primitives"))
     }
 
     fn transaction_insert_and_stream_back<'a>(
@@ -55,9 +47,7 @@ impl FastlyCache for Session {
         options_mask: types::CacheWriteOptionsMask,
         options: &wiggle::GuestPtr<'a, types::CacheWriteOptions<'a>>,
     ) -> Result<(types::BodyHandle, types::CacheHandle), Error> {
-        Err(Error::Unsupported {
-            msg: "Cache API primitives not yet supported",
-        })
+        Err(Error::NotAvailable("Cache API primitives"))
     }
 
     fn transaction_update<'a>(
@@ -66,27 +56,19 @@ impl FastlyCache for Session {
         options_mask: types::CacheWriteOptionsMask,
         options: &wiggle::GuestPtr<'a, types::CacheWriteOptions<'a>>,
     ) -> Result<(), Error> {
-        Err(Error::Unsupported {
-            msg: "Cache API primitives not yet supported",
-        })
+        Err(Error::NotAvailable("Cache API primitives"))
     }
 
     fn transaction_cancel(&mut self, handle: types::CacheHandle) -> Result<(), Error> {
-        Err(Error::Unsupported {
-            msg: "Cache API primitives not yet supported",
-        })
+        Err(Error::NotAvailable("Cache API primitives"))
     }
 
     fn close(&mut self, handle: types::CacheHandle) -> Result<(), Error> {
-        Err(Error::Unsupported {
-            msg: "Cache API primitives not yet supported",
-        })
+        Err(Error::NotAvailable("Cache API primitives"))
     }
 
     fn get_state(&mut self, handle: types::CacheHandle) -> Result<types::CacheLookupState, Error> {
-        Err(Error::Unsupported {
-            msg: "Cache API primitives not yet supported",
-        })
+        Err(Error::NotAvailable("Cache API primitives"))
     }
 
     fn get_user_metadata<'a>(
@@ -96,9 +78,7 @@ impl FastlyCache for Session {
         user_metadata_out_len: u32,
         nwritten_out: &wiggle::GuestPtr<'a, u32>,
     ) -> Result<(), Error> {
-        Err(Error::Unsupported {
-            msg: "Cache API primitives not yet supported",
-        })
+        Err(Error::NotAvailable("Cache API primitives"))
     }
 
     fn get_body(
@@ -107,47 +87,35 @@ impl FastlyCache for Session {
         options_mask: types::CacheGetBodyOptionsMask,
         options: &types::CacheGetBodyOptions,
     ) -> Result<types::BodyHandle, Error> {
-        Err(Error::Unsupported {
-            msg: "Cache API primitives not yet supported",
-        })
+        Err(Error::NotAvailable("Cache API primitives"))
     }
 
     fn get_length(
         &mut self,
         handle: types::CacheHandle,
     ) -> Result<types::CacheObjectLength, Error> {
-        Err(Error::Unsupported {
-            msg: "Cache API primitives not yet supported",
-        })
+        Err(Error::NotAvailable("Cache API primitives"))
     }
 
     fn get_max_age_ns(
         &mut self,
         handle: types::CacheHandle,
     ) -> Result<types::CacheDurationNs, Error> {
-        Err(Error::Unsupported {
-            msg: "Cache API primitives not yet supported",
-        })
+        Err(Error::NotAvailable("Cache API primitives"))
     }
 
     fn get_stale_while_revalidate_ns(
         &mut self,
         handle: types::CacheHandle,
     ) -> Result<types::CacheDurationNs, Error> {
-        Err(Error::Unsupported {
-            msg: "Cache API primitives not yet supported",
-        })
+        Err(Error::NotAvailable("Cache API primitives"))
     }
 
     fn get_age_ns(&mut self, handle: types::CacheHandle) -> Result<types::CacheDurationNs, Error> {
-        Err(Error::Unsupported {
-            msg: "Cache API primitives not yet supported",
-        })
+        Err(Error::NotAvailable("Cache API primitives"))
     }
 
     fn get_hits(&mut self, handle: types::CacheHandle) -> Result<types::CacheHitCount, Error> {
-        Err(Error::Unsupported {
-            msg: "Cache API primitives not yet supported",
-        })
+        Err(Error::NotAvailable("Cache API primitives"))
     }
 }


### PR DESCRIPTION
This PR switches most uses of `Error::Unsupported` to `Error::NotAvailable`, and translates both to `FastlyStatus::Unsupported`.

`Unsupported` is meant to express things that are not supported by the platform, for example trying to make a request with "HTTP/4".

`NotAvailable` is meant to express things that are not available or unimplemented in Viceroy.

Previously, `Unsupported` would return `FastlyStatus::Unsupported` and `NotAvailable` would return the generic `FastlyStatus::Error`.  This led to a bad user experience for the `NotAvailable` case, as the user would see an opaque and generic "Error" message rather than indicating an operation was "Unsupported".

This PR (1) changes `Error::NotAvailable` to map to `FastlyStatus::Unsupported` and (2) changes all our uses of `Error::Unsupported` for things that are not implemented in Viceroy to be `Error::NotAvailable`.
