### PR TITLE
Enable the config-store-lookup tests

### DIFF
--- a/cli/tests/integration/config_store_lookup.rs
+++ b/cli/tests/integration/config_store_lookup.rs
@@ -8,14 +8,13 @@ async fn json_config_store_lookup_works() -> TestResult {
         description = "json config_store lookup test"
         authors = ["Jill Bryson <jbryson@fastly.com>", "Rose McDowall <rmcdowall@fastly.com>"]
         language = "rust"
-        [local_server]
-        [local_server.config_stores]
         [local_server.config_stores.animals]
         file = "../test-fixtures/data/json-config_store.json"
         format = "json"
     "#;
 
-    let resp = Test::using_fixture("config_store-lookup.wasm")
+    // let resp = Test::using_fixture("config_store-lookup.wasm")
+    let resp = Test::using_fixture("config-store-lookup.wasm")
         .using_fastly_toml(FASTLY_TOML)?
         .against_empty()
         .await?;
@@ -37,8 +36,6 @@ async fn inline_toml_config_store_lookup_works() -> TestResult {
         description = "inline toml config_store lookup test"
         authors = ["Jill Bryson <jbryson@fastly.com>", "Rose McDowall <rmcdowall@fastly.com>"]
         language = "rust"
-        [local_server]
-        [local_server.config_stores]
         [local_server.config_stores.animals]
         format = "inline-toml"
         [local_server.config_stores.animals.contents]
@@ -46,7 +43,7 @@ async fn inline_toml_config_store_lookup_works() -> TestResult {
         cat = "meow"
     "#;
 
-    let resp = Test::using_fixture("config_store-lookup.wasm")
+    let resp = Test::using_fixture("config-store-lookup.wasm")
         .using_fastly_toml(FASTLY_TOML)?
         .against_empty()
         .await?;
@@ -69,7 +66,7 @@ async fn missing_config_store_works() -> TestResult {
         language = "rust"
     "#;
 
-    let resp = Test::using_fixture("config_store-lookup.wasm")
+    let resp = Test::using_fixture("config-store-lookup.wasm")
         .using_fastly_toml(FASTLY_TOML)?
         .against_empty()
         .await?;

--- a/cli/tests/integration/main.rs
+++ b/cli/tests/integration/main.rs
@@ -2,6 +2,7 @@ mod async_io;
 mod body;
 mod client_certs;
 mod common;
+mod config_store_lookup;
 mod device_detection_lookup;
 mod dictionary_lookup;
 mod downstream_req;

--- a/test-fixtures/src/bin/config-store-lookup.rs
+++ b/test-fixtures/src/bin/config-store-lookup.rs
@@ -1,0 +1,10 @@
+//! A guest program to test that dictionary lookups work properly.
+
+use fastly::ConfigStore;
+
+fn main() {
+    let animals = ConfigStore::open("animals");
+    assert_eq!(animals.get("dog").unwrap(), "woof");
+    assert_eq!(animals.get("cat").unwrap(), "meow");
+    assert_eq!(animals.get("lamp"), None);
+}


### PR DESCRIPTION
The tests in `cli/tests/integration/config_store_lookup.rs` weren't being run because the module wasn't declared in `cli/tests/integration/main.rs`. I've re-enabled them, and copied the dictionary-lookup.rs test fixture to `config-store-lookup.rs`, to allow them to run successfully.
