### PR TITLE
Remove the trappable_error_type

### DIFF
--- a/lib/src/component/async_io.rs
+++ b/lib/src/component/async_io.rs
@@ -1,6 +1,5 @@
 use {
     super::fastly::api::{async_io, types},
-    super::FastlyError,
     crate::{session::Session, wiggle_abi},
     futures::FutureExt,
     std::time::Duration,
@@ -12,7 +11,7 @@ impl async_io::Host for Session {
         &mut self,
         hs: Vec<async_io::Handle>,
         timeout_ms: u32,
-    ) -> Result<Option<u32>, FastlyError> {
+    ) -> Result<Option<u32>, types::Error> {
         if hs.is_empty() && timeout_ms == 0 {
             return Err(types::Error::InvalidArgument.into());
         }
@@ -42,7 +41,7 @@ impl async_io::Host for Session {
         }
     }
 
-    async fn is_ready(&mut self, handle: async_io::Handle) -> Result<bool, FastlyError> {
+    async fn is_ready(&mut self, handle: async_io::Handle) -> Result<bool, types::Error> {
         let handle = wiggle_abi::types::AsyncItemHandle::from(handle);
         Ok(self
             .async_item_mut(handle.into())?

--- a/lib/src/component/backend.rs
+++ b/lib/src/component/backend.rs
@@ -1,22 +1,24 @@
 use {
-    super::fastly::api::{backend, http_types},
-    super::FastlyError,
+    super::fastly::api::{backend, http_types, types},
     crate::{error::Error, session::Session},
 };
 
 #[async_trait::async_trait]
 impl backend::Host for Session {
-    async fn exists(&mut self, backend: String) -> Result<bool, FastlyError> {
+    async fn exists(&mut self, backend: String) -> Result<bool, types::Error> {
         Ok(self.backend(&backend).is_some())
     }
 
-    async fn is_healthy(&mut self, backend: String) -> Result<backend::BackendHealth, FastlyError> {
+    async fn is_healthy(
+        &mut self,
+        backend: String,
+    ) -> Result<backend::BackendHealth, types::Error> {
         // just doing this to get a different error if the backend doesn't exist
         let _ = self.backend(&backend).ok_or(Error::InvalidArgument)?;
         Ok(backend::BackendHealth::Unknown)
     }
 
-    async fn is_dynamic(&mut self, backend: String) -> Result<bool, FastlyError> {
+    async fn is_dynamic(&mut self, backend: String) -> Result<bool, types::Error> {
         if self.dynamic_backend(&backend).is_some() {
             Ok(true)
         } else if self.backend(&backend).is_some() {
@@ -26,7 +28,7 @@ impl backend::Host for Session {
         }
     }
 
-    async fn get_host(&mut self, backend: String, max_len: u64) -> Result<String, FastlyError> {
+    async fn get_host(&mut self, backend: String, max_len: u64) -> Result<String, types::Error> {
         let backend = self.backend(&backend).ok_or(Error::InvalidArgument)?;
 
         let host = backend.uri.host().expect("backend uri has host");
@@ -46,7 +48,7 @@ impl backend::Host for Session {
         &mut self,
         backend: String,
         max_len: u64,
-    ) -> Result<Option<String>, FastlyError> {
+    ) -> Result<Option<String>, types::Error> {
         let backend = self.backend(&backend).ok_or(Error::InvalidArgument)?;
         if let Some(host) = backend.override_host.as_ref() {
             let host = host.to_str()?;
@@ -65,7 +67,7 @@ impl backend::Host for Session {
         }
     }
 
-    async fn get_port(&mut self, backend: String) -> Result<u16, FastlyError> {
+    async fn get_port(&mut self, backend: String) -> Result<u16, types::Error> {
         let backend = self.backend(&backend).ok_or(Error::InvalidArgument)?;
         match backend.uri.port_u16() {
             Some(port) => Ok(port),
@@ -79,7 +81,7 @@ impl backend::Host for Session {
         }
     }
 
-    async fn get_connect_timeout_ms(&mut self, backend: String) -> Result<u32, FastlyError> {
+    async fn get_connect_timeout_ms(&mut self, backend: String) -> Result<u32, types::Error> {
         // just doing this to get a different error if the backend doesn't exist
         let _ = self.backend(&backend).ok_or(Error::InvalidArgument)?;
         Err(Error::Unsupported {
@@ -88,7 +90,7 @@ impl backend::Host for Session {
         .into())
     }
 
-    async fn get_first_byte_timeout_ms(&mut self, backend: String) -> Result<u32, FastlyError> {
+    async fn get_first_byte_timeout_ms(&mut self, backend: String) -> Result<u32, types::Error> {
         // just doing this to get a different error if the backend doesn't exist
         let _ = self.backend(&backend).ok_or(Error::InvalidArgument)?;
         Err(Error::Unsupported {
@@ -97,7 +99,7 @@ impl backend::Host for Session {
         .into())
     }
 
-    async fn get_between_bytes_timeout_ms(&mut self, backend: String) -> Result<u32, FastlyError> {
+    async fn get_between_bytes_timeout_ms(&mut self, backend: String) -> Result<u32, types::Error> {
         // just doing this to get a different error if the backend doesn't exist
         let _ = self.backend(&backend).ok_or(Error::InvalidArgument)?;
         Err(Error::Unsupported {
@@ -106,7 +108,7 @@ impl backend::Host for Session {
         .into())
     }
 
-    async fn is_ssl(&mut self, backend: String) -> Result<bool, FastlyError> {
+    async fn is_ssl(&mut self, backend: String) -> Result<bool, types::Error> {
         let backend = self.backend(&backend).ok_or(Error::InvalidArgument)?;
         Ok(backend.uri.scheme() == Some(&http::uri::Scheme::HTTPS))
     }
@@ -114,7 +116,7 @@ impl backend::Host for Session {
     async fn get_ssl_min_version(
         &mut self,
         backend: String,
-    ) -> Result<http_types::TlsVersion, FastlyError> {
+    ) -> Result<http_types::TlsVersion, types::Error> {
         // just doing this to get a different error if the backend doesn't exist
         let _ = self.backend(&backend).ok_or(Error::InvalidArgument)?;
         // health checks are not enabled in Viceroy :(
@@ -127,7 +129,7 @@ impl backend::Host for Session {
     async fn get_ssl_max_version(
         &mut self,
         backend: String,
-    ) -> Result<http_types::TlsVersion, FastlyError> {
+    ) -> Result<http_types::TlsVersion, types::Error> {
         // just doing this to get a different error if the backend doesn't exist
         let _ = self.backend(&backend).ok_or(Error::InvalidArgument)?;
         // health checks are not enabled in Viceroy :(

--- a/lib/src/component/cache.rs
+++ b/lib/src/component/cache.rs
@@ -1,6 +1,5 @@
 use {
-    super::fastly::api::{cache, http_types},
-    super::FastlyError,
+    super::fastly::api::{cache, http_types, types},
     crate::{error::Error, session::Session},
 };
 
@@ -11,7 +10,7 @@ impl cache::Host for Session {
         _key: String,
         _options_mask: cache::LookupOptionsMask,
         _options: cache::LookupOptions,
-    ) -> Result<cache::Handle, FastlyError> {
+    ) -> Result<cache::Handle, types::Error> {
         Err(Error::Unsupported {
             msg: "Cache API primitives not yet supported",
         }
@@ -23,7 +22,7 @@ impl cache::Host for Session {
         _key: String,
         _options_mask: cache::WriteOptionsMask,
         _options: cache::WriteOptions,
-    ) -> Result<cache::BodyHandle, FastlyError> {
+    ) -> Result<cache::BodyHandle, types::Error> {
         Err(Error::Unsupported {
             msg: "Cache API primitives not yet supported",
         }
@@ -35,7 +34,7 @@ impl cache::Host for Session {
         _handle: cache::Handle,
         _options_mask: cache::GetBodyOptionsMask,
         _options: cache::GetBodyOptions,
-    ) -> Result<http_types::BodyHandle, FastlyError> {
+    ) -> Result<http_types::BodyHandle, types::Error> {
         Err(Error::Unsupported {
             msg: "Cache API primitives not yet supported",
         }
@@ -47,7 +46,7 @@ impl cache::Host for Session {
         _key: String,
         _options_mask: cache::LookupOptionsMask,
         _options: cache::LookupOptions,
-    ) -> Result<cache::Handle, FastlyError> {
+    ) -> Result<cache::Handle, types::Error> {
         Err(Error::Unsupported {
             msg: "Cache API primitives not yet supported",
         }
@@ -59,7 +58,7 @@ impl cache::Host for Session {
         _handle: cache::Handle,
         _options_mask: cache::WriteOptionsMask,
         _options: cache::WriteOptions,
-    ) -> Result<http_types::BodyHandle, FastlyError> {
+    ) -> Result<http_types::BodyHandle, types::Error> {
         Err(Error::Unsupported {
             msg: "Cache API primitives not yet supported",
         }
@@ -71,7 +70,7 @@ impl cache::Host for Session {
         _handle: cache::Handle,
         _options_mask: cache::WriteOptionsMask,
         _options: cache::WriteOptions,
-    ) -> Result<(http_types::BodyHandle, cache::Handle), FastlyError> {
+    ) -> Result<(http_types::BodyHandle, cache::Handle), types::Error> {
         Err(Error::Unsupported {
             msg: "Cache API primitives not yet supported",
         }
@@ -83,21 +82,21 @@ impl cache::Host for Session {
         _handle: cache::Handle,
         _options_mask: cache::WriteOptionsMask,
         _options: cache::WriteOptions,
-    ) -> Result<(), FastlyError> {
+    ) -> Result<(), types::Error> {
         Err(Error::Unsupported {
             msg: "Cache API primitives not yet supported",
         }
         .into())
     }
 
-    async fn transaction_cancel(&mut self, _handle: cache::Handle) -> Result<(), FastlyError> {
+    async fn transaction_cancel(&mut self, _handle: cache::Handle) -> Result<(), types::Error> {
         Err(Error::Unsupported {
             msg: "Cache API primitives not yet supported",
         }
         .into())
     }
 
-    async fn close(&mut self, _handle: cache::Handle) -> Result<(), FastlyError> {
+    async fn close(&mut self, _handle: cache::Handle) -> Result<(), types::Error> {
         Err(Error::Unsupported {
             msg: "Cache API primitives not yet supported",
         }
@@ -107,28 +106,28 @@ impl cache::Host for Session {
     async fn get_state(
         &mut self,
         _handle: cache::Handle,
-    ) -> Result<cache::LookupState, FastlyError> {
+    ) -> Result<cache::LookupState, types::Error> {
         Err(Error::Unsupported {
             msg: "Cache API primitives not yet supported",
         }
         .into())
     }
 
-    async fn get_user_metadata(&mut self, _handle: cache::Handle) -> Result<String, FastlyError> {
+    async fn get_user_metadata(&mut self, _handle: cache::Handle) -> Result<String, types::Error> {
         Err(Error::Unsupported {
             msg: "Cache API primitives not yet supported",
         }
         .into())
     }
 
-    async fn get_length(&mut self, _handle: cache::Handle) -> Result<u64, FastlyError> {
+    async fn get_length(&mut self, _handle: cache::Handle) -> Result<u64, types::Error> {
         Err(Error::Unsupported {
             msg: "Cache API primitives not yet supported",
         }
         .into())
     }
 
-    async fn get_max_age_ns(&mut self, _handle: cache::Handle) -> Result<u64, FastlyError> {
+    async fn get_max_age_ns(&mut self, _handle: cache::Handle) -> Result<u64, types::Error> {
         Err(Error::Unsupported {
             msg: "Cache API primitives not yet supported",
         }
@@ -138,21 +137,21 @@ impl cache::Host for Session {
     async fn get_stale_while_revalidate_ns(
         &mut self,
         _handle: cache::Handle,
-    ) -> Result<u64, FastlyError> {
+    ) -> Result<u64, types::Error> {
         Err(Error::Unsupported {
             msg: "Cache API primitives not yet supported",
         }
         .into())
     }
 
-    async fn get_age_ns(&mut self, _handle: cache::Handle) -> Result<u64, FastlyError> {
+    async fn get_age_ns(&mut self, _handle: cache::Handle) -> Result<u64, types::Error> {
         Err(Error::Unsupported {
             msg: "Cache API primitives not yet supported",
         }
         .into())
     }
 
-    async fn get_hits(&mut self, _handle: cache::Handle) -> Result<u64, FastlyError> {
+    async fn get_hits(&mut self, _handle: cache::Handle) -> Result<u64, types::Error> {
         Err(Error::Unsupported {
             msg: "Cache API primitives not yet supported",
         }

--- a/lib/src/component/dictionary.rs
+++ b/lib/src/component/dictionary.rs
@@ -1,12 +1,11 @@
 use {
     super::fastly::api::{dictionary, types},
-    super::FastlyError,
     crate::{error, session::Session},
 };
 
 #[async_trait::async_trait]
 impl dictionary::Host for Session {
-    async fn open(&mut self, name: String) -> Result<dictionary::Handle, FastlyError> {
+    async fn open(&mut self, name: String) -> Result<dictionary::Handle, types::Error> {
         let handle = self.dictionary_handle(name.as_str())?;
         Ok(handle.into())
     }
@@ -16,7 +15,7 @@ impl dictionary::Host for Session {
         h: dictionary::Handle,
         key: String,
         max_len: u64,
-    ) -> Result<Option<String>, FastlyError> {
+    ) -> Result<Option<String>, types::Error> {
         let dict = self
             .dictionary(h.into())?
             .contents()
@@ -25,7 +24,7 @@ impl dictionary::Host for Session {
         let key = key.as_str();
         let item = dict
             .get(key)
-            .ok_or_else(|| FastlyError::from(types::Error::OptionalNone))?;
+            .ok_or_else(|| types::Error::from(types::Error::OptionalNone))?;
 
         if item.len() > usize::try_from(max_len).unwrap() {
             return Err(error::Error::BufferLengthError {

--- a/lib/src/component/error.rs
+++ b/lib/src/component/error.rs
@@ -1,6 +1,5 @@
 use {
-    super::fastly::api::types,
-    super::FastlyError,
+    super::fastly::api::{http_req, types},
     crate::{
         config::ClientCertError,
         error::{self, HandleError},
@@ -15,83 +14,89 @@ use {
     },
 };
 
-impl From<types::Error> for FastlyError {
-    fn from(err: types::Error) -> Self {
-        Self::FastlyError(err.into())
+impl types::Error {
+    pub fn with_empty_detail(self) -> (Option<http_req::SendErrorDetail>, Self) {
+        (None, self)
     }
 }
 
-impl From<HandleError> for FastlyError {
+impl From<std::convert::Infallible> for types::Error {
+    fn from(_: std::convert::Infallible) -> Self {
+        unreachable!()
+    }
+}
+
+impl From<HandleError> for types::Error {
     fn from(_: HandleError) -> Self {
-        types::Error::BadHandle.into()
+        types::Error::BadHandle
     }
 }
 
-impl From<ClientCertError> for FastlyError {
+impl From<ClientCertError> for types::Error {
     fn from(_: ClientCertError) -> Self {
-        types::Error::GenericError.into()
+        types::Error::GenericError
     }
 }
 
-impl From<InvalidStatusCode> for FastlyError {
+impl From<InvalidStatusCode> for types::Error {
     fn from(_: InvalidStatusCode) -> Self {
-        types::Error::InvalidArgument.into()
+        types::Error::InvalidArgument
     }
 }
 
-impl From<InvalidHeaderName> for FastlyError {
+impl From<InvalidHeaderName> for types::Error {
     fn from(_: InvalidHeaderName) -> Self {
-        types::Error::GenericError.into()
+        types::Error::GenericError
     }
 }
 
-impl From<InvalidHeaderValue> for FastlyError {
+impl From<InvalidHeaderValue> for types::Error {
     fn from(_: InvalidHeaderValue) -> Self {
-        types::Error::GenericError.into()
+        types::Error::GenericError
     }
 }
 
-impl From<std::str::Utf8Error> for FastlyError {
+impl From<std::str::Utf8Error> for types::Error {
     fn from(_: std::str::Utf8Error) -> Self {
-        types::Error::GenericError.into()
+        types::Error::GenericError
     }
 }
 
-impl From<std::io::Error> for FastlyError {
+impl From<std::io::Error> for types::Error {
     fn from(_: std::io::Error) -> Self {
-        types::Error::GenericError.into()
+        types::Error::GenericError
     }
 }
 
-impl From<ToStrError> for FastlyError {
+impl From<ToStrError> for types::Error {
     fn from(_: ToStrError) -> Self {
-        types::Error::GenericError.into()
+        types::Error::GenericError
     }
 }
 
-impl From<InvalidMethod> for FastlyError {
+impl From<InvalidMethod> for types::Error {
     fn from(_: InvalidMethod) -> Self {
-        types::Error::GenericError.into()
+        types::Error::GenericError
     }
 }
 
-impl From<InvalidUri> for FastlyError {
+impl From<InvalidUri> for types::Error {
     fn from(_: InvalidUri) -> Self {
-        types::Error::GenericError.into()
+        types::Error::GenericError
     }
 }
 
-impl From<http::Error> for FastlyError {
+impl From<http::Error> for types::Error {
     fn from(_: http::Error) -> Self {
-        types::Error::GenericError.into()
+        types::Error::GenericError
     }
 }
 
-impl From<wiggle::GuestError> for FastlyError {
+impl From<wiggle::GuestError> for types::Error {
     fn from(err: wiggle::GuestError) -> Self {
         use wiggle::GuestError::*;
         match err {
-            PtrNotAligned { .. } => types::Error::BadAlign.into(),
+            PtrNotAligned { .. } => types::Error::BadAlign,
             // We may want to expand the FastlyStatus enum to distinguish between more of these
             // values.
             InvalidFlagValue { .. }
@@ -100,10 +105,10 @@ impl From<wiggle::GuestError> for FastlyError {
             | PtrBorrowed { .. }
             | PtrOverflow { .. }
             | InvalidUtf8 { .. }
-            | TryFromIntError { .. } => types::Error::InvalidArgument.into(),
+            | TryFromIntError { .. } => types::Error::InvalidArgument,
             // These errors indicate either a pathological user input or an internal programming
             // error
-            BorrowCheckerOutOfHandles | SliceLengthsDiffer => types::Error::UnknownError.into(),
+            BorrowCheckerOutOfHandles | SliceLengthsDiffer => types::Error::UnknownError,
             // Recursive case: InFunc wraps a GuestError with some context which
             // doesn't determine what sort of FastlyStatus we return.
             InFunc { err, .. } => Self::from(*err),
@@ -111,61 +116,59 @@ impl From<wiggle::GuestError> for FastlyError {
     }
 }
 
-impl From<ObjectStoreError> for FastlyError {
+impl From<ObjectStoreError> for types::Error {
     fn from(err: ObjectStoreError) -> Self {
         use ObjectStoreError::*;
         match err {
-            MissingObject => types::Error::OptionalNone.into(),
+            MissingObject => types::Error::OptionalNone,
             PoisonedLock => panic!("{}", err),
-            UnknownObjectStore(_) => types::Error::InvalidArgument.into(),
+            UnknownObjectStore(_) => types::Error::InvalidArgument,
         }
     }
 }
 
-impl From<KeyValidationError> for FastlyError {
-    fn from(_: KeyValidationError) -> FastlyError {
-        types::Error::GenericError.into()
+impl From<KeyValidationError> for types::Error {
+    fn from(_: KeyValidationError) -> Self {
+        types::Error::GenericError
     }
 }
 
-impl From<SecretStoreError> for FastlyError {
+impl From<SecretStoreError> for types::Error {
     fn from(err: SecretStoreError) -> Self {
         use SecretStoreError::*;
         match err {
-            UnknownSecretStore(_) => types::Error::OptionalNone.into(),
-            UnknownSecret(_) => types::Error::OptionalNone.into(),
-            InvalidSecretStoreHandle(_) => types::Error::InvalidArgument.into(),
-            InvalidSecretHandle(_) => types::Error::InvalidArgument.into(),
+            UnknownSecretStore(_) => types::Error::OptionalNone,
+            UnknownSecret(_) => types::Error::OptionalNone,
+            InvalidSecretStoreHandle(_) => types::Error::InvalidArgument,
+            InvalidSecretHandle(_) => types::Error::InvalidArgument,
         }
     }
 }
 
-impl From<DictionaryError> for FastlyError {
+impl From<DictionaryError> for types::Error {
     fn from(err: DictionaryError) -> Self {
         use DictionaryError::*;
         match err {
-            UnknownDictionaryItem(_) => types::Error::OptionalNone.into(),
-            UnknownDictionary(_) => types::Error::InvalidArgument.into(),
+            UnknownDictionaryItem(_) => types::Error::OptionalNone,
+            UnknownDictionary(_) => types::Error::InvalidArgument,
         }
     }
 }
 
-impl From<error::Error> for FastlyError {
+impl From<error::Error> for types::Error {
     fn from(err: error::Error) -> Self {
         use error::Error;
         match err {
-            Error::BufferLengthError { .. } => types::Error::BufferLen.into(),
-            Error::InvalidArgument => types::Error::InvalidArgument.into(),
-            Error::Unsupported { .. } => types::Error::Unsupported.into(),
-            Error::HandleError { .. } => types::Error::BadHandle.into(),
-            Error::InvalidStatusCode { .. } => types::Error::InvalidArgument.into(),
+            Error::BufferLengthError { .. } => types::Error::BufferLen,
+            Error::InvalidArgument => types::Error::InvalidArgument,
+            Error::Unsupported { .. } => types::Error::Unsupported,
+            Error::HandleError { .. } => types::Error::BadHandle,
+            Error::InvalidStatusCode { .. } => types::Error::InvalidArgument,
             // Map specific kinds of `hyper::Error` into their respective error codes.
-            Error::HyperError(e) if e.is_parse() => types::Error::HttpInvalid.into(),
-            Error::HyperError(e) if e.is_user() => types::Error::HttpUser.into(),
-            Error::HyperError(e) if e.is_incomplete_message() => {
-                types::Error::HttpIncomplete.into()
-            }
-            Error::HyperError(_) => types::Error::UnknownError.into(),
+            Error::HyperError(e) if e.is_parse() => types::Error::HttpInvalid,
+            Error::HyperError(e) if e.is_user() => types::Error::HttpUser,
+            Error::HyperError(e) if e.is_incomplete_message() => types::Error::HttpIncomplete,
+            Error::HyperError(_) => types::Error::UnknownError,
             // Destructuring a GuestError is recursive, so we use a helper function:
             Error::GuestError(e) => e.into(),
             // We delegate to some error types' own implementation of `to_fastly_status`.
@@ -204,7 +207,7 @@ impl From<error::Error> for FastlyError {
             | Error::InvalidAlpnRepsonse { .. }
             | Error::DeviceDetectionError(_)
             | Error::Again
-            | Error::SharedMemory => types::Error::GenericError.into(),
+            | Error::SharedMemory => types::Error::GenericError,
         }
     }
 }

--- a/lib/src/component/geo.rs
+++ b/lib/src/component/geo.rs
@@ -1,13 +1,12 @@
 use {
-    super::fastly::api::geo,
-    super::FastlyError,
+    super::fastly::api::{geo, types},
     crate::{error, session::Session},
     std::net::{IpAddr, Ipv4Addr, Ipv6Addr},
 };
 
 #[async_trait::async_trait]
 impl geo::Host for Session {
-    async fn lookup(&mut self, octets: Vec<u8>, max_len: u64) -> Result<String, FastlyError> {
+    async fn lookup(&mut self, octets: Vec<u8>, max_len: u64) -> Result<String, types::Error> {
         let ip_addr: IpAddr = match octets.len() {
             4 => IpAddr::V4(Ipv4Addr::from(
                 TryInto::<[u8; 4]>::try_into(octets).unwrap(),

--- a/lib/src/component/log.rs
+++ b/lib/src/component/log.rs
@@ -1,6 +1,5 @@
 use {
     super::fastly::api::{log, types},
-    super::FastlyError,
     crate::session::Session,
     lazy_static::lazy_static,
 };
@@ -19,7 +18,7 @@ fn is_reserved_endpoint(name: &[u8]) -> bool {
 
 #[async_trait::async_trait]
 impl log::Host for Session {
-    async fn endpoint_get(&mut self, name: String) -> Result<log::Handle, FastlyError> {
+    async fn endpoint_get(&mut self, name: String) -> Result<log::Handle, types::Error> {
         let name = name.as_bytes();
 
         if is_reserved_endpoint(name) {
@@ -29,7 +28,7 @@ impl log::Host for Session {
         Ok(self.log_endpoint_handle(name).into())
     }
 
-    async fn write(&mut self, h: log::Handle, msg: String) -> Result<u32, FastlyError> {
+    async fn write(&mut self, h: log::Handle, msg: String) -> Result<u32, types::Error> {
         let endpoint = self.log_endpoint(h.into())?;
         let msg = msg.as_bytes();
         endpoint.write_entry(&msg)?;

--- a/lib/src/component/purge.rs
+++ b/lib/src/component/purge.rs
@@ -1,6 +1,5 @@
 use {
-    super::fastly::api::purge,
-    super::FastlyError,
+    super::fastly::api::{purge, types},
     crate::{error::Error, session::Session},
 };
 
@@ -11,7 +10,7 @@ impl purge::Host for Session {
         _surrogate_key: String,
         _options: purge::PurgeOptionsMask,
         _max_len: u64,
-    ) -> Result<Option<String>, FastlyError> {
+    ) -> Result<Option<String>, types::Error> {
         Err(Error::NotAvailable("FastlyPurge").into())
     }
 }

--- a/lib/src/component/secret_store.rs
+++ b/lib/src/component/secret_store.rs
@@ -1,6 +1,5 @@
 use {
-    super::fastly::api::secret_store,
-    super::FastlyError,
+    super::fastly::api::{secret_store, types},
     crate::{
         error::Error, secret_store::SecretLookup, session::Session, wiggle_abi::SecretStoreError,
     },
@@ -8,7 +7,7 @@ use {
 
 #[async_trait::async_trait]
 impl secret_store::Host for Session {
-    async fn open(&mut self, name: String) -> Result<secret_store::StoreHandle, FastlyError> {
+    async fn open(&mut self, name: String) -> Result<secret_store::StoreHandle, types::Error> {
         let handle = self
             .secret_store_handle(&name)
             .ok_or(Error::SecretStoreError(
@@ -21,9 +20,9 @@ impl secret_store::Host for Session {
         &mut self,
         store: secret_store::StoreHandle,
         key: String,
-    ) -> Result<Option<secret_store::SecretHandle>, FastlyError> {
+    ) -> Result<Option<secret_store::SecretHandle>, types::Error> {
         let store_name = self.secret_store_name(store.into()).ok_or_else(|| {
-            FastlyError::from(SecretStoreError::InvalidSecretStoreHandle(store.into()))
+            types::Error::from(SecretStoreError::InvalidSecretStoreHandle(store.into()))
         })?;
         Ok(self
             .secret_handle(&store_name, &key)
@@ -34,7 +33,7 @@ impl secret_store::Host for Session {
         &mut self,
         secret: secret_store::SecretHandle,
         max_len: u64,
-    ) -> Result<Option<String>, FastlyError> {
+    ) -> Result<Option<String>, types::Error> {
         let lookup = self
             .secret_lookup(secret.into())
             .ok_or(Error::SecretStoreError(
@@ -74,7 +73,7 @@ impl secret_store::Host for Session {
     async fn from_bytes(
         &mut self,
         plaintext: String,
-    ) -> Result<secret_store::SecretHandle, FastlyError> {
+    ) -> Result<secret_store::SecretHandle, types::Error> {
         Ok(self.add_secret(Vec::from(plaintext.as_bytes())).into())
     }
 }

--- a/lib/src/component/types.rs
+++ b/lib/src/component/types.rs
@@ -1,15 +1,3 @@
 use {super::fastly::api::types, crate::session::Session};
 
-pub(crate) use super::FastlyError;
-
-impl super::fastly::api::types::Host for Session {
-    fn convert_error(&mut self, err: FastlyError) -> wasmtime::Result<types::Error> {
-        match err {
-            FastlyError::FastlyError(e) => match e.downcast() {
-                Ok(e) => wasmtime::Result::Ok(e),
-                Err(e) => wasmtime::Result::Err(e),
-            },
-            FastlyError::Trap(e) => wasmtime::Result::Err(e),
-        }
-    }
-}
+impl types::Host for Session {}

--- a/lib/src/component/uap.rs
+++ b/lib/src/component/uap.rs
@@ -1,12 +1,11 @@
 use {
-    super::fastly::api::uap,
-    super::FastlyError,
+    super::fastly::api::{types, uap},
     crate::{error::Error, session::Session},
     wasmtime::component::Resource,
 };
 
 #[derive(Debug)]
-pub struct UserAgent;
+pub struct UserAgent {}
 
 #[async_trait::async_trait]
 impl uap::HostUserAgent for Session {
@@ -14,42 +13,42 @@ impl uap::HostUserAgent for Session {
         &mut self,
         _agent: Resource<UserAgent>,
         _max_len: u64,
-    ) -> wasmtime::Result<String> {
-        anyhow::bail!("UserAgent resource is unimplemented")
+    ) -> Result<String, types::Error> {
+        Err(Error::NotAvailable("User-agent parsing is not available").into())
     }
 
     async fn major(
         &mut self,
         _agent: Resource<UserAgent>,
         _max_len: u64,
-    ) -> wasmtime::Result<String> {
-        anyhow::bail!("UserAgent resource is unimplemented")
+    ) -> Result<String, types::Error> {
+        Err(Error::NotAvailable("User-agent parsing is not available").into())
     }
 
     async fn minor(
         &mut self,
         _agent: Resource<UserAgent>,
         _max_len: u64,
-    ) -> wasmtime::Result<String> {
-        anyhow::bail!("UserAgent resource is unimplemented")
+    ) -> Result<String, types::Error> {
+        Err(Error::NotAvailable("User-agent parsing is not available").into())
     }
 
     async fn patch(
         &mut self,
         _agent: Resource<UserAgent>,
         _max_len: u64,
-    ) -> wasmtime::Result<String> {
-        anyhow::bail!("UserAgent resource is unimplemented")
+    ) -> Result<String, types::Error> {
+        Err(Error::NotAvailable("User-agent parsing is not available").into())
     }
 
     fn drop(&mut self, _agent: Resource<UserAgent>) -> wasmtime::Result<()> {
-        anyhow::bail!("UserAgent resource is unimplemented")
+        Err(Error::NotAvailable("User-agent parsing is not available").into())
     }
 }
 
 #[async_trait::async_trait]
 impl uap::Host for Session {
-    async fn parse(&mut self, _user_agent: String) -> Result<Resource<UserAgent>, FastlyError> {
+    async fn parse(&mut self, _user_agent: String) -> Result<Resource<UserAgent>, types::Error> {
         // not available
         Err(Error::NotAvailable("User-agent parsing is not available").into())
     }

--- a/lib/wit/deps/fastly/compute.wit
+++ b/lib/wit/deps/fastly/compute.wit
@@ -136,10 +136,10 @@ interface uap {
   use types.{error};
 
   resource user-agent {
-    family: func(max-len: u64) -> string;
-    major: func(max-len: u64) -> string;
-    minor: func(max-len: u64) -> string;
-    patch: func(max-len: u64) -> string;
+    family: func(max-len: u64) -> result<string, error>;
+    major: func(max-len: u64) -> result<string, error>;
+    minor: func(max-len: u64) -> result<string, error>;
+    patch: func(max-len: u64) -> result<string, error>;
   }
 
   parse: func(user-agent: string) -> result<user-agent, error>;


### PR DESCRIPTION
The `trappable_error_type` argument to `wasmtime::bindgen!` became optional in wasmtime-21, and given that we never expect to trap in any of our host implementations, let's remove that additional complexity.

The meat of this change is removing the custom `FastlyError` type, and replacing it with `types::Error` which is generated from compute.wit. This simplifies some functions like the `v2` suffixed request functions, but in most cases ended up being a renaming from `FastlyError` to `types::Error`.
