### PR TITLE
Return HttpInvalid error instead of FastlyStatus::Error when failed to build Uri

### DIFF
--- a/lib/src/component/error.rs
+++ b/lib/src/component/error.rs
@@ -175,6 +175,7 @@ impl From<error::Error> for types::Error {
             Error::DictionaryError(e) => e.into(),
             Error::ObjectStoreError(e) => e.into(),
             Error::SecretStoreError(e) => e.into(),
+            Error::InvalidBackendUrl => types::Error::HttpInvalid,
             // All other hostcall errors map to a generic `ERROR` value.
             Error::AbiVersionMismatch
             | Error::BackendUrl(_)

--- a/lib/src/error.rs
+++ b/lib/src/error.rs
@@ -119,6 +119,9 @@ pub enum Error {
     #[error(transparent)]
     HttpError(#[from] http::Error),
 
+    #[error("Invalid Url")]
+    InvalidBackendUrl,
+
     #[error("Object Store '{0}' does not exist")]
     UnknownObjectStore(String),
 
@@ -184,6 +187,7 @@ impl Error {
             Error::ObjectStoreError(e) => e.into(),
             Error::SecretStoreError(e) => e.into(),
             Error::Again => FastlyStatus::Again,
+            Error::InvalidBackendUrl => FastlyStatus::Httpinvalid,
             // All other hostcall errors map to a generic `ERROR` value.
             Error::AbiVersionMismatch
             | Error::BackendUrl(_)

--- a/lib/src/wiggle_abi/req_impl.rs
+++ b/lib/src/wiggle_abi/req_impl.rs
@@ -411,12 +411,18 @@ impl FastlyHttpReq for Session {
 
         let grpc = backend_info_mask.contains(BackendConfigOptions::GRPC);
 
+        let uri = match Uri::builder()
+            .scheme(scheme)
+            .authority(origin_name)
+            .path_and_query("/")
+            .build()
+        {
+            Ok(uri) => uri,
+            Err(_) => return Err(Error::InvalidBackendUrl),
+        };
+
         let new_backend = Backend {
-            uri: Uri::builder()
-                .scheme(scheme)
-                .authority(origin_name)
-                .path_and_query("/")
-                .build()?,
+            uri: uri,
             override_host,
             cert_host,
             use_sni,


### PR DESCRIPTION
[Fastly Rust SDK maps `FastlyStatus::Error` to `BackendCreationError::NameInUse`](https://docs.rs/fastly/0.10.1/src/fastly/backend/builder.rs.html#82). 
By this, when we passed invalid host name value to `fastly::Backend::builder` func, we always received `NameInUse` error.
It's a misleading behavior for developers, who will assume they register the same backend multiple times.

In this PR, I defined a new internal Error `InvalidBackendUrl` and map it as `FastlyStatus::HttpInvalid`.
It will help developers to awake they are using invalid URI to build the dynamic backend.


## Example

### before
```rust
let backend = match fastly::Backend::builder("example", "http://example.com").finish() {
    Ok(backend) => backend,
    Err(e) => {
        println!("Error: {:?}", e); // Error: NameInUse
        return Err(e);
    }
};
```

### after
```rust
let backend = match fastly::Backend::builder("example", "http://example.com").finish() {
    Ok(backend) => backend,
    Err(e) => {
        println!("Error: {:?}", e); // Error: HostError(FastlyStatus::HTTP_INVALID_ERROR)
        return Err(e);
    }
};
```