### PR TITLE
Remove an unnecessary Arc from the Session

### DIFF
--- a/lib/src/execute.rs
+++ b/lib/src/execute.rs
@@ -86,7 +86,7 @@ pub struct ExecuteCtx {
     /// The ID to assign the next incoming request
     next_req_id: Arc<AtomicU64>,
     /// The ObjectStore associated with this instance of Viceroy
-    object_store: Arc<ObjectStores>,
+    object_store: ObjectStores,
     /// The secret stores for this execution.
     secret_stores: Arc<SecretStores>,
     // `Arc` for the two fields below because this struct must be `Clone`.
@@ -202,7 +202,7 @@ impl ExecuteCtx {
             log_stdout: false,
             log_stderr: false,
             next_req_id: Arc::new(AtomicU64::new(0)),
-            object_store: Arc::new(ObjectStores::new()),
+            object_store: ObjectStores::new(),
             secret_stores: Arc::new(SecretStores::new()),
             epoch_increment_thread,
             epoch_increment_stop,
@@ -261,7 +261,7 @@ impl ExecuteCtx {
 
     /// Set the object store for this execution context.
     pub fn with_object_stores(mut self, object_store: ObjectStores) -> Self {
-        self.object_store = Arc::new(object_store);
+        self.object_store = object_store;
         self
     }
 

--- a/lib/src/session.rs
+++ b/lib/src/session.rs
@@ -103,7 +103,7 @@ pub struct Session {
     /// The ObjectStore configured for this execution.
     ///
     /// Populated prior to guest execution and can be modified during requests.
-    pub(crate) object_store: Arc<ObjectStores>,
+    pub(crate) object_store: ObjectStores,
     /// The object stores configured for this execution.
     ///
     /// Populated prior to guest execution.
@@ -142,7 +142,7 @@ impl Session {
         tls_config: TlsConfig,
         dictionaries: Arc<Dictionaries>,
         config_path: Arc<Option<PathBuf>>,
-        object_store: Arc<ObjectStores>,
+        object_store: ObjectStores,
         secret_stores: Arc<SecretStores>,
     ) -> Session {
         let (parts, body) = req.into_parts();


### PR DESCRIPTION
`ObjectStores` internally is an `Arc` to an `RwLock`, so the outer `Arc` present in `Session` is not necessary. This PR removes that unnecessary indirection, as `ObjectStore` already derives `Clone`.
