### PR TITLE
⁉️ Switch to using the on-demand allocator, instead of the pooling allocator

### DIFF
--- a/lib/src/linking.rs
+++ b/lib/src/linking.rs
@@ -28,7 +28,10 @@ impl wasmtime::ResourceLimiter for Limiter {
         // gradually resize, this will track the total allocations throughout the lifetime of the
         // instance.
         self.memory_allocated += desired - current;
-        Ok(true)
+        // limit the amount of memory that an instance can use to (roughly) 128MB, erring on
+        // the side of letting things run that might get killed on Compute, because we are not
+        // tracking some runtime factors in this count.
+        Ok(self.memory_allocated < (128 * 1024 * 1024))
     }
 
     fn table_growing(

--- a/lib/src/linking.rs
+++ b/lib/src/linking.rs
@@ -20,23 +20,21 @@ pub struct Limiter {
 
 impl Default for Limiter {
     fn default() -> Self {
-        let limits = StoreLimitsBuilder::new()
-            .instances(1)
-            .memories(1)
-            .memory_size(128 * 1024 * 1024)
-            .table_elements(98765)
-            .tables(1)
-            .build();
-
-        Limiter::new(limits)
+        Limiter::new(1, 1)
     }
 }
 
 impl Limiter {
-    fn new(internal: StoreLimits) -> Self {
+    fn new(max_instances: usize, max_tables: usize) -> Self {
         Limiter {
             memory_allocated: 0,
-            internal,
+            internal: StoreLimitsBuilder::new()
+                .instances(max_instances)
+                .memories(1)
+                .memory_size(128 * 1024 * 1024)
+                .table_elements(98765)
+                .tables(max_tables)
+                .build(),
         }
     }
 }
@@ -137,7 +135,7 @@ impl ComponentCtx {
             wasi: builder.build(),
             session,
             guest_profiler: guest_profiler.map(Box::new),
-            limiter: Limiter::default(),
+            limiter: Limiter::new(100, 100),
         };
         let mut store = Store::new(ctx.engine(), wasm_ctx);
         store.set_epoch_deadline(1);


### PR DESCRIPTION
Fixes #255.

In addition to just fixing #255, this also allows the test suite to be run in parallel, again. At least on my machines, running `make test` directly would cause memory failures. I'm guessing this was due to the pooling allocator's use of virtual memory. Switching to the on-demand allocator means that things run fine.

This extends the built-in `Limiter` object to use a `StoreLimits` under the hood, as suggested in the issue. It then builds different versions of this limiter based on whether or not Viceroy is operating in a component or non-component context, because component-based systems require more instances and more tables than traditional ones.