### PR TITLE
Fix header_values_set handling in the component implementation

### DIFF
--- a/lib/src/component/http_resp.rs
+++ b/lib/src/component/http_resp.rs
@@ -161,15 +161,22 @@ impl http_resp::Host for Session {
         let headers = &mut self.response_parts_mut(h.into())?.headers;
 
         let name = HeaderName::from_bytes(name.as_bytes())?;
+        let values = {
+            // split slice along nul bytes
+            let mut iter = values.split(|b| *b == 0);
+            // drop the empty item at the end
+            iter.next_back();
+            iter.map(HeaderValue::from_bytes)
+                .collect::<Result<Vec<HeaderValue>, _>>()?
+        };
 
         // Remove any values if they exist
         if let http::header::Entry::Occupied(e) = headers.entry(&name) {
             e.remove_entry_mult();
         }
 
-        // Add all the new values
-        for value in values.split(|b| *b == 0) {
-            headers.append(&name, HeaderValue::from_bytes(value)?);
+        for value in values {
+            headers.append(&name, value);
         }
 
         Ok(())


### PR DESCRIPTION
Make the handling of header values given to the `header-values-set` functions in the component implementation consistent with the existing wiggle implementation. Additionally, use `next_back` instead of reversing and skipping the first element.
