### PR TITLE
add adaptive buffer support for geo + device detection lookups

### DIFF
--- a/lib/src/wiggle_abi/device_detection_impl.rs
+++ b/lib/src/wiggle_abi/device_detection_impl.rs
@@ -44,6 +44,7 @@ impl FastlyDeviceDetection for Session {
         };
 
         if result.len() > buf_len as usize {
+            nwritten_out.write(buf_len)?;
             return Err(Error::BufferLengthError {
                 buf: "device_detection_lookup",
                 len: "device_detection_lookup_max_len",

--- a/lib/src/wiggle_abi/geo_impl.rs
+++ b/lib/src/wiggle_abi/geo_impl.rs
@@ -39,6 +39,7 @@ impl FastlyGeo for Session {
         let result = self.geolocation_lookup(&ip_addr).unwrap_or_default();
 
         if result.len() > buf_len as usize {
+            nwritten_out.write(buf_len)?;
             return Err(Error::BufferLengthError {
                 buf: "geolocation_lookup",
                 len: "geolocation_lookup_max_len",


### PR DESCRIPTION
Write out the required buffer size to the nwritten_out value if the
buffer is too small to fit the value.
