### PR TITLE
🎁 Populate nwritten_out when errors occur in config-store::get or dictionary::get

### DIFF
--- a/lib/compute-at-edge-abi/compute-at-edge.witx
+++ b/lib/compute-at-edge-abi/compute-at-edge.witx
@@ -638,7 +638,8 @@
         (param $key string)
         (param $value (@witx pointer (@witx char8)))
         (param $value_max_len (@witx usize))
-        (result $err (expected $num_bytes (error $fastly_status)))
+        (param $nwritten_out (@witx pointer (@witx usize)))
+        (result $err (expected (error $fastly_status)))
     )
 )
 

--- a/lib/compute-at-edge-abi/config-store.witx
+++ b/lib/compute-at-edge-abi/config-store.witx
@@ -14,6 +14,7 @@
         (param $key string)
         (param $value (@witx pointer (@witx char8)))
         (param $value_max_len (@witx usize))
-        (result $err (expected $num_bytes (error $fastly_status)))
+        (param $nwritten_out (@witx pointer (@witx usize)))
+        (result $err (expected (error $fastly_status)))
     )
 )

--- a/lib/src/wiggle_abi/config_store.rs
+++ b/lib/src/wiggle_abi/config_store.rs
@@ -1,8 +1,9 @@
 use super::{
     fastly_config_store::FastlyConfigStore,
+    fastly_dictionary::FastlyDictionary,
     types::{ConfigStoreHandle, DictionaryHandle},
 };
-use crate::{session::Session, wiggle_abi::fastly_dictionary::FastlyDictionary, Error};
+use crate::{session::Session, Error};
 use wiggle::GuestPtr;
 
 impl FastlyConfigStore for Session {
@@ -17,8 +18,9 @@ impl FastlyConfigStore for Session {
         key: &GuestPtr<str>,
         buf: &GuestPtr<u8>,
         buf_len: u32,
-    ) -> Result<u32, Error> {
+        nwritten_out: &GuestPtr<u32>,
+    ) -> Result<(), Error> {
         let dict_handle = DictionaryHandle::from(unsafe { config_store.inner() });
-        <Self as FastlyDictionary>::get(self, dict_handle, key, buf, buf_len)
+        <Self as FastlyDictionary>::get(self, dict_handle, key, buf, buf_len, nwritten_out)
     }
 }

--- a/test-fixtures/src/bin/config-store-lookup.rs
+++ b/test-fixtures/src/bin/config-store-lookup.rs
@@ -1,10 +1,59 @@
-//! A guest program to test that dictionary lookups work properly.
+//! A guest program to test that config-store lookups work properly.
 
-use fastly::ConfigStore;
+use fastly_shared::FastlyStatus;
 
 fn main() {
-    let animals = ConfigStore::open("animals");
-    assert_eq!(animals.get("dog").unwrap(), "woof");
-    assert_eq!(animals.get("cat").unwrap(), "meow");
-    assert_eq!(animals.get("lamp"), None);
+    let animals = unsafe {
+        let mut dict_handle = fastly_shared::INVALID_CONFIG_STORE_HANDLE;
+        let res = fastly_sys::fastly_config_store::open(
+            "animals".as_ptr(),
+            "animals".len(),
+            &mut dict_handle as *mut _,
+        );
+        assert_eq!(res, FastlyStatus::OK, "Failed to open config-store");
+        dict_handle
+    };
+
+    #[derive(Debug, PartialEq, Eq)]
+    enum LookupResult {
+        Success(String),
+        Missing,
+        BufTooSmall(usize),
+        Err(FastlyStatus),
+    }
+
+    let get = |key: &str, buf_len: usize| unsafe {
+        let mut value = Vec::with_capacity(buf_len);
+        let mut nwritten = 0;
+        let res = fastly_sys::fastly_config_store::get(
+            animals,
+            key.as_ptr(),
+            key.len(),
+            value.as_mut_ptr(),
+            buf_len,
+            &mut nwritten as *mut _,
+        );
+
+        if res != FastlyStatus::OK {
+            if res == FastlyStatus::NONE {
+                return LookupResult::Missing;
+            }
+
+            if res == FastlyStatus::BUFLEN {
+                assert!(nwritten > 0 && buf_len < nwritten);
+                return LookupResult::BufTooSmall(nwritten);
+            }
+
+            return LookupResult::Err(res);
+        }
+
+        value.set_len(nwritten);
+        value.shrink_to(nwritten);
+        LookupResult::Success(String::from_utf8(value).unwrap())
+    };
+
+    assert_eq!(get("dog", 4), LookupResult::Success(String::from("woof")));
+    assert_eq!(get("cat", 4), LookupResult::Success(String::from("meow")));
+    assert_eq!(get("cat", 2), LookupResult::BufTooSmall(4));
+    assert_eq!(get("lamp", 4), LookupResult::Missing);
 }

