### PR TITLE
Switch to reading dictionaries during the `fastly_dictionary_open` call

### DIFF
--- a/lib/src/component/config_store.rs
+++ b/lib/src/component/config_store.rs
@@ -16,10 +16,7 @@ impl config_store::Host for Session {
         name: String,
         max_len: u64,
     ) -> Result<Option<String>, types::Error> {
-        let dict = self
-            .dictionary(store.into())?
-            .contents()
-            .map_err(|err| error::Error::Other(err.into()))?;
+        let dict = &self.dictionary(store.into())?.contents;
 
         let item = if let Some(item) = dict.get(&name) {
             item

--- a/lib/src/component/dictionary.rs
+++ b/lib/src/component/dictionary.rs
@@ -16,10 +16,7 @@ impl dictionary::Host for Session {
         key: String,
         max_len: u64,
     ) -> Result<Option<String>, types::Error> {
-        let dict = self
-            .dictionary(h.into())?
-            .contents()
-            .map_err(|err| error::Error::Other(err.into()))?;
+        let dict = &self.dictionary(h.into())?.contents;
 
         let item = if let Some(item) = dict.get(&key) {
             item

--- a/lib/src/config.rs
+++ b/lib/src/config.rs
@@ -21,10 +21,9 @@ mod limits;
 /// Types and deserializers for dictionaries configuration settings.
 mod dictionaries;
 
-pub use self::dictionaries::Dictionary;
-pub use self::dictionaries::DictionaryName;
+pub use self::dictionaries::{Dictionary, LoadedDictionary};
 
-pub type Dictionaries = HashMap<DictionaryName, Dictionary>;
+pub type Dictionaries = HashMap<String, Dictionary>;
 
 /// Types and deserializers for backend configuration settings.
 mod backends;

--- a/lib/src/config/unit_tests.rs
+++ b/lib/src/config/unit_tests.rs
@@ -1,6 +1,6 @@
 use {
     super::{FastlyConfig, LocalServerConfig, RawLocalServerConfig},
-    crate::{config::DictionaryName, error::FastlyConfigError},
+    crate::error::FastlyConfigError,
     std::{convert::TryInto, fs::File, io::Write},
     tempfile::tempdir,
 };
@@ -132,7 +132,7 @@ fn fastly_toml_files_with_simple_dictionary_configurations_can_be_read() {
 
     let dictionary = config
         .dictionaries()
-        .get(&DictionaryName::new("a".to_string()))
+        .get("a")
         .expect("dictionary configurations can be accessed");
     assert_eq!(dictionary.file_path().unwrap(), file_path);
     assert!(dictionary.is_json());
@@ -171,7 +171,7 @@ fn fastly_toml_files_with_simple_config_store_configurations_can_be_read() {
 
     let dictionary = config
         .dictionaries()
-        .get(&DictionaryName::new("a".to_string()))
+        .get("a")
         .expect("dictionary configurations can be accessed");
     assert_eq!(dictionary.file_path().unwrap(), file_path);
     assert!(dictionary.is_json());

--- a/lib/src/wiggle_abi/dictionary_impl.rs
+++ b/lib/src/wiggle_abi/dictionary_impl.rs
@@ -45,10 +45,7 @@ impl FastlyDictionary for Session {
         buf: &GuestPtr<u8>,
         buf_len: u32,
     ) -> Result<u32, Error> {
-        let dict = self
-            .dictionary(dictionary)?
-            .contents()
-            .map_err(|err| Error::Other(err.into()))?;
+        let dict = &self.dictionary(dictionary)?.contents;
 
         let item_bytes = {
             let key: &str = &key.as_str()?.ok_or(Error::SharedMemory)?;


### PR DESCRIPTION
Read dictionaries during the `open` host call instead of once for each `get` call. This improves viceroy performance for large dictionaries, and more closely matches the semantics of the production environment, as changes made while the dictionary is open won't be reflected in subsequent `get` calls.

Additionally, remove the `DictionaryName` newtype, as it wasn't offering anything over using a `String` directly.

co-authored-by: Jamey Sharp <jsharp@fastly.com>
