### PR TITLE
Revert "add adaptive buffer support for geo + device detection lookups"

### DIFF
--- a/lib/src/wiggle_abi/device_detection_impl.rs
+++ b/lib/src/wiggle_abi/device_detection_impl.rs
@@ -44,7 +44,6 @@ impl FastlyDeviceDetection for Session {
         };
 
         if result.len() > buf_len as usize {
-            nwritten_out.write(buf_len)?;
             return Err(Error::BufferLengthError {
                 buf: "device_detection_lookup",
                 len: "device_detection_lookup_max_len",

--- a/lib/src/wiggle_abi/geo_impl.rs
+++ b/lib/src/wiggle_abi/geo_impl.rs
@@ -39,7 +39,6 @@ impl FastlyGeo for Session {
         let result = self.geolocation_lookup(&ip_addr).unwrap_or_default();
 
         if result.len() > buf_len as usize {
-            nwritten_out.write(buf_len)?;
             return Err(Error::BufferLengthError {
                 buf: "geolocation_lookup",
                 len: "geolocation_lookup_max_len",


### PR DESCRIPTION
Reverts fastly/Viceroy#383

This is a great change, but it introduces a mismatch in behavior with production. Let's reopen this as a PR that we can merge once we have support deployed in the fleet.