### PR TITLE
Fix trap handling when running components

### DIFF
--- a/cli/tests/trap-test/src/main.rs
+++ b/cli/tests/trap-test/src/main.rs
@@ -13,10 +13,8 @@ pub type Error = Box<dyn std::error::Error + Send + Sync>;
 /// Handy alias for the return type of async Tokio tests
 pub type TestResult = Result<(), Error>;
 
-#[tokio::test(flavor = "multi_thread")]
-async fn fatal_error_traps() -> TestResult {
+async fn fatal_error_traps_impl(adapt_core_wasm: bool) -> TestResult {
     let module_path = format!("{RUST_FIXTURE_PATH}/response.wasm");
-    let adapt_core_wasm = false;
     let ctx = ExecuteCtx::new(
         module_path,
         ProfilingStrategy::None,
@@ -44,4 +42,14 @@ async fn fatal_error_traps() -> TestResult {
     );
 
     Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn fatal_error_traps() -> TestResult {
+    fatal_error_traps_impl(false).await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn fatal_error_traps_component() -> TestResult {
+    fatal_error_traps_impl(true).await
 }

--- a/lib/src/component/http_req.rs
+++ b/lib/src/component/http_req.rs
@@ -2,6 +2,7 @@ use {
     super::{
         fastly::api::{http_req, http_types, types},
         headers::write_values,
+        types::TrappableError,
     },
     crate::{
         config::{Backend, ClientCertInfo},
@@ -223,7 +224,7 @@ impl http_req::Host for Session {
         name: String,
         max_len: u64,
         cursor: u32,
-    ) -> Result<Option<(Vec<u8>, Option<u32>)>, types::Error> {
+    ) -> Result<Option<(Vec<u8>, Option<u32>)>, TrappableError> {
         let headers = &self.request_parts(h.into())?.headers;
 
         let values = headers.get_all(HeaderName::from_str(&name)?);

--- a/lib/src/component/http_resp.rs
+++ b/lib/src/component/http_resp.rs
@@ -1,7 +1,8 @@
 use {
     super::fastly::api::{http_resp, http_types, types},
-    super::headers::write_values,
+    super::{headers::write_values, types::TrappableError},
     crate::{error::Error, session::Session},
+    cfg_if::cfg_if,
     http::{HeaderName, HeaderValue},
     hyper::http::response::Response,
     std::str::FromStr,
@@ -79,6 +80,8 @@ impl http_resp::Host for Session {
         max_len: u64,
         cursor: u32,
     ) -> Result<Option<(Vec<u8>, Option<u32>)>, types::Error> {
+        {}
+
         let headers = &self.response_parts(h.into())?.headers;
 
         let (buf, next) = write_values(
@@ -134,36 +137,44 @@ impl http_resp::Host for Session {
         name: String,
         max_len: u64,
         cursor: u32,
-    ) -> Result<Option<(Vec<u8>, Option<u32>)>, types::Error> {
-        if name.len() > MAX_HEADER_NAME_LEN {
-            return Err(Error::InvalidArgument.into());
-        }
-
-        let headers = &self.response_parts(h.into())?.headers;
-
-        let values = headers.get_all(HeaderName::from_str(&name)?);
-
-        let (buf, next) = write_values(
-            values.into_iter(),
-            b'\0',
-            usize::try_from(max_len).unwrap(),
-            cursor,
-        );
-
-        if buf.is_empty() {
-            if next.is_none() {
-                return Ok(None);
+    ) -> Result<Option<(Vec<u8>, Option<u32>)>, TrappableError> {
+        cfg_if! {
+            if #[cfg(feature = "test-fatalerror-config")] {
+                // Avoid warnings:
+                let _ = (h, name, max_len, cursor);
+                return Err(Error::FatalError("A fatal error occurred in the test-only implementation of header_values_get".to_string()).into());
             } else {
-                // It's an error if we couldn't write even a single value.
-                return Err(Error::BufferLengthError {
-                    buf: "buf",
-                    len: "buf.len()",
+                if name.len() > MAX_HEADER_NAME_LEN {
+                    return Err(Error::InvalidArgument.into());
                 }
-                .into());
+
+                let headers = &self.response_parts(h.into())?.headers;
+
+                let values = headers.get_all(HeaderName::from_str(&name)?);
+
+                let (buf, next) = write_values(
+                    values.into_iter(),
+                    b'\0',
+                    usize::try_from(max_len).unwrap(),
+                    cursor,
+                );
+
+                if buf.is_empty() {
+                    if next.is_none() {
+                        return Ok(None);
+                    } else {
+                        // It's an error if we couldn't write even a single value.
+                        return Err(Error::BufferLengthError {
+                            buf: "buf",
+                            len: "buf.len()",
+                        }
+                        .into());
+                    }
+                }
+
+                Ok(Some((buf, next)))
             }
         }
-
-        Ok(Some((buf, next)))
     }
 
     async fn header_values_set(

--- a/lib/src/component/http_resp.rs
+++ b/lib/src/component/http_resp.rs
@@ -80,8 +80,6 @@ impl http_resp::Host for Session {
         max_len: u64,
         cursor: u32,
     ) -> Result<Option<(Vec<u8>, Option<u32>)>, types::Error> {
-        {}
-
         let headers = &self.response_parts(h.into())?.headers;
 
         let (buf, next) = write_values(

--- a/lib/src/component/mod.rs
+++ b/lib/src/component/mod.rs
@@ -12,6 +12,14 @@ component::bindgen!({
         "wasi:io": wasmtime_wasi::bindings::io,
         "wasi:cli": wasmtime_wasi::bindings::cli,
     },
+
+    trappable_error_type: {
+        "fastly:api/types/error" => types::TrappableError,
+    },
+
+    trappable_imports: [
+        "header-values-get"
+    ],
 });
 
 pub fn link_host_functions(linker: &mut component::Linker<ComponentCtx>) -> anyhow::Result<()> {

--- a/lib/src/component/types.rs
+++ b/lib/src/component/types.rs
@@ -1,3 +1,43 @@
-use {super::fastly::api::types, crate::session::Session};
+use {
+    super::fastly::api::types,
+    crate::{
+        error::{self, HandleError},
+        session::Session,
+    },
+    http::header::InvalidHeaderName,
+};
 
-impl types::Host for Session {}
+pub enum TrappableError {
+    Error(types::Error),
+    Trap(anyhow::Error),
+}
+
+impl types::Host for Session {
+    fn convert_error(&mut self, err: TrappableError) -> wasmtime::Result<types::Error> {
+        match err {
+            TrappableError::Error(err) => Ok(err),
+            TrappableError::Trap(err) => Err(err),
+        }
+    }
+}
+
+impl From<HandleError> for TrappableError {
+    fn from(_: HandleError) -> Self {
+        Self::Error(types::Error::BadHandle)
+    }
+}
+
+impl From<InvalidHeaderName> for TrappableError {
+    fn from(_: InvalidHeaderName) -> Self {
+        Self::Error(types::Error::GenericError)
+    }
+}
+
+impl From<error::Error> for TrappableError {
+    fn from(e: error::Error) -> Self {
+        match e {
+            error::Error::FatalError(_) => Self::Trap(anyhow::anyhow!(e.to_string())),
+            _ => Self::Error(e.into()),
+        }
+    }
+}


### PR DESCRIPTION
The component implementation didn't have support for either the `test-fatalerror-config` feature, or the ability to treat the `Error::FatalError` variant as a trap. This PR fixes that by doing the following:

* Allowing `header_values_get` to trap based on the `test-fatalerror-config` feature
* Introducing the `TrappableError` type for treating `FatalError` as a trap
* Adding a variant of the `trap-test` that uses the component adapter

The remaining difference to the wiggle implementation is that only functions listed in `trappable_errors` will be able to emit traps for `FatalError`, though the only case we currently use that in is for `test-fatalerror-config`, so it seemed reasonable to not switch everything to `TrappableError`.