--- a/test-fixtures/src/bin/dictionary-lookup.rs
+++ b/test-fixtures/src/bin/dictionary-lookup.rs
@@ -10,9 +10,17 @@ fn main() {
             "animals".len(),
             &mut dict_handle as *mut _,
         );
-        assert_eq!(res, FastlyStatus::OK, "Failed to open dictionary");
+        assert_eq!(res, FastlyStatus::OK, "Failed to open config-store");
         dict_handle
     };
+
+    #[derive(Debug, PartialEq, Eq)]
+    enum LookupResult {
+        Success(String),
+        Missing,
+        BufTooSmall(usize),
+        Err(FastlyStatus),
+    }
 
     let get = |key: &str, buf_len: usize| unsafe {
         let mut value = Vec::with_capacity(buf_len);
@@ -28,18 +36,24 @@ fn main() {
 
         if res != FastlyStatus::OK {
             if res == FastlyStatus::NONE {
-                return Ok(None);
+                return LookupResult::Missing;
             }
 
-            return Err(res);
+            if res == FastlyStatus::BUFLEN {
+                assert!(nwritten > 0 && buf_len < nwritten);
+                return LookupResult::BufTooSmall(nwritten);
+            }
+
+            return LookupResult::Err(res);
         }
 
         value.set_len(nwritten);
         value.shrink_to(nwritten);
-        Ok(Some(String::from_utf8(value).unwrap()))
+        LookupResult::Success(String::from_utf8(value).unwrap())
     };
 
-    assert_eq!(get("dog", 4).unwrap().unwrap(), "woof");
-    assert_eq!(get("cat", 4).unwrap().unwrap(), "meow");
-    assert_eq!(get("lamp", 4), Ok(None));
+    assert_eq!(get("dog", 4), LookupResult::Success(String::from("woof")));
+    assert_eq!(get("cat", 4), LookupResult::Success(String::from("meow")));
+    assert_eq!(get("cat", 2), LookupResult::BufTooSmall(4));
+    assert_eq!(get("lamp", 4), LookupResult::Missing);
 }

--- a/test-fixtures/src/bin/dictionary-lookup.rs
+++ b/test-fixtures/src/bin/dictionary-lookup.rs
@@ -10,7 +10,7 @@ fn main() {
             "animals".len(),
             &mut dict_handle as *mut _,
         );
-        assert_eq!(res, FastlyStatus::OK, "Failed to open config-store");
+        assert_eq!(res, FastlyStatus::OK, "Failed to open dictionary");
         dict_handle
     };
 


### PR DESCRIPTION
The wiggle representation of a function that returns `Result<u32, FastlyStatus>` and one that takes a `u32` outparam as its last argument and returns `Result<(), FastlyStatus>` are the same, which means that we can support communicating the length needed to resolve a `FastlyStatus::BufferLen` error without changing the abi of `fastly_config_store::get` or `fastly_dictionary::get`.

This PR makes this change to both `fastly_config_store::get` and `fastly_dictionary::get`, allowing SDKs to better adapt when buffer-length errors occur.