### PR TITLE
🎁 Update to wasmtime 22.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -94,9 +94,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle-query"
-version = "1.0.3"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a64c907d4e79225ac72e2a354c9ce84d50ebb4586dee56c82b3ee73004f537f5"
+checksum = "ad186efb764318d35165f1758e7dcef3b10628e26d41a44bc5550652e6804391"
 dependencies = [
  "windows-sys 0.52.0",
 ]
@@ -142,16 +142,16 @@ checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
 name = "backtrace"
-version = "0.3.72"
+version = "0.3.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17c6a35df3749d2e8bb1b7b21a976d82b15548788d2735b9d82f329268f71a11"
+checksum = "5cc23269a4f8976d0a4d2e7109211a419fe30e8d88d677cd60b6bc79c5732e0a"
 dependencies = [
  "addr2line 0.22.0",
  "cc",
  "cfg-if",
  "libc",
  "miniz_oxide",
- "object 0.35.0",
+ "object 0.36.0",
  "rustc-demangle",
 ]
 
@@ -289,9 +289,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.98"
+version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41c270e7540d725e65ac7f1b212ac8ce349719624d7bcff99f8e2e488e8cf03f"
+checksum = "c891175c3fb232128f48de6590095e59198bbeb8620c310be349bfc3afd12c7b"
 dependencies = [
  "jobserver",
  "libc",
@@ -306,9 +306,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.5.4"
+version = "4.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bc066a67923782aa8515dbaea16946c5bcc5addbd668bb80af688e53e548a0"
+checksum = "5db83dced34638ad474f39f250d7fea9598bdd239eaced1bdf45d597da0f433f"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -316,9 +316,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.2"
+version = "4.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae129e2e766ae0ec03484e609954119f123cc1fe650337e155d03b022f24f7b4"
+checksum = "f7e204572485eb3fbf28f871612191521df159bc3e15a9f5064c66dba3a8c05f"
 dependencies = [
  "anstream",
  "anstyle",
@@ -328,9 +328,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.4"
+version = "4.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "528131438037fd55894f62d6e9f068b8f45ac57ffa77517819645d10aed04f64"
+checksum = "c780290ccf4fb26629baa7a1081e68ced113f1d3ec302fa5948f1c381ebf06c6"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -340,9 +340,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
+checksum = "4b82cf0babdbd58558212896d1a4272303a57bdb245c2bf1147185fb45640e70"
 
 [[package]]
 name = "cobs"
@@ -392,25 +392,25 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.108.1"
+version = "0.109.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29daf137addc15da6bab6eae2c4a11e274b1d270bf2759508e62f6145e863ef6"
+checksum = "0b6b33d7e757a887989eb18b35712b2a67d96171ec3149d1bfb657b29b7b367c"
 dependencies = [
- "cranelift-entity 0.108.1",
+ "cranelift-entity 0.109.0",
 ]
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.108.1"
+version = "0.109.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de619867d5de4c644b7fd9904d6e3295269c93d8a71013df796ab338681222d4"
+checksum = "b9acf15cb22be42d07c3b57d7856329cb228b7315d385346149df2566ad5e4aa"
 dependencies = [
  "bumpalo",
  "cranelift-bforest",
  "cranelift-codegen-meta",
  "cranelift-codegen-shared",
  "cranelift-control",
- "cranelift-entity 0.108.1",
+ "cranelift-entity 0.109.0",
  "cranelift-isle",
  "gimli 0.28.1",
  "hashbrown 0.14.5",
@@ -423,24 +423,24 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.108.1"
+version = "0.109.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29f5cf277490037d8dae9513d35e0ee8134670ae4a964a5ed5b198d4249d7c10"
+checksum = "e934d301392b73b3f8b0540391fb82465a0f179a3cee7c726482ac4727efcc97"
 dependencies = [
  "cranelift-codegen-shared",
 ]
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.108.1"
+version = "0.109.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c3e22ecad1123343a3c09ac6ecc532bb5c184b6fcb7888df0ea953727f79924"
+checksum = "8afb2a2566b3d54b854dfb288b3b187f6d3d17d6f762c92898207eba302931da"
 
 [[package]]
 name = "cranelift-control"
-version = "0.108.1"
+version = "0.109.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53ca3ec6d30bce84ccf59c81fead4d16381a3ef0ef75e8403bc1e7385980da09"
+checksum = "0100f33b704cdacd01ad66ff41f8c5030d57cbff078e2a4e49ab1822591299fa"
 dependencies = [
  "arbitrary",
 ]
@@ -453,9 +453,9 @@ checksum = "87a0f1b2fdc18776956370cf8d9b009ded3f855350c480c1c52142510961f352"
 
 [[package]]
 name = "cranelift-entity"
-version = "0.108.1"
+version = "0.109.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eabb8d36b0ca8906bec93c78ea516741cac2d7e6b266fa7b0ffddcc09004990"
+checksum = "a8cfdc315e5d18997093e040a8d234bea1ac1e118a716d3e30f40d449e78207b"
 dependencies = [
  "serde",
  "serde_derive",
@@ -463,9 +463,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.108.1"
+version = "0.109.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44b42630229e49a8cfcae90bdc43c8c4c08f7a7aa4618b67f79265cd2f996dd2"
+checksum = "0f74b84f16af2e982b0c0c72233503d9d55cbfe3865dbe807ca28dc6642a28b5"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -475,15 +475,15 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.108.1"
+version = "0.109.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "918d1e36361805dfe0b6cdfd5a5ffdb5d03fa796170c5717d2727cbe623b93a0"
+checksum = "adf306d3dde705fb94bd48082f01d38c4ededc74293a4c007805f610bf08bc6e"
 
 [[package]]
 name = "cranelift-native"
-version = "0.108.1"
+version = "0.109.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75aea85a0d7e1800b14ce9d3f53adf8ad4d1ee8a9e23b0269bdc50285e93b9b3"
+checksum = "1ea0ebdef7aff4a79bcbc8b6495f31315f16b3bf311152f472eaa8d679352581"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -492,17 +492,17 @@ dependencies = [
 
 [[package]]
 name = "cranelift-wasm"
-version = "0.108.1"
+version = "0.109.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dac491fd3473944781f0cf9528c90cc899d18ad438da21961a839a3a44d57dfb"
+checksum = "d549108a1942065cdbac3bb96c2952afa0e1b9a3beff4b08c4308ac72257576d"
 dependencies = [
  "cranelift-codegen",
- "cranelift-entity 0.108.1",
+ "cranelift-entity 0.109.0",
  "cranelift-frontend",
  "itertools 0.12.1",
  "log",
  "smallvec",
- "wasmparser 0.207.0",
+ "wasmparser 0.209.1",
  "wasmtime-types",
 ]
 
@@ -971,9 +971,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.8.0"
+version = "1.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
+checksum = "0fcc0b4a115bf80b728eb8ea024ad5bd707b615bfed49e0665b6e0f86fd082d9"
 
 [[package]]
 name = "httpdate"
@@ -1164,9 +1164,9 @@ dependencies = [
 
 [[package]]
 name = "lazy_static"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "leb128"
@@ -1182,9 +1182,9 @@ checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
 name = "libloading"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c2a198fb6b0eada2a8df47933734e6d35d350665a33a3593d7164fa52c75c19"
+checksum = "e310b3a6b5907f99202fcdb4960ff45b93735d7c7d96b760fcff8db2dc0e103d"
 dependencies = [
  "cfg-if",
  "windows-targets 0.52.5",
@@ -1254,9 +1254,9 @@ checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
 
 [[package]]
 name = "memchr"
-version = "2.7.2"
+version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "memfd"
@@ -1278,9 +1278,9 @@ dependencies = [
 
 [[package]]
 name = "miniz_oxide"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87dfd01fe195c66b572b37921ad8803d010623c0aca821bea2302239d155cdae"
+checksum = "b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08"
 dependencies = [
  "adler",
 ]
@@ -1322,18 +1322,18 @@ version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8dd6c0cdf9429bce006e1362bfce61fa1bfd8c898a643ed8d2b471934701d3d"
 dependencies = [
- "crc32fast",
- "hashbrown 0.14.5",
- "indexmap",
  "memchr",
 ]
 
 [[package]]
 name = "object"
-version = "0.35.0"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8ec7ab813848ba4522158d5517a6093db1ded27575b070f4177b8d12b41db5e"
+checksum = "576dfe1fc8f9df304abb159d767a29d0476f7750fbf8aa7ad07816004a207434"
 dependencies = [
+ "crc32fast",
+ "hashbrown 0.14.5",
+ "indexmap",
  "memchr",
 ]
 
@@ -1480,9 +1480,9 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.84"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec96c6a92621310b51366f1e28d05ef11489516e93be030060e5fc12024a49d6"
+checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
 dependencies = [
  "unicode-ident",
 ]
@@ -1557,9 +1557,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "469052894dcb553421e483e4209ee581a45100d31b4018de03e5a7ad86374a7e"
+checksum = "c82cf8cff14456045f55ec4241383baeff27af886adb72ffb2162f99911de0fd"
 dependencies = [
  "bitflags 2.5.0",
 ]
@@ -1590,14 +1590,14 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.4"
+version = "1.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c117dbdfde9c8308975b6a18d71f3f385c89461f7b3fb054288ecf2a2058ba4c"
+checksum = "b91213439dad192326a0d7c6ee3955910425f441d7038e0d6933b0aec5c4517f"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.6",
- "regex-syntax 0.8.3",
+ "regex-automata 0.4.7",
+ "regex-syntax 0.8.4",
 ]
 
 [[package]]
@@ -1611,13 +1611,13 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
+checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.3",
+ "regex-syntax 0.8.4",
 ]
 
 [[package]]
@@ -1628,9 +1628,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
+checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
 name = "ring"
@@ -1950,9 +1950,9 @@ dependencies = [
 
 [[package]]
 name = "spdx"
-version = "0.10.4"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29ef1a0fa1e39ac22972c8db23ff89aea700ab96aa87114e1fb55937a631a0c9"
+checksum = "47317bbaf63785b53861e1ae2d11b80d6b624211d42cb20efcd210ee6f8a14bc"
 dependencies = [
  "smallvec",
 ]
@@ -1983,9 +1983,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.66"
+version = "2.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c42f3f41a2de00b01c0aaad383c5a45241efc8b2d1eda5661812fda5f3cdcff5"
+checksum = "901fa70d88b9d6c98022e23b4136f9f3e54e4662c3bc1bd1d84a42a9a0f0c1e9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2096,9 +2096,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.37.0"
+version = "1.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1adbebffeca75fcfd058afa480fb6c0b81e165a0323f9c9d39c9697e37c46787"
+checksum = "ba4f4a02a7a80d6f274636f0aa95c7e383b912d41fe721a31f29e29698585a4a"
 dependencies = [
  "backtrace",
  "bytes",
@@ -2115,9 +2115,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
+checksum = "5f5ae998a069d4b5aba8ee9dad856af7d520c3699e6159b185c2acd48155d39a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2158,9 +2158,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.13"
+version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4e43f8cc456c9704c851ae29c67e17ef65d2c30017c17a9765b89c382dc8bba"
+checksum = "6f49eb2ab21d2f26bd6db7bf383edc527a7ebaee412d17af4d40fdccd442f335"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -2179,9 +2179,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.13"
+version = "0.22.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c127785850e8c20836d49732ae6abfa47616e60bf9d9f57c43c250361a9db96c"
+checksum = "f21c7aaf97f1bd9ca9d4f9e73b0a6c74bd5afef56f2bc931943a6e1c37e04e38"
 dependencies = [
  "indexmap",
  "serde",
@@ -2302,9 +2302,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-width"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68f5e5f3158ecfd4b8ff6fe086db7c8467a2dfdac97fe420f2b7c4aa97af66d6"
+checksum = "0336d538f7abc86d282a4189614dfaa90810dfc2c6f6427eaf88e16311dd225d"
 
 [[package]]
 name = "unicode-xid"
@@ -2320,9 +2320,9 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
-version = "2.5.0"
+version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633"
+checksum = "22784dbdf76fdde8af1aeda5622b546b422b6fc585325248a2bf9f5e41e94d6c"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -2331,15 +2331,15 @@ dependencies = [
 
 [[package]]
 name = "utf8parse"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a183cf7feeba97b4dd1c0d46788634f6221d87fa961b305bed08c851829efcc0"
+checksum = "3ea73390fe27785838dcbf75b91b1d84799e28f1ce71e6f372a5dc2200c80de5"
 
 [[package]]
 name = "valuable"
@@ -2518,15 +2518,6 @@ checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
 
 [[package]]
 name = "wasm-encoder"
-version = "0.207.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d996306fb3aeaee0d9157adbe2f670df0236caf19f6728b221e92d0f27b3fe17"
-dependencies = [
- "leb128",
-]
-
-[[package]]
-name = "wasm-encoder"
 version = "0.208.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6425e84e42f7f558478e40ecc2287912cb319f2ca68e5c0bb93c61d4fc63fa17"
@@ -2540,6 +2531,15 @@ name = "wasm-encoder"
 version = "0.209.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b4a05336882dae732ce6bd48b7e11fe597293cb72c13da4f35d7d5f8d53b2a7"
+dependencies = [
+ "leb128",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.211.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e7d931a1120ef357f32b74547646b6fa68ea25e377772b72874b131a9ed70d4"
 dependencies = [
  "leb128",
 ]
@@ -2562,19 +2562,6 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.207.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e19bb9f8ab07616da582ef8adb24c54f1424c7ec876720b7da9db8ec0626c92c"
-dependencies = [
- "ahash",
- "bitflags 2.5.0",
- "hashbrown 0.14.5",
- "indexmap",
- "semver 1.0.23",
-]
-
-[[package]]
-name = "wasmparser"
 version = "0.208.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd921789c9dcc495f589cb37d200155dee65b4a4beeb853323b5e24e0a5f9c58"
@@ -2588,20 +2575,34 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasmprinter"
-version = "0.207.0"
+name = "wasmparser"
+version = "0.209.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c2d8a7b4dabb460208e6b4334d9db5766e84505038b2529e69c3d07ac619115"
+checksum = "07035cc9a9b41e62d3bb3a3815a66ab87c993c06fe1cf6b2a3f2a18499d937db"
+dependencies = [
+ "ahash",
+ "bitflags 2.5.0",
+ "hashbrown 0.14.5",
+ "indexmap",
+ "semver 1.0.23",
+ "serde",
+]
+
+[[package]]
+name = "wasmprinter"
+version = "0.209.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ceca8ae6eaa8c7c87b33c25c53bdf299f8c2a764aee1179402ff7652ef3a6859"
 dependencies = [
  "anyhow",
- "wasmparser 0.207.0",
+ "wasmparser 0.209.1",
 ]
 
 [[package]]
 name = "wasmtime"
-version = "21.0.1"
+version = "22.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f92a1370c66a0022e6d92dcc277e2c84f5dece19569670b8ce7db8162560d8b6"
+checksum = "786d8b5e7a4d54917c5ebe555b9667337e5f93383f49bddaaeec2eba68093b45"
 dependencies = [
  "addr2line 0.21.0",
  "anyhow",
@@ -2621,7 +2622,7 @@ dependencies = [
  "mach2",
  "memfd",
  "memoffset",
- "object 0.33.0",
+ "object 0.36.0",
  "once_cell",
  "paste",
  "postcard",
@@ -2635,8 +2636,8 @@ dependencies = [
  "smallvec",
  "sptr",
  "target-lexicon",
- "wasm-encoder 0.207.0",
- "wasmparser 0.207.0",
+ "wasm-encoder 0.209.1",
+ "wasmparser 0.209.1",
  "wasmtime-asm-macros",
  "wasmtime-cache",
  "wasmtime-component-macro",
@@ -2655,18 +2656,18 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-asm-macros"
-version = "21.0.1"
+version = "22.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dee8679c974a7f258c03d60d3c747c426ed219945b6d08cbc77fd2eab15b2d1"
+checksum = "d697d99c341d4a9ffb72f3af7a02124d233eeb59aee010f36d88e97cca553d5e"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "wasmtime-cache"
-version = "21.0.1"
+version = "22.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b00103ffaf7ee980f4e750fe272b6ada79d9901659892e457c7ca316b16df9ec"
+checksum = "916610f9ae9a6c22deb25bba2e6247ba9f00b093d30620875203b91328a1adfa"
 dependencies = [
  "anyhow",
  "base64",
@@ -2677,16 +2678,16 @@ dependencies = [
  "serde",
  "serde_derive",
  "sha2",
- "toml 0.8.13",
+ "toml 0.8.14",
  "windows-sys 0.52.0",
  "zstd",
 ]
 
 [[package]]
 name = "wasmtime-component-macro"
-version = "21.0.1"
+version = "22.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32cae30035f1cf97dcc6657c979cf39f99ce6be93583675eddf4aeaa5548509c"
+checksum = "b29b462b068e73b5b27fae092a27f47e5937cabf6b26be2779c978698a52feca"
 dependencies = [
  "anyhow",
  "proc-macro2",
@@ -2694,59 +2695,59 @@ dependencies = [
  "syn",
  "wasmtime-component-util",
  "wasmtime-wit-bindgen",
- "wit-parser 0.207.0",
+ "wit-parser 0.209.1",
 ]
 
 [[package]]
 name = "wasmtime-component-util"
-version = "21.0.1"
+version = "22.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7ae611f08cea620c67330925be28a96115bf01f8f393a6cbdf4856a86087134"
+checksum = "f9d2912c53d9054984b380dfbd7579f9c3681b2a73b903a56bd71a1c4f175f1e"
 
 [[package]]
 name = "wasmtime-cranelift"
-version = "21.0.1"
+version = "22.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2909406a6007e28be964067167890bca4574bd48a9ff18f1fa9f4856d89ea40"
+checksum = "a3975deafea000457ba84355c7c0fce0372937204f77026510b7b454f28a3a65"
 dependencies = [
  "anyhow",
  "cfg-if",
  "cranelift-codegen",
  "cranelift-control",
- "cranelift-entity 0.108.1",
+ "cranelift-entity 0.109.0",
  "cranelift-frontend",
  "cranelift-native",
  "cranelift-wasm",
  "gimli 0.28.1",
  "log",
- "object 0.33.0",
+ "object 0.36.0",
  "target-lexicon",
  "thiserror",
- "wasmparser 0.207.0",
+ "wasmparser 0.209.1",
  "wasmtime-environ",
  "wasmtime-versioned-export-macros",
 ]
 
 [[package]]
 name = "wasmtime-environ"
-version = "21.0.1"
+version = "22.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40e227f9ed2f5421473723d6c0352b5986e6e6044fde5410a274a394d726108f"
+checksum = "f444e900e848b884d8a8a2949b6f5b92af642a3e663ff8fbe78731143a55be61"
 dependencies = [
  "anyhow",
  "cpp_demangle",
- "cranelift-entity 0.108.1",
+ "cranelift-entity 0.109.0",
  "gimli 0.28.1",
  "indexmap",
  "log",
- "object 0.33.0",
+ "object 0.36.0",
  "postcard",
  "rustc-demangle",
  "serde",
  "serde_derive",
  "target-lexicon",
- "wasm-encoder 0.207.0",
- "wasmparser 0.207.0",
+ "wasm-encoder 0.209.1",
+ "wasmparser 0.209.1",
  "wasmprinter",
  "wasmtime-component-util",
  "wasmtime-types",
@@ -2754,9 +2755,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-fiber"
-version = "21.0.1"
+version = "22.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42edb392586d07038c1638e854382db916b6ca7845a2e6a7f8dc49e08907acdd"
+checksum = "4ded58eb2d1bf0dcd2182d0ccd7055c4b10b50d711514f1d73f61515d0fa829d"
 dependencies = [
  "anyhow",
  "cc",
@@ -2769,11 +2770,11 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit-debug"
-version = "21.0.1"
+version = "22.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95b26ef7914af0c0e3ca811bdc32f5f66fbba0fd21e1f8563350e8a7951e3598"
+checksum = "9bc54198c6720f098210a85efb3ba8c078d1de4d373cdb6778850a66ae088d11"
 dependencies = [
- "object 0.33.0",
+ "object 0.36.0",
  "once_cell",
  "rustix",
  "wasmtime-versioned-export-macros",
@@ -2781,9 +2782,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit-icache-coherence"
-version = "21.0.1"
+version = "22.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afe088f9b56bb353adaf837bf7e10f1c2e1676719dd5be4cac8e37f2ba1ee5bc"
+checksum = "5afe2f0499542f9a4bcfa1b55bfdda803b6ade4e7c93c6b99e0f39dba44b0a91"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -2793,28 +2794,28 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-slab"
-version = "21.0.1"
+version = "22.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ff75cafffe47b04b036385ce3710f209153525b0ed19d57b0cf44a22d446460"
+checksum = "0a7de1f2bec5bbb35d532e61c85c049dc84ae671df60492f90b954ecf21169e7"
 
 [[package]]
 name = "wasmtime-types"
-version = "21.0.1"
+version = "22.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f2fa462bfea3220711c84e2b549f147e4df89eeb49b8a2a3d89148f6cc4a8b1"
+checksum = "412463e9000e14cf6856be48628d2213c20c153e29ffc22b036980c892ea6964"
 dependencies = [
- "cranelift-entity 0.108.1",
+ "cranelift-entity 0.109.0",
  "serde",
  "serde_derive",
  "smallvec",
- "wasmparser 0.207.0",
+ "wasmparser 0.209.1",
 ]
 
 [[package]]
 name = "wasmtime-versioned-export-macros"
-version = "21.0.1"
+version = "22.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4cedc5bfef3db2a85522ee38564b47ef3b7fc7c92e94cacbce99808e63cdd47"
+checksum = "de5a9bc4f44ceeb168e9e8e3be4e0b4beb9095b468479663a9e24c667e36826f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2823,9 +2824,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi"
-version = "21.0.1"
+version = "22.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdbbe94245904d4c96c7c5f7b55bad896cc27908644efd9442063c0748b631fc"
+checksum = "8abb1301089ed8e0b4840f539cba316a73ac382090f1b25d22d8c8eed8df49c7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2854,9 +2855,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-nn"
-version = "21.0.1"
+version = "22.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4cf6f6e57b20257bd34391d86e5e63c8128432a8e5ddff489597e51456cc39a"
+checksum = "74ad60f6406604fced9fdd9693cd0d17d30e041bb2a652eb75fdab741f79c59e"
 dependencies = [
  "anyhow",
  "openvino",
@@ -2869,16 +2870,16 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-winch"
-version = "21.0.1"
+version = "22.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97b27054fed6be4f3800aba5766f7ef435d4220ce290788f021a08d4fa573108"
+checksum = "ed4db238a0241df2d15f79ad17b3a37a27f2ea6cb885894d81b42ae107544466"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
  "gimli 0.28.1",
- "object 0.33.0",
+ "object 0.36.0",
  "target-lexicon",
- "wasmparser 0.207.0",
+ "wasmparser 0.209.1",
  "wasmtime-cranelift",
  "wasmtime-environ",
  "winch-codegen",
@@ -2886,14 +2887,14 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wit-bindgen"
-version = "21.0.1"
+version = "22.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c936a52ce69c28de2aa3b5fb4f2dbbb2966df304f04cccb7aca4ba56d915fda0"
+checksum = "70dc077306b38288262e5ba01d4b21532a6987416cdc0aedf04bb06c22a68fdc"
 dependencies = [
  "anyhow",
  "heck 0.4.1",
  "indexmap",
- "wit-parser 0.207.0",
+ "wit-parser 0.209.1",
 ]
 
 [[package]]
@@ -2907,31 +2908,31 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "209.0.1"
+version = "211.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fffef2ff6147e4d12e972765fd75332c6a11c722571d4ab7a780d81ffc8f0a4"
+checksum = "b25506dd82d00da6b14a87436b3d52b1d264083fa79cdb72a0d1b04a8595ccaa"
 dependencies = [
  "bumpalo",
  "leb128",
  "memchr",
  "unicode-width",
- "wasm-encoder 0.209.1",
+ "wasm-encoder 0.211.1",
 ]
 
 [[package]]
 name = "wat"
-version = "1.209.1"
+version = "1.211.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42203ec0271d113f8eb1f77ebc624886530cecb35915a7f63a497131f16e4d24"
+checksum = "eb716ca6c86eecac2d82541ffc39860118fc0af9309c4f2670637bea2e1bdd7d"
 dependencies = [
- "wast 209.0.1",
+ "wast 211.0.1",
 ]
 
 [[package]]
 name = "wiggle"
-version = "21.0.1"
+version = "22.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a89ea6f74ece6d1cfbd089783006b8eb69a0219ca83cad22068f0d9fa9df3f91"
+checksum = "29830e5d01c182d24b94092c697aa7ab0ee97d22e78a2bf40ca91eae6ebca5c2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2945,9 +2946,9 @@ dependencies = [
 
 [[package]]
 name = "wiggle-generate"
-version = "21.0.1"
+version = "22.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36beda94813296ecaf0d91b7ada9da073fd41865ba339bdd3b7764e2e785b8e9"
+checksum = "557567f2793508760cd855f7659b7a0b9dc4dbc451f53f1415d6943a15311ade"
 dependencies = [
  "anyhow",
  "heck 0.4.1",
@@ -2960,9 +2961,9 @@ dependencies = [
 
 [[package]]
 name = "wiggle-macro"
-version = "21.0.1"
+version = "22.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b47d2b4442ce93106dba5d1a9c59d5f85b5732878bb3d0598d3c93c0d01b16b"
+checksum = "cc26129a8aea20b62c961d1b9ab4a3c3b56b10042ed85d004f8678af0f21ba6e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3003,9 +3004,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winch-codegen"
-version = "0.19.1"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dc69899ccb2da7daa4df31426dcfd284b104d1a85e1dae35806df0c46187f87"
+checksum = "85c6915884e731b2db0d8cf08cb64474cb69221a161675fd3c135f91febc3daa"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -3013,7 +3014,7 @@ dependencies = [
  "regalloc2",
  "smallvec",
  "target-lexicon",
- "wasmparser 0.207.0",
+ "wasmparser 0.209.1",
  "wasmtime-cranelift",
  "wasmtime-environ",
 ]
@@ -3168,9 +3169,9 @@ checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
 
 [[package]]
 name = "winnow"
-version = "0.6.9"
+version = "0.6.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86c949fede1d13936a99f14fafd3e76fd642b556dd2ce96287fbe2e0151bfac6"
+checksum = "59b5e5f6c299a3c7890b876a2a587f3115162487e704907d9b6cd29473052ba1"
 dependencies = [
  "memchr",
 ]
@@ -3245,24 +3246,6 @@ dependencies = [
 
 [[package]]
 name = "wit-parser"
-version = "0.207.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78c83dab33a9618d86cfe3563cc864deffd08c17efc5db31a3b7cd1edeffe6e1"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap",
- "log",
- "semver 1.0.23",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser 0.207.0",
-]
-
-[[package]]
-name = "wit-parser"
 version = "0.208.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "516417a730725fe3e6c9e2efc8d86697480f80496d32b24e62736950704c047c"
@@ -3277,6 +3260,24 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser 0.208.1",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.209.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e79b9e3c0b6bb589dec46317e645851e0db2734c44e2be5e251b03ff4a51269"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver 1.0.23",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser 0.209.1",
 ]
 
 [[package]]
@@ -3331,9 +3332,9 @@ dependencies = [
 
 [[package]]
 name = "zstd-sys"
-version = "2.0.10+zstd.1.5.6"
+version = "2.0.11+zstd.1.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c253a4914af5bafc8fa8c86ee400827e83cf6ec01195ec1f1ed8441bf00d65aa"
+checksum = "75652c55c0b6f3e6f12eb786fe1bc960396bf05a1eb3bf1f3691c3610ac2e6d4"
 dependencies = [
  "cc",
  "pkg-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,10 +40,10 @@ futures = "0.3.24"
 url = "2.3.1"
 
 # Wasmtime dependencies
-wasmtime = "21.0.0"
-wasmtime-wasi = "21.0.0"
-wasmtime-wasi-nn = "21.0.0"
-wiggle = "21.0.0"
+wasmtime = "22.0.0"
+wasmtime-wasi = "22.0.0"
+wasmtime-wasi-nn = "22.0.0"
+wiggle = "22.0.0"
 wasmparser = "0.208.0"
 wasm-encoder = { version = "0.208.0", features = ["wasmparser"] }
 wit-component = "0.208.0"

--- a/cli/tests/trap-test/Cargo.lock
+++ b/cli/tests/trap-test/Cargo.lock
@@ -109,9 +109,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle-query"
-version = "1.0.3"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a64c907d4e79225ac72e2a354c9ce84d50ebb4586dee56c82b3ee73004f537f5"
+checksum = "ad186efb764318d35165f1758e7dcef3b10628e26d41a44bc5550652e6804391"
 dependencies = [
  "windows-sys 0.52.0",
 ]
@@ -157,16 +157,16 @@ checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
 name = "backtrace"
-version = "0.3.72"
+version = "0.3.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17c6a35df3749d2e8bb1b7b21a976d82b15548788d2735b9d82f329268f71a11"
+checksum = "5cc23269a4f8976d0a4d2e7109211a419fe30e8d88d677cd60b6bc79c5732e0a"
 dependencies = [
  "addr2line 0.22.0",
  "cc",
  "cfg-if",
  "libc",
  "miniz_oxide",
- "object 0.35.0",
+ "object",
  "rustc-demangle",
 ]
 
@@ -300,9 +300,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.98"
+version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41c270e7540d725e65ac7f1b212ac8ce349719624d7bcff99f8e2e488e8cf03f"
+checksum = "c891175c3fb232128f48de6590095e59198bbeb8620c310be349bfc3afd12c7b"
 dependencies = [
  "jobserver",
  "libc",
@@ -329,9 +329,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.4"
+version = "4.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bc066a67923782aa8515dbaea16946c5bcc5addbd668bb80af688e53e548a0"
+checksum = "5db83dced34638ad474f39f250d7fea9598bdd239eaced1bdf45d597da0f433f"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -339,9 +339,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.2"
+version = "4.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae129e2e766ae0ec03484e609954119f123cc1fe650337e155d03b022f24f7b4"
+checksum = "f7e204572485eb3fbf28f871612191521df159bc3e15a9f5064c66dba3a8c05f"
 dependencies = [
  "anstream",
  "anstyle",
@@ -351,9 +351,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.4"
+version = "4.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "528131438037fd55894f62d6e9f068b8f45ac57ffa77517819645d10aed04f64"
+checksum = "c780290ccf4fb26629baa7a1081e68ced113f1d3ec302fa5948f1c381ebf06c6"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -363,9 +363,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
+checksum = "4b82cf0babdbd58558212896d1a4272303a57bdb245c2bf1147185fb45640e70"
 
 [[package]]
 name = "cobs"
@@ -415,25 +415,25 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.108.1"
+version = "0.109.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29daf137addc15da6bab6eae2c4a11e274b1d270bf2759508e62f6145e863ef6"
+checksum = "0b6b33d7e757a887989eb18b35712b2a67d96171ec3149d1bfb657b29b7b367c"
 dependencies = [
- "cranelift-entity 0.108.1",
+ "cranelift-entity 0.109.0",
 ]
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.108.1"
+version = "0.109.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de619867d5de4c644b7fd9904d6e3295269c93d8a71013df796ab338681222d4"
+checksum = "b9acf15cb22be42d07c3b57d7856329cb228b7315d385346149df2566ad5e4aa"
 dependencies = [
  "bumpalo",
  "cranelift-bforest",
  "cranelift-codegen-meta",
  "cranelift-codegen-shared",
  "cranelift-control",
- "cranelift-entity 0.108.1",
+ "cranelift-entity 0.109.0",
  "cranelift-isle",
  "gimli 0.28.1",
  "hashbrown 0.14.5",
@@ -446,24 +446,24 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.108.1"
+version = "0.109.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29f5cf277490037d8dae9513d35e0ee8134670ae4a964a5ed5b198d4249d7c10"
+checksum = "e934d301392b73b3f8b0540391fb82465a0f179a3cee7c726482ac4727efcc97"
 dependencies = [
  "cranelift-codegen-shared",
 ]
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.108.1"
+version = "0.109.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c3e22ecad1123343a3c09ac6ecc532bb5c184b6fcb7888df0ea953727f79924"
+checksum = "8afb2a2566b3d54b854dfb288b3b187f6d3d17d6f762c92898207eba302931da"
 
 [[package]]
 name = "cranelift-control"
-version = "0.108.1"
+version = "0.109.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53ca3ec6d30bce84ccf59c81fead4d16381a3ef0ef75e8403bc1e7385980da09"
+checksum = "0100f33b704cdacd01ad66ff41f8c5030d57cbff078e2a4e49ab1822591299fa"
 dependencies = [
  "arbitrary",
 ]
@@ -476,9 +476,9 @@ checksum = "87a0f1b2fdc18776956370cf8d9b009ded3f855350c480c1c52142510961f352"
 
 [[package]]
 name = "cranelift-entity"
-version = "0.108.1"
+version = "0.109.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eabb8d36b0ca8906bec93c78ea516741cac2d7e6b266fa7b0ffddcc09004990"
+checksum = "a8cfdc315e5d18997093e040a8d234bea1ac1e118a716d3e30f40d449e78207b"
 dependencies = [
  "serde",
  "serde_derive",
@@ -486,9 +486,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.108.1"
+version = "0.109.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44b42630229e49a8cfcae90bdc43c8c4c08f7a7aa4618b67f79265cd2f996dd2"
+checksum = "0f74b84f16af2e982b0c0c72233503d9d55cbfe3865dbe807ca28dc6642a28b5"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -498,15 +498,15 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.108.1"
+version = "0.109.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "918d1e36361805dfe0b6cdfd5a5ffdb5d03fa796170c5717d2727cbe623b93a0"
+checksum = "adf306d3dde705fb94bd48082f01d38c4ededc74293a4c007805f610bf08bc6e"
 
 [[package]]
 name = "cranelift-native"
-version = "0.108.1"
+version = "0.109.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75aea85a0d7e1800b14ce9d3f53adf8ad4d1ee8a9e23b0269bdc50285e93b9b3"
+checksum = "1ea0ebdef7aff4a79bcbc8b6495f31315f16b3bf311152f472eaa8d679352581"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -515,17 +515,17 @@ dependencies = [
 
 [[package]]
 name = "cranelift-wasm"
-version = "0.108.1"
+version = "0.109.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dac491fd3473944781f0cf9528c90cc899d18ad438da21961a839a3a44d57dfb"
+checksum = "d549108a1942065cdbac3bb96c2952afa0e1b9a3beff4b08c4308ac72257576d"
 dependencies = [
  "cranelift-codegen",
- "cranelift-entity 0.108.1",
+ "cranelift-entity 0.109.0",
  "cranelift-frontend",
  "itertools 0.12.1",
  "log",
  "smallvec",
- "wasmparser 0.207.0",
+ "wasmparser 0.209.1",
  "wasmtime-types",
 ]
 
@@ -975,9 +975,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.8.0"
+version = "1.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
+checksum = "0fcc0b4a115bf80b728eb8ea024ad5bd707b615bfed49e0665b6e0f86fd082d9"
 
 [[package]]
 name = "httpdate"
@@ -1168,9 +1168,9 @@ dependencies = [
 
 [[package]]
 name = "lazy_static"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "leb128"
@@ -1186,9 +1186,9 @@ checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
 name = "libloading"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c2a198fb6b0eada2a8df47933734e6d35d350665a33a3593d7164fa52c75c19"
+checksum = "e310b3a6b5907f99202fcdb4960ff45b93735d7c7d96b760fcff8db2dc0e103d"
 dependencies = [
  "cfg-if",
  "windows-targets 0.52.5",
@@ -1258,9 +1258,9 @@ checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
 
 [[package]]
 name = "memchr"
-version = "2.7.2"
+version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "memfd"
@@ -1282,9 +1282,9 @@ dependencies = [
 
 [[package]]
 name = "miniz_oxide"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87dfd01fe195c66b572b37921ad8803d010623c0aca821bea2302239d155cdae"
+checksum = "b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08"
 dependencies = [
  "adler",
 ]
@@ -1321,22 +1321,13 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.33.0"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8dd6c0cdf9429bce006e1362bfce61fa1bfd8c898a643ed8d2b471934701d3d"
+checksum = "576dfe1fc8f9df304abb159d767a29d0476f7750fbf8aa7ad07816004a207434"
 dependencies = [
  "crc32fast",
  "hashbrown 0.14.5",
  "indexmap",
- "memchr",
-]
-
-[[package]]
-name = "object"
-version = "0.35.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8ec7ab813848ba4522158d5517a6093db1ded27575b070f4177b8d12b41db5e"
-dependencies = [
  "memchr",
 ]
 
@@ -1477,9 +1468,9 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.84"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec96c6a92621310b51366f1e28d05ef11489516e93be030060e5fc12024a49d6"
+checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
 dependencies = [
  "unicode-ident",
 ]
@@ -1554,9 +1545,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "469052894dcb553421e483e4209ee581a45100d31b4018de03e5a7ad86374a7e"
+checksum = "c82cf8cff14456045f55ec4241383baeff27af886adb72ffb2162f99911de0fd"
 dependencies = [
  "bitflags 2.5.0",
 ]
@@ -1587,14 +1578,14 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.4"
+version = "1.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c117dbdfde9c8308975b6a18d71f3f385c89461f7b3fb054288ecf2a2058ba4c"
+checksum = "b91213439dad192326a0d7c6ee3955910425f441d7038e0d6933b0aec5c4517f"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.6",
- "regex-syntax 0.8.3",
+ "regex-automata 0.4.7",
+ "regex-syntax 0.8.4",
 ]
 
 [[package]]
@@ -1608,13 +1599,13 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
+checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.3",
+ "regex-syntax 0.8.4",
 ]
 
 [[package]]
@@ -1625,9 +1616,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
+checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
 name = "ring"
@@ -1922,9 +1913,9 @@ dependencies = [
 
 [[package]]
 name = "spdx"
-version = "0.10.4"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29ef1a0fa1e39ac22972c8db23ff89aea700ab96aa87114e1fb55937a631a0c9"
+checksum = "47317bbaf63785b53861e1ae2d11b80d6b624211d42cb20efcd210ee6f8a14bc"
 dependencies = [
  "smallvec",
 ]
@@ -1955,9 +1946,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.66"
+version = "2.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c42f3f41a2de00b01c0aaad383c5a45241efc8b2d1eda5661812fda5f3cdcff5"
+checksum = "901fa70d88b9d6c98022e23b4136f9f3e54e4662c3bc1bd1d84a42a9a0f0c1e9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2042,9 +2033,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.37.0"
+version = "1.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1adbebffeca75fcfd058afa480fb6c0b81e165a0323f9c9d39c9697e37c46787"
+checksum = "ba4f4a02a7a80d6f274636f0aa95c7e383b912d41fe721a31f29e29698585a4a"
 dependencies = [
  "backtrace",
  "bytes",
@@ -2061,9 +2052,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
+checksum = "5f5ae998a069d4b5aba8ee9dad856af7d520c3699e6159b185c2acd48155d39a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2104,9 +2095,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.13"
+version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4e43f8cc456c9704c851ae29c67e17ef65d2c30017c17a9765b89c382dc8bba"
+checksum = "6f49eb2ab21d2f26bd6db7bf383edc527a7ebaee412d17af4d40fdccd442f335"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -2125,9 +2116,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.13"
+version = "0.22.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c127785850e8c20836d49732ae6abfa47616e60bf9d9f57c43c250361a9db96c"
+checksum = "f21c7aaf97f1bd9ca9d4f9e73b0a6c74bd5afef56f2bc931943a6e1c37e04e38"
 dependencies = [
  "indexmap",
  "serde",
@@ -2275,9 +2266,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-width"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68f5e5f3158ecfd4b8ff6fe086db7c8467a2dfdac97fe420f2b7c4aa97af66d6"
+checksum = "0336d538f7abc86d282a4189614dfaa90810dfc2c6f6427eaf88e16311dd225d"
 
 [[package]]
 name = "unicode-xid"
@@ -2293,9 +2284,9 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
-version = "2.5.0"
+version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633"
+checksum = "22784dbdf76fdde8af1aeda5622b546b422b6fc585325248a2bf9f5e41e94d6c"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -2304,15 +2295,15 @@ dependencies = [
 
 [[package]]
 name = "utf8parse"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a183cf7feeba97b4dd1c0d46788634f6221d87fa961b305bed08c851829efcc0"
+checksum = "3ea73390fe27785838dcbf75b91b1d84799e28f1ce71e6f372a5dc2200c80de5"
 
 [[package]]
 name = "valuable"
@@ -2450,15 +2441,6 @@ checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
 
 [[package]]
 name = "wasm-encoder"
-version = "0.207.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d996306fb3aeaee0d9157adbe2f670df0236caf19f6728b221e92d0f27b3fe17"
-dependencies = [
- "leb128",
-]
-
-[[package]]
-name = "wasm-encoder"
 version = "0.208.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6425e84e42f7f558478e40ecc2287912cb319f2ca68e5c0bb93c61d4fc63fa17"
@@ -2472,6 +2454,15 @@ name = "wasm-encoder"
 version = "0.209.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b4a05336882dae732ce6bd48b7e11fe597293cb72c13da4f35d7d5f8d53b2a7"
+dependencies = [
+ "leb128",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.211.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e7d931a1120ef357f32b74547646b6fa68ea25e377772b72874b131a9ed70d4"
 dependencies = [
  "leb128",
 ]
@@ -2494,19 +2485,6 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.207.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e19bb9f8ab07616da582ef8adb24c54f1424c7ec876720b7da9db8ec0626c92c"
-dependencies = [
- "ahash",
- "bitflags 2.5.0",
- "hashbrown 0.14.5",
- "indexmap",
- "semver 1.0.23",
-]
-
-[[package]]
-name = "wasmparser"
 version = "0.208.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd921789c9dcc495f589cb37d200155dee65b4a4beeb853323b5e24e0a5f9c58"
@@ -2520,20 +2498,34 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasmprinter"
-version = "0.207.0"
+name = "wasmparser"
+version = "0.209.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c2d8a7b4dabb460208e6b4334d9db5766e84505038b2529e69c3d07ac619115"
+checksum = "07035cc9a9b41e62d3bb3a3815a66ab87c993c06fe1cf6b2a3f2a18499d937db"
+dependencies = [
+ "ahash",
+ "bitflags 2.5.0",
+ "hashbrown 0.14.5",
+ "indexmap",
+ "semver 1.0.23",
+ "serde",
+]
+
+[[package]]
+name = "wasmprinter"
+version = "0.209.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ceca8ae6eaa8c7c87b33c25c53bdf299f8c2a764aee1179402ff7652ef3a6859"
 dependencies = [
  "anyhow",
- "wasmparser 0.207.0",
+ "wasmparser 0.209.1",
 ]
 
 [[package]]
 name = "wasmtime"
-version = "21.0.1"
+version = "22.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f92a1370c66a0022e6d92dcc277e2c84f5dece19569670b8ce7db8162560d8b6"
+checksum = "786d8b5e7a4d54917c5ebe555b9667337e5f93383f49bddaaeec2eba68093b45"
 dependencies = [
  "addr2line 0.21.0",
  "anyhow",
@@ -2553,7 +2545,7 @@ dependencies = [
  "mach2",
  "memfd",
  "memoffset",
- "object 0.33.0",
+ "object",
  "once_cell",
  "paste",
  "postcard",
@@ -2567,8 +2559,8 @@ dependencies = [
  "smallvec",
  "sptr",
  "target-lexicon",
- "wasm-encoder 0.207.0",
- "wasmparser 0.207.0",
+ "wasm-encoder 0.209.1",
+ "wasmparser 0.209.1",
  "wasmtime-asm-macros",
  "wasmtime-cache",
  "wasmtime-component-macro",
@@ -2587,18 +2579,18 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-asm-macros"
-version = "21.0.1"
+version = "22.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dee8679c974a7f258c03d60d3c747c426ed219945b6d08cbc77fd2eab15b2d1"
+checksum = "d697d99c341d4a9ffb72f3af7a02124d233eeb59aee010f36d88e97cca553d5e"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "wasmtime-cache"
-version = "21.0.1"
+version = "22.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b00103ffaf7ee980f4e750fe272b6ada79d9901659892e457c7ca316b16df9ec"
+checksum = "916610f9ae9a6c22deb25bba2e6247ba9f00b093d30620875203b91328a1adfa"
 dependencies = [
  "anyhow",
  "base64",
@@ -2609,16 +2601,16 @@ dependencies = [
  "serde",
  "serde_derive",
  "sha2",
- "toml 0.8.13",
+ "toml 0.8.14",
  "windows-sys 0.52.0",
  "zstd",
 ]
 
 [[package]]
 name = "wasmtime-component-macro"
-version = "21.0.1"
+version = "22.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32cae30035f1cf97dcc6657c979cf39f99ce6be93583675eddf4aeaa5548509c"
+checksum = "b29b462b068e73b5b27fae092a27f47e5937cabf6b26be2779c978698a52feca"
 dependencies = [
  "anyhow",
  "proc-macro2",
@@ -2626,59 +2618,59 @@ dependencies = [
  "syn",
  "wasmtime-component-util",
  "wasmtime-wit-bindgen",
- "wit-parser 0.207.0",
+ "wit-parser 0.209.1",
 ]
 
 [[package]]
 name = "wasmtime-component-util"
-version = "21.0.1"
+version = "22.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7ae611f08cea620c67330925be28a96115bf01f8f393a6cbdf4856a86087134"
+checksum = "f9d2912c53d9054984b380dfbd7579f9c3681b2a73b903a56bd71a1c4f175f1e"
 
 [[package]]
 name = "wasmtime-cranelift"
-version = "21.0.1"
+version = "22.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2909406a6007e28be964067167890bca4574bd48a9ff18f1fa9f4856d89ea40"
+checksum = "a3975deafea000457ba84355c7c0fce0372937204f77026510b7b454f28a3a65"
 dependencies = [
  "anyhow",
  "cfg-if",
  "cranelift-codegen",
  "cranelift-control",
- "cranelift-entity 0.108.1",
+ "cranelift-entity 0.109.0",
  "cranelift-frontend",
  "cranelift-native",
  "cranelift-wasm",
  "gimli 0.28.1",
  "log",
- "object 0.33.0",
+ "object",
  "target-lexicon",
  "thiserror",
- "wasmparser 0.207.0",
+ "wasmparser 0.209.1",
  "wasmtime-environ",
  "wasmtime-versioned-export-macros",
 ]
 
 [[package]]
 name = "wasmtime-environ"
-version = "21.0.1"
+version = "22.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40e227f9ed2f5421473723d6c0352b5986e6e6044fde5410a274a394d726108f"
+checksum = "f444e900e848b884d8a8a2949b6f5b92af642a3e663ff8fbe78731143a55be61"
 dependencies = [
  "anyhow",
  "cpp_demangle",
- "cranelift-entity 0.108.1",
+ "cranelift-entity 0.109.0",
  "gimli 0.28.1",
  "indexmap",
  "log",
- "object 0.33.0",
+ "object",
  "postcard",
  "rustc-demangle",
  "serde",
  "serde_derive",
  "target-lexicon",
- "wasm-encoder 0.207.0",
- "wasmparser 0.207.0",
+ "wasm-encoder 0.209.1",
+ "wasmparser 0.209.1",
  "wasmprinter",
  "wasmtime-component-util",
  "wasmtime-types",
@@ -2686,9 +2678,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-fiber"
-version = "21.0.1"
+version = "22.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42edb392586d07038c1638e854382db916b6ca7845a2e6a7f8dc49e08907acdd"
+checksum = "4ded58eb2d1bf0dcd2182d0ccd7055c4b10b50d711514f1d73f61515d0fa829d"
 dependencies = [
  "anyhow",
  "cc",
@@ -2701,11 +2693,11 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit-debug"
-version = "21.0.1"
+version = "22.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95b26ef7914af0c0e3ca811bdc32f5f66fbba0fd21e1f8563350e8a7951e3598"
+checksum = "9bc54198c6720f098210a85efb3ba8c078d1de4d373cdb6778850a66ae088d11"
 dependencies = [
- "object 0.33.0",
+ "object",
  "once_cell",
  "rustix",
  "wasmtime-versioned-export-macros",
@@ -2713,9 +2705,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit-icache-coherence"
-version = "21.0.1"
+version = "22.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afe088f9b56bb353adaf837bf7e10f1c2e1676719dd5be4cac8e37f2ba1ee5bc"
+checksum = "5afe2f0499542f9a4bcfa1b55bfdda803b6ade4e7c93c6b99e0f39dba44b0a91"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -2725,28 +2717,28 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-slab"
-version = "21.0.1"
+version = "22.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ff75cafffe47b04b036385ce3710f209153525b0ed19d57b0cf44a22d446460"
+checksum = "0a7de1f2bec5bbb35d532e61c85c049dc84ae671df60492f90b954ecf21169e7"
 
 [[package]]
 name = "wasmtime-types"
-version = "21.0.1"
+version = "22.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f2fa462bfea3220711c84e2b549f147e4df89eeb49b8a2a3d89148f6cc4a8b1"
+checksum = "412463e9000e14cf6856be48628d2213c20c153e29ffc22b036980c892ea6964"
 dependencies = [
- "cranelift-entity 0.108.1",
+ "cranelift-entity 0.109.0",
  "serde",
  "serde_derive",
  "smallvec",
- "wasmparser 0.207.0",
+ "wasmparser 0.209.1",
 ]
 
 [[package]]
 name = "wasmtime-versioned-export-macros"
-version = "21.0.1"
+version = "22.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4cedc5bfef3db2a85522ee38564b47ef3b7fc7c92e94cacbce99808e63cdd47"
+checksum = "de5a9bc4f44ceeb168e9e8e3be4e0b4beb9095b468479663a9e24c667e36826f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2755,9 +2747,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi"
-version = "21.0.1"
+version = "22.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdbbe94245904d4c96c7c5f7b55bad896cc27908644efd9442063c0748b631fc"
+checksum = "8abb1301089ed8e0b4840f539cba316a73ac382090f1b25d22d8c8eed8df49c7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2786,9 +2778,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-nn"
-version = "21.0.1"
+version = "22.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4cf6f6e57b20257bd34391d86e5e63c8128432a8e5ddff489597e51456cc39a"
+checksum = "74ad60f6406604fced9fdd9693cd0d17d30e041bb2a652eb75fdab741f79c59e"
 dependencies = [
  "anyhow",
  "openvino",
@@ -2801,16 +2793,16 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-winch"
-version = "21.0.1"
+version = "22.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97b27054fed6be4f3800aba5766f7ef435d4220ce290788f021a08d4fa573108"
+checksum = "ed4db238a0241df2d15f79ad17b3a37a27f2ea6cb885894d81b42ae107544466"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
  "gimli 0.28.1",
- "object 0.33.0",
+ "object",
  "target-lexicon",
- "wasmparser 0.207.0",
+ "wasmparser 0.209.1",
  "wasmtime-cranelift",
  "wasmtime-environ",
  "winch-codegen",
@@ -2818,14 +2810,14 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wit-bindgen"
-version = "21.0.1"
+version = "22.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c936a52ce69c28de2aa3b5fb4f2dbbb2966df304f04cccb7aca4ba56d915fda0"
+checksum = "70dc077306b38288262e5ba01d4b21532a6987416cdc0aedf04bb06c22a68fdc"
 dependencies = [
  "anyhow",
  "heck 0.4.1",
  "indexmap",
- "wit-parser 0.207.0",
+ "wit-parser 0.209.1",
 ]
 
 [[package]]
@@ -2839,31 +2831,31 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "209.0.1"
+version = "211.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fffef2ff6147e4d12e972765fd75332c6a11c722571d4ab7a780d81ffc8f0a4"
+checksum = "b25506dd82d00da6b14a87436b3d52b1d264083fa79cdb72a0d1b04a8595ccaa"
 dependencies = [
  "bumpalo",
  "leb128",
  "memchr",
  "unicode-width",
- "wasm-encoder 0.209.1",
+ "wasm-encoder 0.211.1",
 ]
 
 [[package]]
 name = "wat"
-version = "1.209.1"
+version = "1.211.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42203ec0271d113f8eb1f77ebc624886530cecb35915a7f63a497131f16e4d24"
+checksum = "eb716ca6c86eecac2d82541ffc39860118fc0af9309c4f2670637bea2e1bdd7d"
 dependencies = [
- "wast 209.0.1",
+ "wast 211.0.1",
 ]
 
 [[package]]
 name = "wiggle"
-version = "21.0.1"
+version = "22.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a89ea6f74ece6d1cfbd089783006b8eb69a0219ca83cad22068f0d9fa9df3f91"
+checksum = "29830e5d01c182d24b94092c697aa7ab0ee97d22e78a2bf40ca91eae6ebca5c2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2877,9 +2869,9 @@ dependencies = [
 
 [[package]]
 name = "wiggle-generate"
-version = "21.0.1"
+version = "22.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36beda94813296ecaf0d91b7ada9da073fd41865ba339bdd3b7764e2e785b8e9"
+checksum = "557567f2793508760cd855f7659b7a0b9dc4dbc451f53f1415d6943a15311ade"
 dependencies = [
  "anyhow",
  "heck 0.4.1",
@@ -2892,9 +2884,9 @@ dependencies = [
 
 [[package]]
 name = "wiggle-macro"
-version = "21.0.1"
+version = "22.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b47d2b4442ce93106dba5d1a9c59d5f85b5732878bb3d0598d3c93c0d01b16b"
+checksum = "cc26129a8aea20b62c961d1b9ab4a3c3b56b10042ed85d004f8678af0f21ba6e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2935,9 +2927,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winch-codegen"
-version = "0.19.1"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dc69899ccb2da7daa4df31426dcfd284b104d1a85e1dae35806df0c46187f87"
+checksum = "85c6915884e731b2db0d8cf08cb64474cb69221a161675fd3c135f91febc3daa"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -2945,7 +2937,7 @@ dependencies = [
  "regalloc2",
  "smallvec",
  "target-lexicon",
- "wasmparser 0.207.0",
+ "wasmparser 0.209.1",
  "wasmtime-cranelift",
  "wasmtime-environ",
 ]
@@ -3100,9 +3092,9 @@ checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
 
 [[package]]
 name = "winnow"
-version = "0.6.9"
+version = "0.6.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86c949fede1d13936a99f14fafd3e76fd642b556dd2ce96287fbe2e0151bfac6"
+checksum = "59b5e5f6c299a3c7890b876a2a587f3115162487e704907d9b6cd29473052ba1"
 dependencies = [
  "memchr",
 ]
@@ -3138,24 +3130,6 @@ dependencies = [
 
 [[package]]
 name = "wit-parser"
-version = "0.207.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78c83dab33a9618d86cfe3563cc864deffd08c17efc5db31a3b7cd1edeffe6e1"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap",
- "log",
- "semver 1.0.23",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser 0.207.0",
-]
-
-[[package]]
-name = "wit-parser"
 version = "0.208.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "516417a730725fe3e6c9e2efc8d86697480f80496d32b24e62736950704c047c"
@@ -3170,6 +3144,24 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser 0.208.1",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.209.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e79b9e3c0b6bb589dec46317e645851e0db2734c44e2be5e251b03ff4a51269"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver 1.0.23",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser 0.209.1",
 ]
 
 [[package]]
@@ -3224,9 +3216,9 @@ dependencies = [
 
 [[package]]
 name = "zstd-sys"
-version = "2.0.10+zstd.1.5.6"
+version = "2.0.11+zstd.1.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c253a4914af5bafc8fa8c86ee400827e83cf6ec01195ec1f1ed8441bf00d65aa"
+checksum = "75652c55c0b6f3e6f12eb786fe1bc960396bf05a1eb3bf1f3691c3610ac2e6d4"
 dependencies = [
  "cc",
  "pkg-config",

--- a/lib/src/async_io.rs
+++ b/lib/src/async_io.rs
@@ -26,7 +26,11 @@ impl FastlyAsyncIo for Session {
         let select_fut = self
             .select_impl(
                 memory
-                    // TODO: wiggle only supports slices of u8 in 22.0.0
+                    // TODO: `GuestMemory::as_slice` only supports guest pointers to u8 slices in
+                    // wiggle 22.0.0, but `GuestMemory::to_vec` supports guest pointers to slices
+                    // of arbitrary types. As `GuestMemory::to_vec` will copy the contents of the
+                    // slice out of guest memory, we should switch this to `GuestMemory::as_slice`
+                    // once it is polymorphic in the element type of the slice.
                     .to_vec(handles)?
                     .into_iter()
                     .map(|i| AsyncItemHandle::from(i).into()),

--- a/lib/src/async_io.rs
+++ b/lib/src/async_io.rs
@@ -7,28 +7,28 @@ use {
     futures::{FutureExt, TryFutureExt},
     std::time::Duration,
     tokio::time::timeout,
-    wiggle::GuestPtr,
+    wiggle::{GuestMemory, GuestPtr},
 };
 
 #[wiggle::async_trait]
 impl FastlyAsyncIo for Session {
-    async fn select<'a>(
+    async fn select(
         &mut self,
-        handles: &GuestPtr<'a, [AsyncItemHandle]>,
+        memory: &mut GuestMemory<'_>,
+        handles: GuestPtr<[AsyncItemHandle]>,
         timeout_ms: u32,
     ) -> Result<u32, Error> {
-        let handles = GuestPtr::<'a, [u32]>::new(handles.mem(), handles.offset())
-            .as_slice()?
-            .ok_or(Error::SharedMemory)?;
+        let handles = handles.cast::<[u32]>();
         if handles.len() == 0 && timeout_ms == 0 {
             return Err(Error::InvalidArgument);
         }
 
         let select_fut = self
             .select_impl(
-                handles
-                    .iter()
-                    .copied()
+                memory
+                    // TODO: wiggle only supports slices of u8 in 22.0.0
+                    .to_vec(handles)?
+                    .into_iter()
                     .map(|i| AsyncItemHandle::from(i).into()),
             )
             .map_ok(|done_idx| done_idx as u32);
@@ -41,7 +41,11 @@ impl FastlyAsyncIo for Session {
                 .unwrap_or(Ok(u32::MAX))
         }
     }
-    fn is_ready(&mut self, handle: AsyncItemHandle) -> Result<u32, Error> {
+    fn is_ready(
+        &mut self,
+        _memory: &mut GuestMemory<'_>,
+        handle: AsyncItemHandle,
+    ) -> Result<u32, Error> {
         if self
             .async_item_mut(handle.into())?
             .await_ready()

--- a/lib/src/component/mod.rs
+++ b/lib/src/component/mod.rs
@@ -23,32 +23,23 @@ component::bindgen!({
 });
 
 pub fn link_host_functions(linker: &mut component::Linker<ComponentCtx>) -> anyhow::Result<()> {
-    // A utility function to add the types needed for `add_to_linker_get_host`.
-    fn project_wasi_view(
-        t: &mut impl wasmtime_wasi::WasiView,
-    ) -> &mut impl wasmtime_wasi::WasiView {
-        t
+    fn wrap(ctx: &mut ComponentCtx) -> wasmtime_wasi::WasiImpl<&mut ComponentCtx> {
+        wasmtime_wasi::WasiImpl(ctx)
     }
 
-    wasmtime_wasi::bindings::clocks::wall_clock::add_to_linker_get_host(linker, project_wasi_view)?;
-    wasmtime_wasi::bindings::clocks::monotonic_clock::add_to_linker_get_host(
-        linker,
-        project_wasi_view,
-    )?;
-    wasmtime_wasi::bindings::random::random::add_to_linker_get_host(linker, project_wasi_view)?;
-    wasmtime_wasi::bindings::filesystem::types::add_to_linker_get_host(linker, project_wasi_view)?;
-    wasmtime_wasi::bindings::filesystem::preopens::add_to_linker_get_host(
-        linker,
-        project_wasi_view,
-    )?;
-    wasmtime_wasi::bindings::io::error::add_to_linker_get_host(linker, project_wasi_view)?;
-    wasmtime_wasi::bindings::io::streams::add_to_linker_get_host(linker, project_wasi_view)?;
-    wasmtime_wasi::bindings::io::poll::add_to_linker_get_host(linker, project_wasi_view)?;
-    wasmtime_wasi::bindings::cli::environment::add_to_linker_get_host(linker, project_wasi_view)?;
-    wasmtime_wasi::bindings::cli::exit::add_to_linker_get_host(linker, project_wasi_view)?;
-    wasmtime_wasi::bindings::cli::stdin::add_to_linker_get_host(linker, project_wasi_view)?;
-    wasmtime_wasi::bindings::cli::stdout::add_to_linker_get_host(linker, project_wasi_view)?;
-    wasmtime_wasi::bindings::cli::stderr::add_to_linker_get_host(linker, project_wasi_view)?;
+    wasmtime_wasi::bindings::clocks::wall_clock::add_to_linker_get_host(linker, wrap)?;
+    wasmtime_wasi::bindings::clocks::monotonic_clock::add_to_linker_get_host(linker, wrap)?;
+    wasmtime_wasi::bindings::random::random::add_to_linker_get_host(linker, wrap)?;
+    wasmtime_wasi::bindings::filesystem::types::add_to_linker_get_host(linker, wrap)?;
+    wasmtime_wasi::bindings::filesystem::preopens::add_to_linker_get_host(linker, wrap)?;
+    wasmtime_wasi::bindings::io::error::add_to_linker_get_host(linker, wrap)?;
+    wasmtime_wasi::bindings::io::streams::add_to_linker_get_host(linker, wrap)?;
+    wasmtime_wasi::bindings::io::poll::add_to_linker_get_host(linker, wrap)?;
+    wasmtime_wasi::bindings::cli::environment::add_to_linker_get_host(linker, wrap)?;
+    wasmtime_wasi::bindings::cli::exit::add_to_linker_get_host(linker, wrap)?;
+    wasmtime_wasi::bindings::cli::stdin::add_to_linker_get_host(linker, wrap)?;
+    wasmtime_wasi::bindings::cli::stdout::add_to_linker_get_host(linker, wrap)?;
+    wasmtime_wasi::bindings::cli::stderr::add_to_linker_get_host(linker, wrap)?;
 
     fastly::api::async_io::add_to_linker(linker, |x| x.session())?;
     fastly::api::backend::add_to_linker(linker, |x| x.session())?;

--- a/lib/src/wiggle_abi/body_impl.rs
+++ b/lib/src/wiggle_abi/body_impl.rs
@@ -18,12 +18,17 @@ use {
     },
     http_body::Body as HttpBody,
     std::convert::TryInto,
-    wiggle::GuestPtr,
+    wiggle::{GuestMemory, GuestPtr},
 };
 
 #[wiggle::async_trait]
 impl FastlyHttpBody for Session {
-    async fn append(&mut self, dest: BodyHandle, src: BodyHandle) -> Result<(), Error> {
+    async fn append(
+        &mut self,
+        _memory: &mut GuestMemory<'_>,
+        dest: BodyHandle,
+        src: BodyHandle,
+    ) -> Result<(), Error> {
         // Take the `src` body out of the session, and get a mutable reference
         // to the `dest` body we will append to.
         let mut src = self.take_body(src)?;
@@ -43,14 +48,15 @@ impl FastlyHttpBody for Session {
         Ok(())
     }
 
-    fn new(&mut self) -> Result<BodyHandle, Error> {
+    fn new(&mut self, _memory: &mut GuestMemory<'_>) -> Result<BodyHandle, Error> {
         Ok(self.insert_body(Body::empty()))
     }
 
-    async fn read<'a>(
+    async fn read(
         &mut self,
+        memory: &mut GuestMemory<'_>,
         body_handle: BodyHandle,
-        buf: &GuestPtr<'a, u8>,
+        buf: GuestPtr<u8>,
         buf_len: u32,
     ) -> Result<u32, Error> {
         // only normal bodies (not streaming bodies) can be read from
@@ -63,8 +69,7 @@ impl FastlyHttpBody for Session {
             let copy_len = std::cmp::min(buf_len as usize, chunk.len());
             let extra_bytes = chunk.split_off(copy_len);
             // `chunk.len()` is now the smaller of (1) the destination buffer and (2) the available data.
-            buf.as_array(u32::try_from(copy_len).unwrap())
-                .copy_from_slice(&chunk)?;
+            memory.copy_from_slice(&chunk, buf.as_array(u32::try_from(copy_len).unwrap()))?;
             // if there are leftover bytes, put them back at the front of the body
             if !extra_bytes.is_empty() {
                 body.push_front(extra_bytes);
@@ -76,14 +81,15 @@ impl FastlyHttpBody for Session {
         }
     }
 
-    async fn write<'a>(
+    async fn write(
         &mut self,
+        memory: &mut GuestMemory<'_>,
         body_handle: BodyHandle,
-        buf: &GuestPtr<'a, [u8]>,
+        buf: GuestPtr<[u8]>,
         end: BodyWriteEnd,
     ) -> Result<u32, Error> {
         // Validate the body handle and the buffer.
-        let buf = &buf.as_slice()?.ok_or(Error::SharedMemory)?[..];
+        let buf = memory.as_slice(buf)?.ok_or(Error::SharedMemory)?;
 
         // Push the buffer onto the front or back of the body based on the `BodyWriteEnd` flag.
         match end {
@@ -108,7 +114,11 @@ impl FastlyHttpBody for Session {
             .expect("the buffer length must fit into a u32"))
     }
 
-    fn close(&mut self, body_handle: BodyHandle) -> Result<(), Error> {
+    fn close(
+        &mut self,
+        _memory: &mut GuestMemory<'_>,
+        body_handle: BodyHandle,
+    ) -> Result<(), Error> {
         // Drop the body and pass up an error if the handle does not exist
         if self.is_streaming_body(body_handle) {
             // Make sure a streaming body gets a `finish` message
@@ -118,39 +128,46 @@ impl FastlyHttpBody for Session {
         }
     }
 
-    fn abandon(&mut self, body_handle: BodyHandle) -> Result<(), Error> {
+    fn abandon(
+        &mut self,
+        _memory: &mut GuestMemory<'_>,
+        body_handle: BodyHandle,
+    ) -> Result<(), Error> {
         // Drop the body without a `finish` message
         Ok(self.drop_body(body_handle)?)
     }
 
     fn trailer_append(
         &mut self,
+        memory: &mut GuestMemory<'_>,
         body_handle: BodyHandle,
-        name: &GuestPtr<[u8]>,
-        value: &GuestPtr<[u8]>,
+        name: GuestPtr<[u8]>,
+        value: GuestPtr<[u8]>,
     ) -> Result<(), Error> {
         // Appending trailers is always allowed for bodies and streaming bodies.
         if self.is_streaming_body(body_handle) {
             let body = self.streaming_body_mut(body_handle)?;
-            let name = HeaderName::from_bytes(&name.as_slice()?.ok_or(Error::SharedMemory)?)?;
-            let value = HeaderValue::from_bytes(&value.as_slice()?.ok_or(Error::SharedMemory)?)?;
+            let name = HeaderName::from_bytes(memory.as_slice(name)?.ok_or(Error::SharedMemory)?)?;
+            let value =
+                HeaderValue::from_bytes(memory.as_slice(value)?.ok_or(Error::SharedMemory)?)?;
             body.append_trailer(name, value);
             Ok(())
         } else {
             let body = self.body_mut(body_handle)?;
             let trailers = &mut body.trailers;
-            HttpHeaders::append(trailers, name, value)
+            HttpHeaders::append(trailers, memory, name, value)
         }
     }
 
     fn trailer_names_get<'a>(
         &mut self,
+        memory: &mut GuestMemory<'_>,
         body_handle: BodyHandle,
-        buf: &GuestPtr<u8>,
+        buf: GuestPtr<u8>,
         buf_len: u32,
         cursor: MultiValueCursor,
-        ending_cursor_out: &GuestPtr<MultiValueCursorResult>,
-        nwritten_out: &GuestPtr<u32>,
+        ending_cursor_out: GuestPtr<MultiValueCursorResult>,
+        nwritten_out: GuestPtr<u32>,
     ) -> Result<(), Error> {
         // Read operations are not allowed on streaming bodies.
         if self.is_streaming_body(body_handle) {
@@ -161,7 +178,8 @@ impl FastlyHttpBody for Session {
         if body.trailers_ready {
             let trailers = &body.trailers;
             return multi_value_result!(
-                trailers.names_get(buf, buf_len, cursor, nwritten_out),
+                memory,
+                trailers.names_get(memory, buf, buf_len, cursor, nwritten_out),
                 ending_cursor_out
             );
         }
@@ -170,11 +188,12 @@ impl FastlyHttpBody for Session {
 
     fn trailer_value_get<'a>(
         &mut self,
+        memory: &mut GuestMemory<'_>,
         body_handle: BodyHandle,
-        name: &GuestPtr<[u8]>,
-        value: &GuestPtr<u8>,
+        name: GuestPtr<[u8]>,
+        value: GuestPtr<u8>,
         value_max_len: u32,
-        nwritten_out: &GuestPtr<u32>,
+        nwritten_out: GuestPtr<u32>,
     ) -> Result<(), Error> {
         // Read operations are not allowed on streaming bodies.
         if self.is_streaming_body(body_handle) {
@@ -184,20 +203,21 @@ impl FastlyHttpBody for Session {
         let body = &mut self.body_mut(body_handle)?;
         if body.trailers_ready {
             let trailers = &mut body.trailers;
-            return trailers.value_get(name, value, value_max_len, nwritten_out);
+            return trailers.value_get(memory, name, value, value_max_len, nwritten_out);
         }
         Err(Error::Again)
     }
 
     fn trailer_values_get<'a>(
         &mut self,
+        memory: &mut GuestMemory<'_>,
         body_handle: BodyHandle,
-        name: &GuestPtr<[u8]>,
-        buf: &GuestPtr<u8>,
+        name: GuestPtr<[u8]>,
+        buf: GuestPtr<u8>,
         buf_len: u32,
         cursor: MultiValueCursor,
-        ending_cursor_out: &GuestPtr<MultiValueCursorResult>,
-        nwritten_out: &GuestPtr<u32>,
+        ending_cursor_out: GuestPtr<MultiValueCursorResult>,
+        nwritten_out: GuestPtr<u32>,
     ) -> Result<(), Error> {
         // Read operations are not allowed on streaming bodies.
         if self.is_streaming_body(body_handle) {
@@ -208,14 +228,19 @@ impl FastlyHttpBody for Session {
         if body.trailers_ready {
             let trailers = &mut body.trailers;
             return multi_value_result!(
-                trailers.values_get(name, buf, buf_len, cursor, nwritten_out),
+                memory,
+                trailers.values_get(memory, name, buf, buf_len, cursor, nwritten_out),
                 ending_cursor_out
             );
         }
         Err(Error::Again)
     }
 
-    fn known_length(&mut self, body_handle: BodyHandle) -> Result<BodyLength, Error> {
+    fn known_length(
+        &mut self,
+        _memory: &mut GuestMemory<'_>,
+        body_handle: BodyHandle,
+    ) -> Result<BodyLength, Error> {
         if self.is_streaming_body(body_handle) {
             Err(Error::ValueAbsent)
         } else if let Some(len) = self.body_mut(body_handle)?.len() {

--- a/lib/src/wiggle_abi/cache.rs
+++ b/lib/src/wiggle_abi/cache.rs
@@ -7,42 +7,47 @@ use super::{types, Error};
 impl FastlyCache for Session {
     fn lookup<'a>(
         &mut self,
-        cache_key: &wiggle::GuestPtr<'a, [u8]>,
+        memory: &mut wiggle::GuestMemory<'_>,
+        cache_key: wiggle::GuestPtr<[u8]>,
         options_mask: types::CacheLookupOptionsMask,
-        options: &wiggle::GuestPtr<'a, types::CacheLookupOptions>,
+        options: wiggle::GuestPtr<types::CacheLookupOptions>,
     ) -> Result<types::CacheHandle, Error> {
         Err(Error::NotAvailable("Cache API primitives"))
     }
 
     fn insert<'a>(
         &mut self,
-        cache_key: &wiggle::GuestPtr<'a, [u8]>,
+        memory: &mut wiggle::GuestMemory<'_>,
+        cache_key: wiggle::GuestPtr<[u8]>,
         options_mask: types::CacheWriteOptionsMask,
-        options: &wiggle::GuestPtr<'a, types::CacheWriteOptions<'a>>,
+        options: wiggle::GuestPtr<types::CacheWriteOptions>,
     ) -> Result<types::BodyHandle, Error> {
         Err(Error::NotAvailable("Cache API primitives"))
     }
 
     fn transaction_lookup<'a>(
         &mut self,
-        cache_key: &wiggle::GuestPtr<'a, [u8]>,
+        memory: &mut wiggle::GuestMemory<'_>,
+        cache_key: wiggle::GuestPtr<[u8]>,
         options_mask: types::CacheLookupOptionsMask,
-        options: &wiggle::GuestPtr<'a, types::CacheLookupOptions>,
+        options: wiggle::GuestPtr<types::CacheLookupOptions>,
     ) -> Result<types::CacheHandle, Error> {
         Err(Error::NotAvailable("Cache API primitives"))
     }
 
     fn transaction_lookup_async<'a>(
         &mut self,
-        cache_key: &wiggle::GuestPtr<'a, [u8]>,
+        memory: &mut wiggle::GuestMemory<'_>,
+        cache_key: wiggle::GuestPtr<[u8]>,
         options_mask: types::CacheLookupOptionsMask,
-        options: &wiggle::GuestPtr<'a, types::CacheLookupOptions>,
+        options: wiggle::GuestPtr<types::CacheLookupOptions>,
     ) -> Result<types::CacheBusyHandle, Error> {
         Err(Error::NotAvailable("Cache API primitives"))
     }
 
     fn cache_busy_handle_wait(
         &mut self,
+        memory: &mut wiggle::GuestMemory<'_>,
         handle: types::CacheBusyHandle,
     ) -> Result<types::CacheHandle, Error> {
         Err(Error::NotAvailable("Cache API primitives"))
@@ -50,59 +55,80 @@ impl FastlyCache for Session {
 
     fn transaction_insert<'a>(
         &mut self,
+        memory: &mut wiggle::GuestMemory<'_>,
         handle: types::CacheHandle,
         options_mask: types::CacheWriteOptionsMask,
-        options: &wiggle::GuestPtr<'a, types::CacheWriteOptions<'a>>,
+        options: wiggle::GuestPtr<types::CacheWriteOptions>,
     ) -> Result<types::BodyHandle, Error> {
         Err(Error::NotAvailable("Cache API primitives"))
     }
 
     fn transaction_insert_and_stream_back<'a>(
         &mut self,
+        memory: &mut wiggle::GuestMemory<'_>,
         handle: types::CacheHandle,
         options_mask: types::CacheWriteOptionsMask,
-        options: &wiggle::GuestPtr<'a, types::CacheWriteOptions<'a>>,
+        options: wiggle::GuestPtr<types::CacheWriteOptions>,
     ) -> Result<(types::BodyHandle, types::CacheHandle), Error> {
         Err(Error::NotAvailable("Cache API primitives"))
     }
 
     fn transaction_update<'a>(
         &mut self,
+        memory: &mut wiggle::GuestMemory<'_>,
         handle: types::CacheHandle,
         options_mask: types::CacheWriteOptionsMask,
-        options: &wiggle::GuestPtr<'a, types::CacheWriteOptions<'a>>,
+        options: wiggle::GuestPtr<types::CacheWriteOptions>,
     ) -> Result<(), Error> {
         Err(Error::NotAvailable("Cache API primitives"))
     }
 
-    fn transaction_cancel(&mut self, handle: types::CacheHandle) -> Result<(), Error> {
+    fn transaction_cancel(
+        &mut self,
+        memory: &mut wiggle::GuestMemory<'_>,
+        handle: types::CacheHandle,
+    ) -> Result<(), Error> {
         Err(Error::NotAvailable("Cache API primitives"))
     }
 
-    fn close_busy(&mut self, handle: types::CacheBusyHandle) -> Result<(), Error> {
+    fn close_busy(
+        &mut self,
+        memory: &mut wiggle::GuestMemory<'_>,
+        handle: types::CacheBusyHandle,
+    ) -> Result<(), Error> {
         Err(Error::NotAvailable("Cache API primitives"))
     }
 
-    fn close(&mut self, handle: types::CacheHandle) -> Result<(), Error> {
+    fn close(
+        &mut self,
+        memory: &mut wiggle::GuestMemory<'_>,
+        handle: types::CacheHandle,
+    ) -> Result<(), Error> {
         Err(Error::NotAvailable("Cache API primitives"))
     }
 
-    fn get_state(&mut self, handle: types::CacheHandle) -> Result<types::CacheLookupState, Error> {
+    fn get_state(
+        &mut self,
+        memory: &mut wiggle::GuestMemory<'_>,
+        handle: types::CacheHandle,
+    ) -> Result<types::CacheLookupState, Error> {
         Err(Error::NotAvailable("Cache API primitives"))
     }
 
     fn get_user_metadata<'a>(
         &mut self,
+        memory: &mut wiggle::GuestMemory<'_>,
         handle: types::CacheHandle,
-        user_metadata_out_ptr: &wiggle::GuestPtr<'a, u8>,
+        user_metadata_out_ptr: wiggle::GuestPtr<u8>,
         user_metadata_out_len: u32,
-        nwritten_out: &wiggle::GuestPtr<'a, u32>,
+        nwritten_out: wiggle::GuestPtr<u32>,
     ) -> Result<(), Error> {
         Err(Error::NotAvailable("Cache API primitives"))
     }
 
     fn get_body(
         &mut self,
+        memory: &mut wiggle::GuestMemory<'_>,
         handle: types::CacheHandle,
         options_mask: types::CacheGetBodyOptionsMask,
         options: &types::CacheGetBodyOptions,
@@ -112,6 +138,7 @@ impl FastlyCache for Session {
 
     fn get_length(
         &mut self,
+        memory: &mut wiggle::GuestMemory<'_>,
         handle: types::CacheHandle,
     ) -> Result<types::CacheObjectLength, Error> {
         Err(Error::NotAvailable("Cache API primitives"))
@@ -119,6 +146,7 @@ impl FastlyCache for Session {
 
     fn get_max_age_ns(
         &mut self,
+        memory: &mut wiggle::GuestMemory<'_>,
         handle: types::CacheHandle,
     ) -> Result<types::CacheDurationNs, Error> {
         Err(Error::NotAvailable("Cache API primitives"))
@@ -126,16 +154,25 @@ impl FastlyCache for Session {
 
     fn get_stale_while_revalidate_ns(
         &mut self,
+        memory: &mut wiggle::GuestMemory<'_>,
         handle: types::CacheHandle,
     ) -> Result<types::CacheDurationNs, Error> {
         Err(Error::NotAvailable("Cache API primitives"))
     }
 
-    fn get_age_ns(&mut self, handle: types::CacheHandle) -> Result<types::CacheDurationNs, Error> {
+    fn get_age_ns(
+        &mut self,
+        memory: &mut wiggle::GuestMemory<'_>,
+        handle: types::CacheHandle,
+    ) -> Result<types::CacheDurationNs, Error> {
         Err(Error::NotAvailable("Cache API primitives"))
     }
 
-    fn get_hits(&mut self, handle: types::CacheHandle) -> Result<types::CacheHitCount, Error> {
+    fn get_hits(
+        &mut self,
+        memory: &mut wiggle::GuestMemory<'_>,
+        handle: types::CacheHandle,
+    ) -> Result<types::CacheHitCount, Error> {
         Err(Error::NotAvailable("Cache API primitives"))
     }
 }

--- a/lib/src/wiggle_abi/config_store.rs
+++ b/lib/src/wiggle_abi/config_store.rs
@@ -4,23 +4,28 @@ use super::{
     types::{ConfigStoreHandle, DictionaryHandle},
 };
 use crate::{session::Session, Error};
-use wiggle::GuestPtr;
+use wiggle::{GuestMemory, GuestPtr};
 
 impl FastlyConfigStore for Session {
-    fn open(&mut self, name: &GuestPtr<str>) -> Result<ConfigStoreHandle, Error> {
-        let dict_answer = <Self as FastlyDictionary>::open(self, name)?;
+    fn open(
+        &mut self,
+        memory: &mut GuestMemory<'_>,
+        name: GuestPtr<str>,
+    ) -> Result<ConfigStoreHandle, Error> {
+        let dict_answer = <Self as FastlyDictionary>::open(self, memory, name)?;
         Ok(ConfigStoreHandle::from(unsafe { dict_answer.inner() }))
     }
 
     fn get(
         &mut self,
+        memory: &mut GuestMemory<'_>,
         config_store: ConfigStoreHandle,
-        key: &GuestPtr<str>,
-        buf: &GuestPtr<u8>,
+        key: GuestPtr<str>,
+        buf: GuestPtr<u8>,
         buf_len: u32,
-        nwritten_out: &GuestPtr<u32>,
+        nwritten_out: GuestPtr<u32>,
     ) -> Result<(), Error> {
         let dict_handle = DictionaryHandle::from(unsafe { config_store.inner() });
-        <Self as FastlyDictionary>::get(self, dict_handle, key, buf, buf_len, nwritten_out)
+        <Self as FastlyDictionary>::get(self, memory, dict_handle, key, buf, buf_len, nwritten_out)
     }
 }

--- a/lib/src/wiggle_abi/device_detection_impl.rs
+++ b/lib/src/wiggle_abi/device_detection_impl.rs
@@ -3,7 +3,7 @@
 use crate::error::Error;
 use crate::wiggle_abi::{fastly_device_detection::FastlyDeviceDetection, FastlyStatus, Session};
 use std::convert::TryFrom;
-use wiggle::GuestPtr;
+use wiggle::{GuestMemory, GuestPtr};
 
 #[derive(Debug, thiserror::Error)]
 pub enum DeviceDetectionError {
@@ -25,15 +25,15 @@ impl DeviceDetectionError {
 impl FastlyDeviceDetection for Session {
     fn lookup(
         &mut self,
-        user_agent: &GuestPtr<str>,
-        buf: &GuestPtr<u8>,
+        memory: &mut GuestMemory<'_>,
+        user_agent: GuestPtr<str>,
+        buf: GuestPtr<u8>,
         buf_len: u32,
-        nwritten_out: &GuestPtr<u32>,
+        nwritten_out: GuestPtr<u32>,
     ) -> Result<(), Error> {
         let result = {
-            let user_agent_slice = user_agent
-                .as_bytes()
-                .as_slice()?
+            let user_agent_slice = memory
+                .as_slice(user_agent.as_bytes())?
                 .ok_or(Error::SharedMemory)?;
             let user_agent_str = std::str::from_utf8(&user_agent_slice)?;
 
@@ -44,7 +44,7 @@ impl FastlyDeviceDetection for Session {
         };
 
         if result.len() > buf_len as usize {
-            nwritten_out.write(u32::try_from(result.len()).unwrap_or(0))?;
+            memory.write(nwritten_out, u32::try_from(result.len()).unwrap_or(0))?;
             return Err(Error::BufferLengthError {
                 buf: "device_detection_lookup",
                 len: "device_detection_lookup_max_len",
@@ -54,10 +54,9 @@ impl FastlyDeviceDetection for Session {
         let result_len =
             u32::try_from(result.len()).expect("smaller than buf_len means it must fit");
 
-        buf.as_array(result_len)
-            .copy_from_slice(result.as_bytes())?;
+        memory.copy_from_slice(result.as_bytes(), buf.as_array(result_len))?;
 
-        nwritten_out.write(result_len)?;
+        memory.write(nwritten_out, result_len)?;
         Ok(())
     }
 }

--- a/lib/src/wiggle_abi/erl_impl.rs
+++ b/lib/src/wiggle_abi/erl_impl.rs
@@ -1,16 +1,20 @@
 use crate::{
-    error::Error, session::Session, wiggle_abi::fastly_erl::FastlyErl, wiggle_abi::GuestPtr,
+    error::Error,
+    session::Session,
+    wiggle_abi::fastly_erl::FastlyErl,
+    wiggle_abi::{GuestMemory, GuestPtr},
 };
 
 impl FastlyErl for Session {
     fn check_rate(
         &mut self,
-        _rc: &GuestPtr<str>,
-        _entry: &GuestPtr<str>,
+        _memory: &mut GuestMemory<'_>,
+        _rc: GuestPtr<str>,
+        _entry: GuestPtr<str>,
         _delta: u32,
         _window: u32,
         _limit: u32,
-        _pb: &GuestPtr<str>,
+        _pb: GuestPtr<str>,
         _ttl: u32,
     ) -> std::result::Result<u32, Error> {
         Ok(0)
@@ -18,8 +22,9 @@ impl FastlyErl for Session {
 
     fn ratecounter_increment(
         &mut self,
-        _rc: &GuestPtr<str>,
-        _entry: &GuestPtr<str>,
+        _memory: &mut GuestMemory<'_>,
+        _rc: GuestPtr<str>,
+        _entry: GuestPtr<str>,
         _delta: u32,
     ) -> std::result::Result<(), Error> {
         Ok(())
@@ -27,8 +32,9 @@ impl FastlyErl for Session {
 
     fn ratecounter_lookup_rate(
         &mut self,
-        _rc: &GuestPtr<str>,
-        _entry: &GuestPtr<str>,
+        _memory: &mut GuestMemory<'_>,
+        _rc: GuestPtr<str>,
+        _entry: GuestPtr<str>,
         _window: u32,
     ) -> std::result::Result<u32, Error> {
         Ok(0)
@@ -36,8 +42,9 @@ impl FastlyErl for Session {
 
     fn ratecounter_lookup_count(
         &mut self,
-        _rc: &GuestPtr<str>,
-        _entry: &GuestPtr<str>,
+        _memory: &mut GuestMemory<'_>,
+        _rc: GuestPtr<str>,
+        _entry: GuestPtr<str>,
         _duration: u32,
     ) -> std::result::Result<u32, Error> {
         Ok(0)
@@ -45,8 +52,9 @@ impl FastlyErl for Session {
 
     fn penaltybox_add(
         &mut self,
-        _pb: &GuestPtr<str>,
-        _entry: &GuestPtr<str>,
+        _memory: &mut GuestMemory<'_>,
+        _pb: GuestPtr<str>,
+        _entry: GuestPtr<str>,
         _ttl: u32,
     ) -> std::result::Result<(), Error> {
         Ok(())
@@ -54,8 +62,9 @@ impl FastlyErl for Session {
 
     fn penaltybox_has(
         &mut self,
-        _pb: &GuestPtr<str>,
-        _entry: &GuestPtr<str>,
+        _memory: &mut GuestMemory<'_>,
+        _pb: GuestPtr<str>,
+        _entry: GuestPtr<str>,
     ) -> std::result::Result<u32, Error> {
         Ok(0)
     }

--- a/lib/src/wiggle_abi/fastly_purge_impl.rs
+++ b/lib/src/wiggle_abi/fastly_purge_impl.rs
@@ -3,16 +3,16 @@
 use {
     super::types::{PurgeOptions, PurgeOptionsMask},
     crate::{error::Error, session::Session, wiggle_abi::fastly_purge::FastlyPurge},
-    wiggle::GuestPtr,
+    wiggle::{GuestMemory, GuestPtr},
 };
 
 impl FastlyPurge for Session {
-    #[allow(unused_variables)] // FIXME FDE 2022-09-26: Remove this directive once implemented.
-    fn purge_surrogate_key<'a>(
+    fn purge_surrogate_key(
         &mut self,
-        surrogate_key: &GuestPtr<'a, str>,
-        options_mask: PurgeOptionsMask,
-        options: &GuestPtr<'a, PurgeOptions<'a>>,
+        _memory: &mut GuestMemory<'_>,
+        _surrogate_key: GuestPtr<str>,
+        _options_mask: PurgeOptionsMask,
+        _options: GuestPtr<PurgeOptions>,
     ) -> Result<(), Error> {
         Err(Error::NotAvailable("FastlyPurge"))
     }

--- a/lib/src/wiggle_abi/headers.rs
+++ b/lib/src/wiggle_abi/headers.rs
@@ -1,7 +1,7 @@
 use {
     crate::{error::Error, wiggle_abi::types, wiggle_abi::MultiValueWriter},
     http::{header::HeaderName, HeaderMap, HeaderValue},
-    wiggle::GuestPtr,
+    wiggle::{GuestMemory, GuestPtr},
 };
 
 /// This constant reflects a similar constant within Hyper, which will panic
@@ -11,66 +11,86 @@ pub const MAX_HEADER_NAME_LEN: u32 = (1 << 16) - 1;
 pub(crate) trait HttpHeaders {
     fn names_get(
         &self,
-        buf: &GuestPtr<u8>,
+        memory: &mut GuestMemory<'_>,
+        buf: GuestPtr<u8>,
         buf_len: u32,
         cursor: types::MultiValueCursor,
-        nwritten_out: &GuestPtr<u32>,
+        nwritten_out: GuestPtr<u32>,
     ) -> Result<types::MultiValueCursorResult, Error>;
 
     fn value_get(
         &self,
-        name: &GuestPtr<[u8]>,
-        value: &GuestPtr<u8>,
+        memory: &mut GuestMemory<'_>,
+        name: GuestPtr<[u8]>,
+        value: GuestPtr<u8>,
         value_max_len: u32,
-        nwritten_out: &GuestPtr<u32>,
+        nwritten_out: GuestPtr<u32>,
     ) -> Result<(), Error>;
 
     fn values_get(
         &self,
-        name: &GuestPtr<[u8]>,
-        buf: &GuestPtr<u8>,
+        memory: &mut GuestMemory<'_>,
+        name: GuestPtr<[u8]>,
+        buf: GuestPtr<u8>,
         buf_len: u32,
         cursor: types::MultiValueCursor,
-        nwritten_out: &GuestPtr<u32>,
+        nwritten_out: GuestPtr<u32>,
     ) -> Result<types::MultiValueCursorResult, Error>;
 
-    fn values_set(&mut self, name: &GuestPtr<[u8]>, values: &GuestPtr<[u8]>) -> Result<(), Error>;
+    fn values_set(
+        &mut self,
+        memory: &GuestMemory<'_>,
+        name: GuestPtr<[u8]>,
+        values: GuestPtr<[u8]>,
+    ) -> Result<(), Error>;
 
-    fn insert(&mut self, name: &GuestPtr<[u8]>, value: &GuestPtr<[u8]>) -> Result<(), Error>;
+    fn insert(
+        &mut self,
+        memory: &GuestMemory<'_>,
+        name: GuestPtr<[u8]>,
+        value: GuestPtr<[u8]>,
+    ) -> Result<(), Error>;
 
-    fn append(&mut self, name: &GuestPtr<[u8]>, value: &GuestPtr<[u8]>) -> Result<(), Error>;
+    fn append(
+        &mut self,
+        memory: &GuestMemory<'_>,
+        name: GuestPtr<[u8]>,
+        value: GuestPtr<[u8]>,
+    ) -> Result<(), Error>;
 
-    fn remove(&mut self, name: &GuestPtr<[u8]>) -> Result<(), Error>;
+    fn remove(&mut self, memory: &GuestMemory<'_>, name: GuestPtr<[u8]>) -> Result<(), Error>;
 }
 
 impl HttpHeaders for HeaderMap<HeaderValue> {
     fn names_get(
         &self,
-        buf: &GuestPtr<u8>,
+        memory: &mut GuestMemory<'_>,
+        buf: GuestPtr<u8>,
         buf_len: u32,
         cursor: types::MultiValueCursor,
-        nwritten_out: &GuestPtr<u32>,
+        nwritten_out: GuestPtr<u32>,
     ) -> Result<types::MultiValueCursorResult, Error> {
         // order consistency: "The iteration order is arbitrary, but consistent across platforms for the
         // same crate version."
         let mut names_iter = self.keys();
         // Write the values to guest memory
-        names_iter.write_values(b'\0', &buf.as_array(buf_len), cursor, nwritten_out)
+        names_iter.write_values(memory, b'\0', buf.as_array(buf_len), cursor, nwritten_out)
     }
 
     fn value_get(
         &self,
-        name: &GuestPtr<[u8]>,
-        value_ptr: &GuestPtr<u8>,
+        memory: &mut GuestMemory<'_>,
+        name: GuestPtr<[u8]>,
+        value_ptr: GuestPtr<u8>,
         value_max_len: u32,
-        nwritten_out: &GuestPtr<u32>,
+        nwritten_out: GuestPtr<u32>,
     ) -> Result<(), Error> {
         if name.len() > MAX_HEADER_NAME_LEN {
             return Err(Error::InvalidArgument);
         }
 
         let value = {
-            let name = HeaderName::from_bytes(&name.as_slice()?.ok_or(Error::SharedMemory)?)?;
+            let name = HeaderName::from_bytes(memory.as_slice(name)?.ok_or(Error::SharedMemory)?)?;
             self.get(&name).ok_or(Error::InvalidArgument)?
         };
 
@@ -78,7 +98,7 @@ impl HttpHeaders for HeaderMap<HeaderValue> {
         if value_bytes.len() > value_max_len as usize {
             // Write out the number of bytes necessary to fit this header value, or zero on overflow
             // to signal an error condition.
-            nwritten_out.write(value_bytes.len().try_into().unwrap_or(0))?;
+            memory.write(nwritten_out, value_bytes.len().try_into().unwrap_or(0))?;
             return Err(Error::BufferLengthError {
                 buf: "value",
                 len: "value_max_len",
@@ -86,40 +106,46 @@ impl HttpHeaders for HeaderMap<HeaderValue> {
         }
         let value_len =
             u32::try_from(value_bytes.len()).expect("smaller than value_max_len means it must fit");
-        value_ptr.as_array(value_len).copy_from_slice(value_bytes)?;
-        nwritten_out.write(value_len)?;
+        memory.copy_from_slice(value_bytes, value_ptr.as_array(value_len))?;
+        memory.write(nwritten_out, value_len)?;
 
         Ok(())
     }
 
     fn values_get(
         &self,
-        name: &GuestPtr<[u8]>,
-        buf: &GuestPtr<u8>,
+        memory: &mut GuestMemory<'_>,
+        name: GuestPtr<[u8]>,
+        buf: GuestPtr<u8>,
         buf_len: u32,
         cursor: types::MultiValueCursor,
-        nwritten_out: &GuestPtr<u32>,
+        nwritten_out: GuestPtr<u32>,
     ) -> Result<types::MultiValueCursorResult, Error> {
         if name.len() > MAX_HEADER_NAME_LEN {
             return Err(Error::InvalidArgument);
         }
 
         let mut values_iter = {
-            let name = HeaderName::from_bytes(&name.as_slice()?.ok_or(Error::SharedMemory)?)?;
+            let name = HeaderName::from_bytes(memory.as_slice(name)?.ok_or(Error::SharedMemory)?)?;
             self.get_all(&name).iter()
         };
 
-        values_iter.write_values(b'\0', &buf.as_array(buf_len), cursor, nwritten_out)
+        values_iter.write_values(memory, b'\0', buf.as_array(buf_len), cursor, nwritten_out)
     }
 
-    fn values_set(&mut self, name: &GuestPtr<[u8]>, values: &GuestPtr<[u8]>) -> Result<(), Error> {
+    fn values_set(
+        &mut self,
+        memory: &GuestMemory<'_>,
+        name: GuestPtr<[u8]>,
+        values: GuestPtr<[u8]>,
+    ) -> Result<(), Error> {
         if name.len() > MAX_HEADER_NAME_LEN {
             return Err(Error::InvalidArgument);
         }
 
-        let name = HeaderName::from_bytes(&name.as_slice()?.ok_or(Error::SharedMemory)?)?;
+        let name = HeaderName::from_bytes(memory.as_slice(name)?.ok_or(Error::SharedMemory)?)?;
         let values = {
-            let values_bytes = values.as_slice()?.ok_or(Error::SharedMemory)?;
+            let values_bytes = memory.as_slice(values)?.ok_or(Error::SharedMemory)?;
             // split slice along nul bytes
             let mut iter = values_bytes.split(|b| *b == 0);
             // drop the empty item at the end
@@ -140,34 +166,44 @@ impl HttpHeaders for HeaderMap<HeaderValue> {
         Ok(())
     }
 
-    fn insert(&mut self, name: &GuestPtr<[u8]>, value: &GuestPtr<[u8]>) -> Result<(), Error> {
+    fn insert(
+        &mut self,
+        memory: &GuestMemory<'_>,
+        name: GuestPtr<[u8]>,
+        value: GuestPtr<[u8]>,
+    ) -> Result<(), Error> {
         if name.len() > MAX_HEADER_NAME_LEN {
             return Err(Error::InvalidArgument);
         }
 
-        let name = HeaderName::from_bytes(&name.as_slice()?.ok_or(Error::SharedMemory)?)?;
-        let value = HeaderValue::from_bytes(&value.as_slice()?.ok_or(Error::SharedMemory)?)?;
+        let name = HeaderName::from_bytes(memory.as_slice(name)?.ok_or(Error::SharedMemory)?)?;
+        let value = HeaderValue::from_bytes(memory.as_slice(value)?.ok_or(Error::SharedMemory)?)?;
         self.insert(name, value);
         Ok(())
     }
 
-    fn append(&mut self, name: &GuestPtr<[u8]>, value: &GuestPtr<[u8]>) -> Result<(), Error> {
+    fn append(
+        &mut self,
+        memory: &GuestMemory<'_>,
+        name: GuestPtr<[u8]>,
+        value: GuestPtr<[u8]>,
+    ) -> Result<(), Error> {
         if name.len() > MAX_HEADER_NAME_LEN {
             return Err(Error::InvalidArgument);
         }
 
-        let name = HeaderName::from_bytes(&name.as_slice()?.ok_or(Error::SharedMemory)?)?;
-        let value = HeaderValue::from_bytes(&value.as_slice()?.ok_or(Error::SharedMemory)?)?;
+        let name = HeaderName::from_bytes(memory.as_slice(name)?.ok_or(Error::SharedMemory)?)?;
+        let value = HeaderValue::from_bytes(memory.as_slice(value)?.ok_or(Error::SharedMemory)?)?;
         self.append(name, value);
         Ok(())
     }
 
-    fn remove(&mut self, name: &GuestPtr<[u8]>) -> Result<(), Error> {
+    fn remove(&mut self, memory: &GuestMemory<'_>, name: GuestPtr<[u8]>) -> Result<(), Error> {
         if name.len() > MAX_HEADER_NAME_LEN {
             return Err(Error::InvalidArgument);
         }
 
-        let name = HeaderName::from_bytes(&name.as_slice()?.ok_or(Error::SharedMemory)?)?;
+        let name = HeaderName::from_bytes(memory.as_slice(name)?.ok_or(Error::SharedMemory)?)?;
         let _ = self.remove(name).ok_or(Error::InvalidArgument)?;
         Ok(())
     }

--- a/lib/src/wiggle_abi/obj_store_impl.rs
+++ b/lib/src/wiggle_abi/obj_store_impl.rs
@@ -15,13 +15,17 @@ use {
             types::{BodyHandle, ObjectStoreHandle},
         },
     },
-    wiggle::GuestPtr,
+    wiggle::{GuestMemory, GuestPtr},
 };
 
 #[wiggle::async_trait]
 impl FastlyObjectStore for Session {
-    fn open(&mut self, name: &GuestPtr<str>) -> Result<ObjectStoreHandle, Error> {
-        let name = name.as_str()?.ok_or(Error::SharedMemory)?;
+    fn open(
+        &mut self,
+        memory: &mut GuestMemory<'_>,
+        name: GuestPtr<str>,
+    ) -> Result<ObjectStoreHandle, Error> {
+        let name = memory.as_str(name)?.ok_or(Error::SharedMemory)?;
         if self.object_store.store_exists(&name)? {
             self.obj_store_handle(&name)
         } else {
@@ -33,16 +37,17 @@ impl FastlyObjectStore for Session {
 
     fn lookup(
         &mut self,
+        memory: &mut GuestMemory<'_>,
         store: ObjectStoreHandle,
-        key: &GuestPtr<str>,
-        opt_body_handle_out: &GuestPtr<BodyHandle>,
+        key: GuestPtr<str>,
+        opt_body_handle_out: GuestPtr<BodyHandle>,
     ) -> Result<(), Error> {
         let store = self.get_obj_store_key(store).unwrap();
-        let key = ObjectKey::new(key.as_str()?.ok_or(Error::SharedMemory)?.to_string())?;
+        let key = ObjectKey::new(memory.as_str(key)?.ok_or(Error::SharedMemory)?.to_string())?;
         match self.obj_lookup(store, &key) {
             Ok(obj) => {
                 let new_handle = self.insert_body(Body::from(obj));
-                opt_body_handle_out.write(new_handle)?;
+                memory.write(opt_body_handle_out, new_handle)?;
                 Ok(())
             }
             // Don't write to the invalid handle as the SDK will return Ok(None)
@@ -53,26 +58,30 @@ impl FastlyObjectStore for Session {
         }
     }
 
-    async fn lookup_async<'a>(
+    async fn lookup_async(
         &mut self,
+        memory: &mut GuestMemory<'_>,
         store: ObjectStoreHandle,
-        key: &GuestPtr<str>,
-        opt_pending_body_handle_out: &GuestPtr<PendingKvLookupHandle>,
+        key: GuestPtr<str>,
+        opt_pending_body_handle_out: GuestPtr<PendingKvLookupHandle>,
     ) -> Result<(), Error> {
         let store = self.get_obj_store_key(store).unwrap();
-        let key = ObjectKey::new(key.as_str()?.ok_or(Error::SharedMemory)?.to_string())?;
+        let key = ObjectKey::new(memory.as_str(key)?.ok_or(Error::SharedMemory)?.to_string())?;
         // just create a future that's already ready
         let fut = futures::future::ok(self.obj_lookup(store, &key));
         let task = PeekableTask::spawn(fut).await;
-        opt_pending_body_handle_out
-            .write(self.insert_pending_kv_lookup(PendingKvLookupTask::new(task)))?;
+        memory.write(
+            opt_pending_body_handle_out,
+            self.insert_pending_kv_lookup(PendingKvLookupTask::new(task)),
+        )?;
         Ok(())
     }
 
-    async fn pending_lookup_wait<'a>(
+    async fn pending_lookup_wait(
         &mut self,
+        memory: &mut wiggle::GuestMemory<'_>,
         pending_body_handle: PendingKvLookupHandle,
-        opt_body_handle_out: &GuestPtr<BodyHandle>,
+        opt_body_handle_out: GuestPtr<BodyHandle>,
     ) -> Result<(), Error> {
         let pending_obj = self
             .take_pending_kv_lookup(pending_body_handle)?
@@ -83,7 +92,7 @@ impl FastlyObjectStore for Session {
         match pending_obj {
             Ok(obj) => {
                 let new_handle = self.insert_body(Body::from(obj));
-                opt_body_handle_out.write(new_handle)?;
+                memory.write(opt_body_handle_out, new_handle)?;
                 Ok(())
             }
             Err(ObjectStoreError::MissingObject) => Ok(()),
@@ -91,39 +100,44 @@ impl FastlyObjectStore for Session {
         }
     }
 
-    async fn insert<'a>(
+    async fn insert(
         &mut self,
+        memory: &mut wiggle::GuestMemory<'_>,
         store: ObjectStoreHandle,
-        key: &GuestPtr<'a, str>,
+        key: GuestPtr<str>,
         body_handle: BodyHandle,
     ) -> Result<(), Error> {
         let store = self.get_obj_store_key(store).unwrap().clone();
-        let key = ObjectKey::new(key.as_str()?.ok_or(Error::SharedMemory)?.to_string())?;
+        let key = ObjectKey::new(memory.as_str(key)?.ok_or(Error::SharedMemory)?.to_string())?;
         let bytes = self.take_body(body_handle)?.read_into_vec().await?;
         self.obj_insert(store, key, bytes)?;
 
         Ok(())
     }
 
-    async fn insert_async<'a>(
+    async fn insert_async(
         &mut self,
+        memory: &mut GuestMemory<'_>,
         store: ObjectStoreHandle,
-        key: &GuestPtr<str>,
+        key: GuestPtr<str>,
         body_handle: BodyHandle,
-        opt_pending_body_handle_out: &GuestPtr<PendingKvInsertHandle>,
+        opt_pending_body_handle_out: GuestPtr<PendingKvInsertHandle>,
     ) -> Result<(), Error> {
         let store = self.get_obj_store_key(store).unwrap().clone();
-        let key = ObjectKey::new(key.as_str()?.ok_or(Error::SharedMemory)?.to_string())?;
+        let key = ObjectKey::new(memory.as_str(key)?.ok_or(Error::SharedMemory)?.to_string())?;
         let bytes = self.take_body(body_handle)?.read_into_vec().await?;
         let fut = futures::future::ok(self.obj_insert(store, key, bytes));
         let task = PeekableTask::spawn(fut).await;
-        opt_pending_body_handle_out
-            .write(self.insert_pending_kv_insert(PendingKvInsertTask::new(task)))?;
+        memory.write(
+            opt_pending_body_handle_out,
+            self.insert_pending_kv_insert(PendingKvInsertTask::new(task)),
+        )?;
         Ok(())
     }
 
     async fn pending_insert_wait(
         &mut self,
+        _memory: &mut GuestMemory<'_>,
         pending_insert_handle: PendingKvInsertHandle,
     ) -> Result<(), Error> {
         Ok((self
@@ -133,23 +147,27 @@ impl FastlyObjectStore for Session {
             .await?)?)
     }
 
-    async fn delete_async<'a>(
+    async fn delete_async(
         &mut self,
+        memory: &mut wiggle::GuestMemory<'_>,
         store: ObjectStoreHandle,
-        key: &GuestPtr<str>,
-        opt_pending_delete_handle_out: &GuestPtr<PendingKvDeleteHandle>,
+        key: GuestPtr<str>,
+        opt_pending_delete_handle_out: GuestPtr<PendingKvDeleteHandle>,
     ) -> Result<(), Error> {
         let store = self.get_obj_store_key(store).unwrap().clone();
-        let key = ObjectKey::new(key.as_str()?.ok_or(Error::SharedMemory)?.to_string())?;
+        let key = ObjectKey::new(memory.as_str(key)?.ok_or(Error::SharedMemory)?.to_string())?;
         let fut = futures::future::ok(self.obj_delete(store, key));
         let task = PeekableTask::spawn(fut).await;
-        opt_pending_delete_handle_out
-            .write(self.insert_pending_kv_delete(PendingKvDeleteTask::new(task)))?;
+        memory.write(
+            opt_pending_delete_handle_out,
+            self.insert_pending_kv_delete(PendingKvDeleteTask::new(task)),
+        )?;
         Ok(())
     }
 
     async fn pending_delete_wait(
         &mut self,
+        _memory: &mut GuestMemory<'_>,
         pending_delete_handle: PendingKvDeleteHandle,
     ) -> Result<(), Error> {
         Ok((self

--- a/lib/src/wiggle_abi/req_impl.rs
+++ b/lib/src/wiggle_abi/req_impl.rs
@@ -25,13 +25,15 @@ use {
     fastly_shared::{INVALID_BODY_HANDLE, INVALID_REQUEST_HANDLE, INVALID_RESPONSE_HANDLE},
     http::{HeaderValue, Method, Uri},
     hyper::http::request::Request,
-    std::ops::Deref,
-    wiggle::GuestPtr,
+    wiggle::{GuestMemory, GuestPtr},
 };
 
 #[wiggle::async_trait]
 impl FastlyHttpReq for Session {
-    fn body_downstream_get(&mut self) -> Result<(RequestHandle, BodyHandle), Error> {
+    fn body_downstream_get(
+        &mut self,
+        _memory: &mut GuestMemory<'_>,
+    ) -> Result<(RequestHandle, BodyHandle), Error> {
         let req_handle = self.downstream_request();
         let body_handle = self.downstream_request_body();
         Ok((req_handle, body_handle))
@@ -40,6 +42,7 @@ impl FastlyHttpReq for Session {
     #[allow(unused_variables)] // FIXME KTM 2020-06-25: Remove this directive once implemented.
     fn cache_override_set(
         &mut self,
+        memory: &mut GuestMemory<'_>,
         req_handle: RequestHandle,
         tag: CacheOverrideTag,
         ttl: u32,
@@ -52,11 +55,12 @@ impl FastlyHttpReq for Session {
     #[allow(unused_variables)] // FIXME KTM 2020-06-25: Remove this directive once implemented.
     fn cache_override_v2_set(
         &mut self,
+        memory: &mut GuestMemory<'_>,
         req_handle: RequestHandle,
         tag: CacheOverrideTag,
         ttl: u32,
         stale_while_revalidate: u32,
-        sk: &GuestPtr<[u8]>,
+        sk: GuestPtr<[u8]>,
     ) -> Result<(), Error> {
         // For now, we ignore caching directives because we never cache anything
         Ok(())
@@ -64,8 +68,9 @@ impl FastlyHttpReq for Session {
 
     fn downstream_client_ip_addr(
         &mut self,
+        memory: &mut GuestMemory<'_>,
         // Must be a 16-byte array:
-        addr_octets_ptr: &GuestPtr<u8>,
+        addr_octets_ptr: GuestPtr<u8>,
     ) -> Result<u32, Error> {
         use std::net::IpAddr;
         match self.downstream_client_ip() {
@@ -73,18 +78,14 @@ impl FastlyHttpReq for Session {
                 let octets = addr.octets();
                 let octets_bytes = octets.len() as u32;
                 debug_assert_eq!(octets_bytes, 4);
-                addr_octets_ptr
-                    .as_array(octets_bytes)
-                    .copy_from_slice(&octets)?;
+                memory.copy_from_slice(&octets, addr_octets_ptr.as_array(octets_bytes))?;
                 Ok(octets_bytes)
             }
             IpAddr::V6(addr) => {
                 let octets = addr.octets();
                 let octets_bytes = octets.len() as u32;
                 debug_assert_eq!(octets_bytes, 16);
-                addr_octets_ptr
-                    .as_array(octets_bytes)
-                    .copy_from_slice(&octets)?;
+                memory.copy_from_slice(&octets, addr_octets_ptr.as_array(octets_bytes))?;
                 Ok(octets_bytes)
             }
         }
@@ -93,25 +94,27 @@ impl FastlyHttpReq for Session {
     #[allow(unused_variables)] // FIXME JDC 2023-06-18: Remove this directive once implemented.
     fn downstream_client_h2_fingerprint(
         &mut self,
-        h2fp_out: &GuestPtr<'_, u8>,
+        memory: &mut GuestMemory<'_>,
+        h2fp_out: GuestPtr<u8>,
         h2fp_max_len: u32,
-        nwritten_out: &GuestPtr<u32>,
+        nwritten_out: GuestPtr<u32>,
     ) -> Result<(), Error> {
         Err(Error::NotAvailable("Client H2 fingerprint"))
     }
 
     fn downstream_client_request_id(
         &mut self,
-        reqid_out: &GuestPtr<u8>,
+        memory: &mut GuestMemory<'_>,
+        reqid_out: GuestPtr<u8>,
         reqid_max_len: u32,
-        nwritten_out: &GuestPtr<u32>,
+        nwritten_out: GuestPtr<u32>,
     ) -> Result<(), Error> {
         let reqid_bytes = format!("{:032x}", self.req_id()).into_bytes();
 
         if reqid_bytes.len() > reqid_max_len as usize {
             // Write out the number of bytes necessary to fit the value, or zero on overflow to
             // signal an error condition.
-            nwritten_out.write(reqid_bytes.len().try_into().unwrap_or(0))?;
+            memory.write(nwritten_out, reqid_bytes.len().try_into().unwrap_or(0))?;
             return Err(Error::BufferLengthError {
                 buf: "reqid_out",
                 len: "reqid_max_len",
@@ -121,68 +124,83 @@ impl FastlyHttpReq for Session {
         let reqid_len =
             u32::try_from(reqid_bytes.len()).expect("smaller u32::MAX means it must fit");
 
-        reqid_out
-            .as_array(reqid_len)
-            .copy_from_slice(&reqid_bytes)?;
-        nwritten_out.write(reqid_len)?;
+        memory.copy_from_slice(&reqid_bytes, reqid_out.as_array(reqid_len))?;
+        memory.write(nwritten_out, reqid_len)?;
         Ok(())
     }
 
     fn downstream_client_oh_fingerprint(
         &mut self,
-        _ohfp_out: &GuestPtr<'_, u8>,
+        _memory: &mut GuestMemory<'_>,
+        _ohfp_out: GuestPtr<u8>,
         _ohfp_max_len: u32,
-        _nwritten_out: &GuestPtr<u32>,
+        _nwritten_out: GuestPtr<u32>,
     ) -> Result<(), Error> {
         Err(Error::NotAvailable("Client original header fingerprint"))
     }
 
-    fn downstream_tls_cipher_openssl_name<'a>(
+    fn downstream_tls_cipher_openssl_name(
         &mut self,
-        _cipher_out: &GuestPtr<'a, u8>,
+        _memory: &mut GuestMemory<'_>,
+        _cipher_out: GuestPtr<u8>,
         _cipher_max_len: u32,
-        _nwritten_out: &GuestPtr<u32>,
+        _nwritten_out: GuestPtr<u32>,
     ) -> Result<(), Error> {
         // FIXME JDC 2023-09-27: For now, we don't support incoming TLS connections, this function currently only implements the solution for non-tls connections.
         Err(Error::ValueAbsent)
     }
 
     #[allow(unused_variables)] // FIXME ACF 2022-05-03: Remove this directive once implemented.
-    fn upgrade_websocket(&mut self, backend_name: &GuestPtr<str>) -> Result<(), Error> {
+    fn upgrade_websocket(
+        &mut self,
+        memory: &mut GuestMemory<'_>,
+        backend_name: GuestPtr<str>,
+    ) -> Result<(), Error> {
         Err(Error::NotAvailable("WebSocket upgrade"))
     }
 
     #[allow(unused_variables)] // FIXME ACF 2022-10-03: Remove this directive once implemented.
-    fn redirect_to_websocket_proxy(&mut self, backend_name: &GuestPtr<str>) -> Result<(), Error> {
+    fn redirect_to_websocket_proxy(
+        &mut self,
+        memory: &mut GuestMemory<'_>,
+        backend_name: GuestPtr<str>,
+    ) -> Result<(), Error> {
         Err(Error::NotAvailable("Redirect to WebSocket proxy"))
     }
 
     #[allow(unused_variables)] // FIXME ACF 2022-10-03: Remove this directive once implemented.
-    fn redirect_to_grip_proxy(&mut self, backend_name: &GuestPtr<str>) -> Result<(), Error> {
+    fn redirect_to_grip_proxy(
+        &mut self,
+        memory: &mut GuestMemory<'_>,
+        backend_name: GuestPtr<str>,
+    ) -> Result<(), Error> {
         Err(Error::NotAvailable("Redirect to Fanout/GRIP proxy"))
     }
 
     fn redirect_to_websocket_proxy_v2(
         &mut self,
+        _memory: &mut GuestMemory<'_>,
         _req_handle: RequestHandle,
-        _backend: &GuestPtr<'_, str>,
+        _backend: GuestPtr<str>,
     ) -> Result<(), Error> {
         Err(Error::NotAvailable("Redirect to WebSocket proxy"))
     }
 
     fn redirect_to_grip_proxy_v2(
         &mut self,
+        _memory: &mut GuestMemory<'_>,
         _req_handle: RequestHandle,
-        _backend: &GuestPtr<'_, str>,
+        _backend: GuestPtr<str>,
     ) -> Result<(), Error> {
         Err(Error::NotAvailable("Redirect to Fanout/GRIP proxy"))
     }
 
-    fn downstream_tls_protocol<'a>(
+    fn downstream_tls_protocol(
         &mut self,
-        _protocol_out: &GuestPtr<'a, u8>,
+        _memory: &mut GuestMemory<'_>,
+        _protocol_out: GuestPtr<u8>,
         _protocol_max_len: u32,
-        _nwritten_out: &GuestPtr<u32>,
+        _nwritten_out: GuestPtr<u32>,
     ) -> Result<(), Error> {
         // FIXME JDC 2023-09-27: For now, we don't support incoming TLS connections, this function currently only implements the solution for non-tls connections.
         Err(Error::ValueAbsent)
@@ -191,19 +209,21 @@ impl FastlyHttpReq for Session {
     #[allow(unused_variables)] // FIXME KTM 2020-06-25: Remove this directive once implemented.
     fn downstream_tls_client_hello(
         &mut self,
-        chello_out: &GuestPtr<'_, u8>,
+        memory: &mut GuestMemory<'_>,
+        chello_out: GuestPtr<u8>,
         chello_max_len: u32,
-        nwritten_out: &GuestPtr<u32>,
+        nwritten_out: GuestPtr<u32>,
     ) -> Result<(), Error> {
         // FIXME JDC 2023-09-27: For now, we don't support incoming TLS connections, this function currently only implements the solution for non-tls connections.
         Err(Error::ValueAbsent)
     }
 
-    fn downstream_tls_raw_client_certificate<'a>(
+    fn downstream_tls_raw_client_certificate(
         &mut self,
-        _tokio_rustlsraw_client_cert_out: &GuestPtr<'a, u8>,
+        _memory: &mut GuestMemory<'_>,
+        _tokio_rustlsraw_client_cert_out: GuestPtr<u8>,
         _raw_client_cert_max_len: u32,
-        _nwritten_out: &GuestPtr<u32>,
+        _nwritten_out: GuestPtr<u32>,
     ) -> Result<(), Error> {
         // FIXME JDC 2023-09-27: For now, we don't support incoming TLS connections, this function currently only implements the solution for non-tls connections.
         Err(Error::ValueAbsent)
@@ -211,12 +231,17 @@ impl FastlyHttpReq for Session {
 
     fn downstream_tls_client_cert_verify_result(
         &mut self,
+        _memory: &mut GuestMemory<'_>,
     ) -> Result<ClientCertVerifyResult, Error> {
         // FIXME JDC 2023-09-27: For now, we don't support incoming TLS connections, this function currently only implements the solution for non-tls connections.
         Err(Error::ValueAbsent)
     }
 
-    fn downstream_tls_ja3_md5(&mut self, _ja3_md5_out: &GuestPtr<u8>) -> Result<u32, Error> {
+    fn downstream_tls_ja3_md5(
+        &mut self,
+        _memory: &mut GuestMemory<'_>,
+        _ja3_md5_out: GuestPtr<u8>,
+    ) -> Result<u32, Error> {
         // FIXME JDC 2023-09-27: For now, we don't support incoming TLS connections, this function currently only implements the solution for non-tls connections.
         Err(Error::ValueAbsent)
     }
@@ -224,15 +249,17 @@ impl FastlyHttpReq for Session {
     #[allow(unused_variables)] // FIXME UFSM 2024-02-19: Remove this directive once implemented.
     fn downstream_tls_ja4(
         &mut self,
-        ja4_out: &GuestPtr<u8>,
+        _memory: &mut GuestMemory<'_>,
+        ja4_out: GuestPtr<u8>,
         ja4_max_len: u32,
-        nwritten_out: &GuestPtr<u32>,
+        nwritten_out: GuestPtr<u32>,
     ) -> Result<(), Error> {
         Err(Error::NotAvailable("Client TLS JA4 hash"))
     }
 
     fn framing_headers_mode_set(
         &mut self,
+        _memory: &mut GuestMemory<'_>,
         _h: RequestHandle,
         mode: FramingHeadersMode,
     ) -> Result<(), Error> {
@@ -244,25 +271,23 @@ impl FastlyHttpReq for Session {
         }
     }
 
-    fn register_dynamic_backend<'a>(
+    fn register_dynamic_backend(
         &mut self,
-        name: &GuestPtr<str>,
-        upstream_dynamic: &GuestPtr<str>,
+        memory: &mut GuestMemory<'_>,
+        name: GuestPtr<str>,
+        upstream_dynamic: GuestPtr<str>,
         backend_info_mask: BackendConfigOptions,
-        backend_info: &GuestPtr<'a, DynamicBackendConfig<'a>>,
+        backend_info: GuestPtr<DynamicBackendConfig>,
     ) -> Result<(), Error> {
         let name = {
-            let name_slice = name.as_bytes().as_slice()?.ok_or(Error::SharedMemory)?;
-            std::str::from_utf8(&name_slice)?.to_owned()
+            let name_slice = memory.to_vec(name.as_bytes())?;
+            String::from_utf8(name_slice).map_err(|_| Error::InvalidArgument)?
         };
         let origin_name = {
-            let origin_name_slice = upstream_dynamic
-                .as_bytes()
-                .as_slice()?
-                .ok_or(Error::SharedMemory)?;
-            std::str::from_utf8(&origin_name_slice)?.to_owned()
+            let origin_name_slice = memory.to_vec(upstream_dynamic.as_bytes())?;
+            String::from_utf8(origin_name_slice).map_err(|_| Error::InvalidArgument)?
         };
-        let config = backend_info.read()?;
+        let config = memory.read(backend_info)?;
 
         // If someone set our reserved bit, error. We might need it, and we don't
         // want anyone it early.
@@ -285,10 +310,8 @@ impl FastlyHttpReq for Session {
                 return Err(Error::InvalidArgument);
             }
 
-            let byte_slice = config
-                .host_override
-                .as_array(config.host_override_len)
-                .to_vec()?;
+            let byte_slice =
+                memory.to_vec(config.host_override.as_array(config.host_override_len))?;
 
             let string = String::from_utf8(byte_slice).map_err(|_| Error::InvalidArgument)?;
 
@@ -313,10 +336,8 @@ impl FastlyHttpReq for Session {
                     return Err(Error::InvalidArgument);
                 }
 
-                let byte_slice = config
-                    .ca_cert
-                    .as_array(config.ca_cert_len)
-                    .as_slice()?
+                let byte_slice = memory
+                    .as_slice(config.ca_cert.as_array(config.ca_cert_len))?
                     .ok_or(Error::SharedMemory)?;
                 let mut byte_cursor = std::io::Cursor::new(&byte_slice[..]);
                 rustls_pemfile::certs(&mut byte_cursor)?
@@ -336,10 +357,8 @@ impl FastlyHttpReq for Session {
                 return Err(Error::InvalidArgument);
             }
 
-            let byte_slice = config
-                .cert_hostname
-                .as_array(config.cert_hostname_len)
-                .as_slice()?
+            let byte_slice = memory
+                .as_slice(config.cert_hostname.as_array(config.cert_hostname_len))?
                 .ok_or(Error::SharedMemory)?;
 
             Some(std::str::from_utf8(&byte_slice)?.to_owned())
@@ -353,10 +372,8 @@ impl FastlyHttpReq for Session {
             } else if config.sni_hostname_len > 1024 {
                 return Err(Error::InvalidArgument);
             } else {
-                let byte_slice = config
-                    .sni_hostname
-                    .as_array(config.sni_hostname_len)
-                    .as_slice()?
+                let byte_slice = memory
+                    .as_slice(config.sni_hostname.as_array(config.sni_hostname_len))?
                     .ok_or(Error::SharedMemory)?;
                 let sni_hostname = std::str::from_utf8(&byte_slice)?;
                 if let Some(cert_host) = &cert_host {
@@ -375,10 +392,12 @@ impl FastlyHttpReq for Session {
         };
 
         let client_cert = if backend_info_mask.contains(BackendConfigOptions::CLIENT_CERT) {
-            let cert_slice = config
-                .client_certificate
-                .as_array(config.client_certificate_len)
-                .as_slice()?
+            let cert_slice = memory
+                .as_slice(
+                    config
+                        .client_certificate
+                        .as_array(config.client_certificate_len),
+                )?
                 .ok_or(Error::SharedMemory)?;
             let key_lookup =
                 self.secret_lookup(config.client_key)
@@ -432,43 +451,47 @@ impl FastlyHttpReq for Session {
         Ok(())
     }
 
-    fn new(&mut self) -> Result<RequestHandle, Error> {
+    fn new(&mut self, _memory: &mut GuestMemory<'_>) -> Result<RequestHandle, Error> {
         let (parts, _) = Request::new(()).into_parts();
         Ok(self.insert_request_parts(parts))
     }
 
     fn header_names_get(
         &mut self,
+        memory: &mut GuestMemory<'_>,
         req_handle: RequestHandle,
-        buf: &GuestPtr<'_, u8>,
+        buf: GuestPtr<u8>,
         buf_len: u32,
         cursor: MultiValueCursor,
-        ending_cursor_out: &GuestPtr<MultiValueCursorResult>,
-        nwritten_out: &GuestPtr<u32>,
+        ending_cursor_out: GuestPtr<MultiValueCursorResult>,
+        nwritten_out: GuestPtr<u32>,
     ) -> Result<(), Error> {
         let headers = &self.request_parts(req_handle)?.headers;
         multi_value_result!(
-            headers.names_get(buf, buf_len, cursor, nwritten_out),
+            memory,
+            headers.names_get(memory, buf, buf_len, cursor, nwritten_out),
             ending_cursor_out
         )
     }
 
     fn original_header_names_get(
         &mut self,
-        buf: &GuestPtr<'_, u8>,
+        memory: &mut GuestMemory<'_>,
+        buf: GuestPtr<u8>,
         buf_len: u32,
         cursor: MultiValueCursor,
-        ending_cursor_out: &GuestPtr<MultiValueCursorResult>,
-        nwritten_out: &GuestPtr<u32>,
+        ending_cursor_out: GuestPtr<MultiValueCursorResult>,
+        nwritten_out: GuestPtr<u32>,
     ) -> Result<(), Error> {
         let headers = self.downstream_original_headers();
         multi_value_result!(
-            headers.names_get(buf, buf_len, cursor, nwritten_out),
+            memory,
+            headers.names_get(memory, buf, buf_len, cursor, nwritten_out),
             ending_cursor_out
         )
     }
 
-    fn original_header_count(&mut self) -> Result<u32, Error> {
+    fn original_header_count(&mut self, _memory: &mut GuestMemory<'_>) -> Result<u32, Error> {
         let headers = self.downstream_original_headers();
         Ok(headers
             .len()
@@ -476,80 +499,88 @@ impl FastlyHttpReq for Session {
             .expect("More than u32::MAX headers"))
     }
 
-    fn header_value_get<'a>(
+    fn header_value_get(
         &mut self,
+        memory: &mut GuestMemory<'_>,
         req_handle: RequestHandle,
-        name: &GuestPtr<[u8]>,
-        value: &GuestPtr<u8>,
+        name: GuestPtr<[u8]>,
+        value: GuestPtr<u8>,
         value_max_len: u32,
-        nwritten_out: &GuestPtr<u32>,
+        nwritten_out: GuestPtr<u32>,
     ) -> Result<(), Error> {
         let headers = &self.request_parts(req_handle)?.headers;
-        headers.value_get(name, value, value_max_len, nwritten_out)
+        headers.value_get(memory, name, value, value_max_len, nwritten_out)
     }
 
-    fn header_values_get<'a>(
+    fn header_values_get(
         &mut self,
+        memory: &mut GuestMemory<'_>,
         req_handle: RequestHandle,
-        name: &GuestPtr<[u8]>,
-        buf: &GuestPtr<u8>,
+        name: GuestPtr<[u8]>,
+        buf: GuestPtr<u8>,
         buf_len: u32,
         cursor: MultiValueCursor,
-        ending_cursor_out: &GuestPtr<MultiValueCursorResult>,
-        nwritten_out: &GuestPtr<u32>,
+        ending_cursor_out: GuestPtr<MultiValueCursorResult>,
+        nwritten_out: GuestPtr<u32>,
     ) -> Result<(), Error> {
         let headers = &self.request_parts(req_handle)?.headers;
         multi_value_result!(
-            headers.values_get(name, buf, buf_len, cursor, nwritten_out),
+            memory,
+            headers.values_get(memory, name, buf, buf_len, cursor, nwritten_out),
             ending_cursor_out
         )
     }
 
-    fn header_values_set<'a>(
+    fn header_values_set(
         &mut self,
+        memory: &mut GuestMemory<'_>,
         req_handle: RequestHandle,
-        name: &GuestPtr<[u8]>,
-        values: &GuestPtr<[u8]>,
+        name: GuestPtr<[u8]>,
+        values: GuestPtr<[u8]>,
     ) -> Result<(), Error> {
         let headers = &mut self.request_parts_mut(req_handle)?.headers;
-        headers.values_set(name, values)
+        headers.values_set(memory, name, values)
     }
 
-    fn header_insert<'a>(
+    fn header_insert(
         &mut self,
+        memory: &mut GuestMemory<'_>,
         req_handle: RequestHandle,
-        name: &GuestPtr<[u8]>,
-        value: &GuestPtr<[u8]>,
+        name: GuestPtr<[u8]>,
+        value: GuestPtr<[u8]>,
     ) -> Result<(), Error> {
         let headers = &mut self.request_parts_mut(req_handle)?.headers;
-        HttpHeaders::insert(headers, name, value)
+        HttpHeaders::insert(headers, memory, name, value)
     }
 
-    fn header_append<'a>(
+    fn header_append(
         &mut self,
+        memory: &mut GuestMemory<'_>,
         req_handle: RequestHandle,
-        name: &GuestPtr<[u8]>,
-        value: &GuestPtr<[u8]>,
+        name: GuestPtr<[u8]>,
+        value: GuestPtr<[u8]>,
     ) -> Result<(), Error> {
         let headers = &mut self.request_parts_mut(req_handle)?.headers;
-        HttpHeaders::append(headers, name, value)
+        HttpHeaders::append(headers, memory, name, value)
     }
 
-    fn header_remove<'a>(
+    fn header_remove(
         &mut self,
+        memory: &mut GuestMemory<'_>,
         req_handle: RequestHandle,
-        name: &GuestPtr<[u8]>,
+        name: GuestPtr<[u8]>,
     ) -> Result<(), Error> {
         let headers = &mut self.request_parts_mut(req_handle)?.headers;
-        HttpHeaders::remove(headers, name)
+        HttpHeaders::remove(headers, memory, name)
     }
 
     fn method_get(
         &mut self,
+        memory: &mut GuestMemory<'_>,
         req_handle: RequestHandle,
-        buf: &GuestPtr<'_, u8>,
+        buf: GuestPtr<u8>,
         buf_len: u32,
-        nwritten_out: &GuestPtr<u32>,
+        nwritten_out: GuestPtr<u32>,
     ) -> Result<(), Error> {
         let req = self.request_parts(req_handle)?;
         let req_method = &req.method;
@@ -558,7 +589,7 @@ impl FastlyHttpReq for Session {
         if req_method_bytes.len() > buf_len as usize {
             // Write out the number of bytes necessary to fit this method, or zero on overflow to
             // signal an error condition.
-            nwritten_out.write(req_method_bytes.len().try_into().unwrap_or(0))?;
+            memory.write(nwritten_out, req_method_bytes.len().try_into().unwrap_or(0))?;
             return Err(Error::BufferLengthError {
                 buf: "method",
                 len: "method_max_len",
@@ -568,40 +599,42 @@ impl FastlyHttpReq for Session {
         let req_method_len = u32::try_from(req_method_bytes.len())
             .expect("smaller than method_max_len means it must fit");
 
-        buf.as_array(req_method_len)
-            .copy_from_slice(&req_method_bytes)?;
-        nwritten_out.write(req_method_len)?;
+        memory.copy_from_slice(&req_method_bytes, buf.as_array(req_method_len))?;
+        memory.write(nwritten_out, req_method_len)?;
 
         Ok(())
     }
 
     fn method_set(
         &mut self,
+        memory: &mut GuestMemory<'_>,
         req_handle: RequestHandle,
-        method: &GuestPtr<'_, str>,
+        method: GuestPtr<str>,
     ) -> Result<(), Error> {
         let method_ref = &mut self.request_parts_mut(req_handle)?.method;
-        let method_slice = method.as_bytes().as_slice()?.ok_or(Error::SharedMemory)?;
-        *method_ref = Method::from_bytes(method_slice.deref())?;
+        let method_slice = memory
+            .as_slice(method.as_bytes())?
+            .ok_or(Error::SharedMemory)?;
+        *method_ref = Method::from_bytes(method_slice)?;
 
         Ok(())
     }
 
     fn uri_get(
         &mut self,
+        memory: &mut GuestMemory<'_>,
         req_handle: RequestHandle,
-        buf: &GuestPtr<'_, u8>,
+        buf: GuestPtr<u8>,
         buf_len: u32,
-        nwritten_out: &GuestPtr<u32>,
+        nwritten_out: GuestPtr<u32>,
     ) -> Result<(), Error> {
         let req = self.request_parts(req_handle)?;
-        let req_uri = &req.uri;
-        let req_uri_bytes = req_uri.to_string().into_bytes();
+        let req_uri_bytes = req.uri.to_string().into_bytes();
 
         if req_uri_bytes.len() > buf_len as usize {
             // Write out the number of bytes necessary to fit this method, or zero on overflow to
             // signal an error condition.
-            nwritten_out.write(req_uri_bytes.len().try_into().unwrap_or(0))?;
+            memory.write(nwritten_out, req_uri_bytes.len().try_into().unwrap_or(0))?;
             return Err(Error::BufferLengthError {
                 buf: "uri",
                 len: "uri_max_len",
@@ -610,28 +643,39 @@ impl FastlyHttpReq for Session {
         let req_uri_len =
             u32::try_from(req_uri_bytes.len()).expect("smaller than uri_max_len means it must fit");
 
-        buf.as_array(req_uri_len).copy_from_slice(&req_uri_bytes)?;
-        nwritten_out.write(req_uri_len)?;
+        memory.copy_from_slice(&req_uri_bytes, buf.as_array(req_uri_len))?;
+        memory.write(nwritten_out, req_uri_len)?;
 
         Ok(())
     }
 
-    fn uri_set(&mut self, req_handle: RequestHandle, uri: &GuestPtr<'_, str>) -> Result<(), Error> {
+    fn uri_set(
+        &mut self,
+        memory: &mut GuestMemory<'_>,
+        req_handle: RequestHandle,
+        uri: GuestPtr<str>,
+    ) -> Result<(), Error> {
         let uri_ref = &mut self.request_parts_mut(req_handle)?.uri;
-        let req_uri_str = uri.as_str()?.ok_or(Error::SharedMemory)?;
-        let req_uri_bytes = req_uri_str.as_bytes();
+        let req_uri_bytes = memory
+            .as_slice(uri.as_bytes())?
+            .ok_or(Error::SharedMemory)?;
 
         *uri_ref = Uri::try_from(req_uri_bytes)?;
         Ok(())
     }
 
-    fn version_get(&mut self, req_handle: RequestHandle) -> Result<HttpVersion, Error> {
+    fn version_get(
+        &mut self,
+        _memory: &mut GuestMemory<'_>,
+        req_handle: RequestHandle,
+    ) -> Result<HttpVersion, Error> {
         let req = self.request_parts(req_handle)?;
         HttpVersion::try_from(req.version).map_err(|msg| Error::Unsupported { msg })
     }
 
     fn version_set(
         &mut self,
+        _memory: &mut GuestMemory<'_>,
         req_handle: RequestHandle,
         version: HttpVersion,
     ) -> Result<(), Error> {
@@ -642,15 +686,15 @@ impl FastlyHttpReq for Session {
         Ok(())
     }
 
-    async fn send<'a>(
+    async fn send(
         &mut self,
+        memory: &mut GuestMemory<'_>,
         req_handle: RequestHandle,
         body_handle: BodyHandle,
-        backend_bytes: &GuestPtr<'a, str>,
+        backend_bytes: GuestPtr<str>,
     ) -> Result<(ResponseHandle, BodyHandle), Error> {
-        let backend_bytes_slice = backend_bytes
-            .as_bytes()
-            .as_slice()?
+        let backend_bytes_slice = memory
+            .as_slice(backend_bytes.as_bytes())?
             .ok_or(Error::SharedMemory)?;
         let backend_name = std::str::from_utf8(&backend_bytes_slice)?;
 
@@ -667,26 +711,28 @@ impl FastlyHttpReq for Session {
         Ok(self.insert_response(resp))
     }
 
-    async fn send_v2<'a>(
+    async fn send_v2(
         &mut self,
+        memory: &mut GuestMemory<'_>,
         req_handle: RequestHandle,
         body_handle: BodyHandle,
-        backend_bytes: &GuestPtr<'a, str>,
-        _error_detail: &GuestPtr<'a, SendErrorDetail>,
+        backend_bytes: GuestPtr<str>,
+        _error_detail: GuestPtr<SendErrorDetail>,
     ) -> Result<(ResponseHandle, BodyHandle), Error> {
         // This initial implementation ignores the error detail field
-        self.send(req_handle, body_handle, backend_bytes).await
+        self.send(memory, req_handle, body_handle, backend_bytes)
+            .await
     }
 
-    async fn send_async<'a>(
+    async fn send_async(
         &mut self,
+        memory: &mut GuestMemory<'_>,
         req_handle: RequestHandle,
         body_handle: BodyHandle,
-        backend_bytes: &GuestPtr<'a, str>,
+        backend_bytes: GuestPtr<str>,
     ) -> Result<PendingRequestHandle, Error> {
-        let backend_bytes_slice = backend_bytes
-            .as_bytes()
-            .as_slice()?
+        let backend_bytes_slice = memory
+            .as_slice(backend_bytes.as_bytes())?
             .ok_or(Error::SharedMemory)?;
         let backend_name = std::str::from_utf8(&backend_bytes_slice)?;
 
@@ -706,17 +752,17 @@ impl FastlyHttpReq for Session {
         Ok(self.insert_pending_request(task))
     }
 
-    async fn send_async_streaming<'a>(
+    async fn send_async_streaming(
         &mut self,
+        memory: &mut GuestMemory<'_>,
         req_handle: RequestHandle,
         body_handle: BodyHandle,
-        backend_bytes: &GuestPtr<'a, str>,
+        backend_bytes: GuestPtr<str>,
     ) -> Result<PendingRequestHandle, Error> {
-        let backend_bytes_slice = backend_bytes
-            .as_bytes()
-            .as_slice()?
+        let backend_bytes_slice = memory
+            .as_slice(backend_bytes.as_bytes())?
             .ok_or(Error::SharedMemory)?;
-        let backend_name = std::str::from_utf8(&backend_bytes_slice)?;
+        let backend_name = std::str::from_utf8(backend_bytes_slice)?;
 
         // prepare the request
         let req_parts = self.take_request_parts(req_handle)?;
@@ -738,6 +784,7 @@ impl FastlyHttpReq for Session {
     // done, 1 when done.
     async fn pending_req_poll(
         &mut self,
+        _memory: &mut GuestMemory<'_>,
         pending_req_handle: PendingRequestHandle,
     ) -> Result<(u32, ResponseHandle, BodyHandle), Error> {
         if self.async_item_mut(pending_req_handle.into())?.is_ready() {
@@ -752,17 +799,19 @@ impl FastlyHttpReq for Session {
         }
     }
 
-    async fn pending_req_poll_v2<'a>(
+    async fn pending_req_poll_v2(
         &mut self,
+        memory: &mut GuestMemory<'_>,
         pending_req_handle: PendingRequestHandle,
-        _error_detail: &GuestPtr<'a, SendErrorDetail>,
+        _error_detail: GuestPtr<SendErrorDetail>,
     ) -> Result<(u32, ResponseHandle, BodyHandle), Error> {
         // This initial implementation ignores the error detail field
-        self.pending_req_poll(pending_req_handle).await
+        self.pending_req_poll(memory, pending_req_handle).await
     }
 
     async fn pending_req_wait(
         &mut self,
+        _memory: &mut GuestMemory<'_>,
         pending_req_handle: PendingRequestHandle,
     ) -> Result<(ResponseHandle, BodyHandle), Error> {
         let pending_req = self
@@ -772,39 +821,41 @@ impl FastlyHttpReq for Session {
         Ok(self.insert_response(pending_req))
     }
 
-    async fn pending_req_wait_v2<'a>(
+    async fn pending_req_wait_v2(
         &mut self,
+        memory: &mut GuestMemory<'_>,
         pending_req_handle: PendingRequestHandle,
-        _error_detail: &GuestPtr<'a, SendErrorDetail>,
+        _error_detail: GuestPtr<SendErrorDetail>,
     ) -> Result<(ResponseHandle, BodyHandle), Error> {
         // This initial implementation ignores the error detail field
-        self.pending_req_wait(pending_req_handle).await
+        self.pending_req_wait(memory, pending_req_handle).await
     }
 
     // First element of return tuple is the "done index"
-    async fn pending_req_select<'a>(
+    async fn pending_req_select(
         &mut self,
-        pending_req_handles: &GuestPtr<'a, [PendingRequestHandle]>,
+        memory: &mut GuestMemory<'_>,
+        pending_req_handles: GuestPtr<[PendingRequestHandle]>,
     ) -> Result<(u32, ResponseHandle, BodyHandle), Error> {
         if pending_req_handles.len() == 0 {
             return Err(Error::InvalidArgument);
         }
-        let pending_req_handles: GuestPtr<'a, [u32]> =
-            GuestPtr::new(pending_req_handles.mem(), pending_req_handles.offset());
+        let pending_req_handles = pending_req_handles.cast::<[u32]>();
 
         // perform the select operation
         let done_index = self
             .select_impl(
-                pending_req_handles
-                    .as_slice()?
-                    .ok_or(Error::SharedMemory)?
-                    .iter()
-                    .map(|handle| PendingRequestHandle::from(*handle).into()),
+                memory
+                    // TODO: wiggle only supports slices of u8 in 22.0.0
+                    .to_vec(pending_req_handles)?
+                    .into_iter()
+                    .map(|handle| PendingRequestHandle::from(handle).into()),
             )
             .await? as u32;
 
         let item = self.take_async_item(
-            PendingRequestHandle::from(pending_req_handles.get(done_index).unwrap().read()?).into(),
+            PendingRequestHandle::from(memory.read(pending_req_handles.get(done_index).unwrap())?)
+                .into(),
         )?;
 
         let outcome = match item {
@@ -828,20 +879,25 @@ impl FastlyHttpReq for Session {
         Ok(outcome)
     }
 
-    async fn pending_req_select_v2<'a>(
+    async fn pending_req_select_v2(
         &mut self,
-        pending_req_handles: &GuestPtr<'a, [PendingRequestHandle]>,
-        _error_detail: &GuestPtr<'a, SendErrorDetail>,
+        memory: &mut GuestMemory<'_>,
+        pending_req_handles: GuestPtr<[PendingRequestHandle]>,
+        _error_detail: GuestPtr<SendErrorDetail>,
     ) -> Result<(u32, ResponseHandle, BodyHandle), Error> {
         // This initial implementation ignores the error detail field
-        self.pending_req_select(pending_req_handles).await
+        self.pending_req_select(memory, pending_req_handles).await
     }
 
-    fn fastly_key_is_valid(&mut self) -> Result<u32, Error> {
+    fn fastly_key_is_valid(&mut self, _memory: &mut GuestMemory<'_>) -> Result<u32, Error> {
         Err(Error::NotAvailable("FASTLY_KEY is valid"))
     }
 
-    fn close(&mut self, req_handle: RequestHandle) -> Result<(), Error> {
+    fn close(
+        &mut self,
+        _memory: &mut GuestMemory<'_>,
+        req_handle: RequestHandle,
+    ) -> Result<(), Error> {
         // We don't do anything with the parts, but we do pass the error up if
         // the handle given doesn't exist
         self.take_request_parts(req_handle)?;
@@ -850,6 +906,7 @@ impl FastlyHttpReq for Session {
 
     fn auto_decompress_response_set(
         &mut self,
+        _memory: &mut GuestMemory<'_>,
         req_handle: RequestHandle,
         encodings: ContentEncodings,
     ) -> Result<(), Error> {

--- a/lib/src/wiggle_abi/req_impl.rs
+++ b/lib/src/wiggle_abi/req_impl.rs
@@ -846,7 +846,11 @@ impl FastlyHttpReq for Session {
         let done_index = self
             .select_impl(
                 memory
-                    // TODO: wiggle only supports slices of u8 in 22.0.0
+                    // TODO: `GuestMemory::as_slice` only supports guest pointers to u8 slices in
+                    // wiggle 22.0.0, but `GuestMemory::to_vec` supports guest pointers to slices
+                    // of arbitrary types. As `GuestMemory::to_vec` will copy the contents of the
+                    // slice out of guest memory, we should switch this to `GuestMemory::as_slice`
+                    // once it is polymorphic in the element type of the slice.
                     .to_vec(pending_req_handles)?
                     .into_iter()
                     .map(|handle| PendingRequestHandle::from(handle).into()),

--- a/lib/src/wiggle_abi/resp_impl.rs
+++ b/lib/src/wiggle_abi/resp_impl.rs
@@ -15,115 +15,129 @@ use {
     },
     cfg_if::cfg_if,
     hyper::http::response::Response,
-    wiggle::GuestPtr,
+    wiggle::{GuestMemory, GuestPtr},
 };
 
 impl FastlyHttpResp for Session {
-    fn new(&mut self) -> Result<ResponseHandle, Error> {
+    fn new(&mut self, _memory: &mut GuestMemory<'_>) -> Result<ResponseHandle, Error> {
         // KTM: Unfortunately `response::Parts` doesn't expose a constructor. This is a workaround.
         let (parts, _) = Response::new(()).into_parts();
         Ok(self.insert_response_parts(parts))
     }
 
-    fn header_names_get<'a>(
+    fn header_names_get(
         &mut self,
+        memory: &mut GuestMemory<'_>,
         resp_handle: ResponseHandle,
-        buf: &GuestPtr<u8>,
+        buf: GuestPtr<u8>,
         buf_len: u32,
         cursor: MultiValueCursor,
-        ending_cursor_out: &GuestPtr<MultiValueCursorResult>,
-        nwritten_out: &GuestPtr<u32>,
+        ending_cursor_out: GuestPtr<MultiValueCursorResult>,
+        nwritten_out: GuestPtr<u32>,
     ) -> Result<(), Error> {
         let headers = &self.response_parts(resp_handle)?.headers;
         multi_value_result!(
-            headers.names_get(buf, buf_len, cursor, nwritten_out),
+            memory,
+            headers.names_get(memory, buf, buf_len, cursor, nwritten_out),
             ending_cursor_out
         )
     }
 
-    fn header_value_get<'a>(
+    fn header_value_get(
         &mut self,
+        memory: &mut GuestMemory<'_>,
         resp_handle: ResponseHandle,
-        name: &GuestPtr<[u8]>,
-        value: &GuestPtr<u8>,
+        name: GuestPtr<[u8]>,
+        value: GuestPtr<u8>,
         value_max_len: u32,
-        nwritten_out: &GuestPtr<u32>,
+        nwritten_out: GuestPtr<u32>,
     ) -> Result<(), Error> {
         let headers = &self.response_parts(resp_handle)?.headers;
-        headers.value_get(name, value, value_max_len, nwritten_out)
+        headers.value_get(memory, name, value, value_max_len, nwritten_out)
     }
 
-    fn header_values_get<'a>(
+    fn header_values_get(
         &mut self,
+        memory: &mut GuestMemory<'_>,
         resp_handle: ResponseHandle,
-        name: &GuestPtr<[u8]>,
-        buf: &GuestPtr<u8>,
+        name: GuestPtr<[u8]>,
+        buf: GuestPtr<u8>,
         buf_len: u32,
         cursor: MultiValueCursor,
-        ending_cursor_out: &GuestPtr<MultiValueCursorResult>,
-        nwritten_out: &GuestPtr<u32>,
+        ending_cursor_out: GuestPtr<MultiValueCursorResult>,
+        nwritten_out: GuestPtr<u32>,
     ) -> Result<(), Error> {
         cfg_if! {
             if #[cfg(feature = "test-fatalerror-config")] {
                 // Avoid warnings:
-                let _ = (resp_handle, name, buf, buf_len, cursor, ending_cursor_out, nwritten_out);
+                let _ = (memory, resp_handle, name, buf, buf_len, cursor, ending_cursor_out, nwritten_out);
                 return Err(Error::FatalError("A fatal error occurred in the test-only implementation of header_values_get".to_string()));
             } else {
                 let headers = &self.response_parts(resp_handle)?.headers;
                 multi_value_result!(
-                    headers.values_get(name, buf, buf_len, cursor, nwritten_out),
+                    memory,
+                    headers.values_get(memory, name, buf, buf_len, cursor, nwritten_out),
                     ending_cursor_out
                 )
             }
         }
     }
 
-    fn header_values_set<'a>(
+    fn header_values_set(
         &mut self,
+        memory: &mut GuestMemory<'_>,
         resp_handle: ResponseHandle,
-        name: &GuestPtr<[u8]>,
-        values: &GuestPtr<[u8]>,
+        name: GuestPtr<[u8]>,
+        values: GuestPtr<[u8]>,
     ) -> Result<(), Error> {
         let headers = &mut self.response_parts_mut(resp_handle)?.headers;
-        headers.values_set(name, values)
+        headers.values_set(memory, name, values)
     }
 
-    fn header_insert<'a>(
+    fn header_insert(
         &mut self,
+        memory: &mut GuestMemory<'_>,
         resp_handle: ResponseHandle,
-        name: &GuestPtr<[u8]>,
-        value: &GuestPtr<[u8]>,
+        name: GuestPtr<[u8]>,
+        value: GuestPtr<[u8]>,
     ) -> Result<(), Error> {
         let headers = &mut self.response_parts_mut(resp_handle)?.headers;
-        HttpHeaders::insert(headers, name, value)
+        HttpHeaders::insert(headers, memory, name, value)
     }
 
     fn header_append<'a>(
         &mut self,
+        memory: &mut GuestMemory<'_>,
         resp_handle: ResponseHandle,
-        name: &GuestPtr<[u8]>,
-        value: &GuestPtr<[u8]>,
+        name: GuestPtr<[u8]>,
+        value: GuestPtr<[u8]>,
     ) -> Result<(), Error> {
         let headers = &mut self.response_parts_mut(resp_handle)?.headers;
-        HttpHeaders::append(headers, name, value)
+        HttpHeaders::append(headers, memory, name, value)
     }
 
     fn header_remove<'a>(
         &mut self,
+        memory: &mut GuestMemory<'_>,
         resp_handle: ResponseHandle,
-        name: &GuestPtr<[u8]>,
+        name: GuestPtr<[u8]>,
     ) -> Result<(), Error> {
         let headers = &mut self.response_parts_mut(resp_handle)?.headers;
-        HttpHeaders::remove(headers, name)
+        HttpHeaders::remove(headers, memory, name)
     }
 
-    fn version_get(&mut self, resp_handle: ResponseHandle) -> Result<HttpVersion, Error> {
+    fn version_get(
+        &mut self,
+        _memory: &mut GuestMemory<'_>,
+        resp_handle: ResponseHandle,
+    ) -> Result<HttpVersion, Error> {
         let resp = self.response_parts(resp_handle)?;
         HttpVersion::try_from(resp.version).map_err(|msg| Error::Unsupported { msg })
     }
 
     fn version_set(
         &mut self,
+        _memory: &mut GuestMemory<'_>,
         resp_handle: ResponseHandle,
         version: HttpVersion,
     ) -> Result<(), Error> {
@@ -136,6 +150,7 @@ impl FastlyHttpResp for Session {
 
     fn send_downstream(
         &mut self,
+        _memory: &mut GuestMemory<'_>,
         resp_handle: ResponseHandle,
         body_handle: BodyHandle,
         streaming: u32,
@@ -154,11 +169,20 @@ impl FastlyHttpResp for Session {
         self.send_downstream_response(resp)
     }
 
-    fn status_get(&mut self, resp_handle: ResponseHandle) -> Result<HttpStatus, Error> {
+    fn status_get(
+        &mut self,
+        _memory: &mut GuestMemory<'_>,
+        resp_handle: ResponseHandle,
+    ) -> Result<HttpStatus, Error> {
         Ok(self.response_parts(resp_handle)?.status.as_u16())
     }
 
-    fn status_set(&mut self, resp_handle: ResponseHandle, status: HttpStatus) -> Result<(), Error> {
+    fn status_set(
+        &mut self,
+        _memory: &mut GuestMemory<'_>,
+        resp_handle: ResponseHandle,
+        status: HttpStatus,
+    ) -> Result<(), Error> {
         let resp = self.response_parts_mut(resp_handle)?;
         let status = hyper::StatusCode::from_u16(status)?;
         resp.status = status;
@@ -167,6 +191,7 @@ impl FastlyHttpResp for Session {
 
     fn framing_headers_mode_set(
         &mut self,
+        _memory: &mut GuestMemory<'_>,
         _h: ResponseHandle,
         mode: FramingHeadersMode,
     ) -> Result<(), Error> {
@@ -178,7 +203,11 @@ impl FastlyHttpResp for Session {
         }
     }
 
-    fn close(&mut self, resp_handle: ResponseHandle) -> Result<(), Error> {
+    fn close(
+        &mut self,
+        _memory: &mut GuestMemory<'_>,
+        resp_handle: ResponseHandle,
+    ) -> Result<(), Error> {
         // We don't do anything with the parts, but we do pass the error up if
         // the handle given doesn't exist
         self.take_response_parts(resp_handle)?;
@@ -187,6 +216,7 @@ impl FastlyHttpResp for Session {
 
     fn http_keepalive_mode_set(
         &mut self,
+        _memory: &mut GuestMemory<'_>,
         _h: ResponseHandle,
         mode: HttpKeepaliveMode,
     ) -> Result<(), Error> {

--- a/lib/src/wiggle_abi/uap_impl.rs
+++ b/lib/src/wiggle_abi/uap_impl.rs
@@ -2,26 +2,26 @@
 
 use {
     crate::{error::Error, session::Session, wiggle_abi::fastly_uap::FastlyUap},
-    wiggle::GuestPtr,
+    wiggle::{GuestMemory, GuestPtr},
 };
 
 impl FastlyUap for Session {
-    #[allow(unused_variables)] // FIXME KTM 2020-06-25: Remove this directive once implemented.
-    fn parse<'a>(
+    fn parse(
         &mut self,
-        user_agent: &GuestPtr<'a, str>,
-        family: &GuestPtr<'a, u8>,
-        family_len: u32,
-        family_nwritten_out: &GuestPtr<'a, u32>,
-        major: &GuestPtr<'a, u8>,
-        major_len: u32,
-        major_nwritten_out: &GuestPtr<'a, u32>,
-        minor: &GuestPtr<'a, u8>,
-        minor_len: u32,
-        minor_nwritten_out: &GuestPtr<'a, u32>,
-        patch: &GuestPtr<'a, u8>,
-        patch_len: u32,
-        patch_nwritten_out: &GuestPtr<'a, u32>,
+        _memory: &mut GuestMemory<'_>,
+        _user_agent: GuestPtr<str>,
+        _family: GuestPtr<u8>,
+        _family_len: u32,
+        _family_nwritten_out: GuestPtr<u32>,
+        _major: GuestPtr<u8>,
+        _major_len: u32,
+        _major_nwritten_out: GuestPtr<u32>,
+        _minor: GuestPtr<u8>,
+        _minor_len: u32,
+        _minor_nwritten_out: GuestPtr<u32>,
+        _patch: GuestPtr<u8>,
+        _patch_len: u32,
+        _patch_nwritten_out: GuestPtr<u32>,
     ) -> Result<(), Error> {
         Err(Error::NotAvailable("Useragent parsing"))
     }

--- a/test-fixtures/Cargo.lock
+++ b/test-fixtures/Cargo.lock
@@ -167,9 +167,9 @@ checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "lazy_static"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
@@ -197,9 +197,9 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.84"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec96c6a92621310b51366f1e28d05ef11489516e93be030060e5fc12024a49d6"
+checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
 dependencies = [
  "unicode-ident",
 ]
@@ -245,7 +245,7 @@ checksum = "500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -297,9 +297,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.66"
+version = "2.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c42f3f41a2de00b01c0aaad383c5a45241efc8b2d1eda5661812fda5f3cdcff5"
+checksum = "901fa70d88b9d6c98022e23b4136f9f3e54e4662c3bc1bd1d84a42a9a0f0c1e9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -337,7 +337,7 @@ checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -410,9 +410,9 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "2.5.0"
+version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633"
+checksum = "22784dbdf76fdde8af1aeda5622b546b422b6fc585325248a2bf9f5e41e94d6c"
 dependencies = [
  "form_urlencoded",
  "idna",


### PR DESCRIPTION
Update to wasmtime 22.0.0.

This included some pretty substantial changes to the wiggle crate, which removes
runtime borrow checking of guest memory. This is a huge ergonomic improvement,
as the borrows are all tracked as rrust borrows instead.

One piece of functionality that's missing after the wiggle changes is the
ability to interact with a slice of guest memory that's not `&[u8]`. To work
around this, I'm copying memory over to the host, but in future releases of
wiggle we should have the ability to interact with slices that aren't just to
`u8`.
