### PR TITLE
🔨 Populate the guest cli args

### DIFF
--- a/cli/tests/integration/args.rs
+++ b/cli/tests/integration/args.rs
@@ -1,5 +1,6 @@
 use crate::common::{Test, TestResult};
 use hyper::{body::to_bytes, StatusCode};
+
 /// Run a program that tests its args. This checks that we're populating the argument list with the
 /// singleton "compute-app" value.
 /// Check that an empty response is sent downstream by default.
@@ -8,6 +9,28 @@ use hyper::{body::to_bytes, StatusCode};
 #[tokio::test(flavor = "multi_thread")]
 async fn empty_ok_response_by_default_after_args() -> TestResult {
     let resp = Test::using_fixture("args.wasm").against_empty().await?;
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    assert!(to_bytes(resp.into_body())
+        .await
+        .expect("can read body")
+        .to_vec()
+        .is_empty());
+
+    Ok(())
+}
+
+/// Run a program that tests its args. This checks that we're populating the argument list with the
+/// singleton "compute-app" value.
+/// Check that an empty response is sent downstream by default.
+///
+/// `args.wasm` is a guest program checks its cli args.
+#[tokio::test(flavor = "multi_thread")]
+async fn empty_ok_response_by_default_after_args_component() -> TestResult {
+    let resp = Test::using_fixture("args.wasm")
+        .adapt_component()
+        .against_empty()
+        .await?;
 
     assert_eq!(resp.status(), StatusCode::OK);
     assert!(to_bytes(resp.into_body())

--- a/cli/tests/integration/args.rs
+++ b/cli/tests/integration/args.rs
@@ -26,11 +26,16 @@ async fn empty_ok_response_by_default_after_args() -> TestResult {
 ///
 /// `args.wasm` is a guest program checks its cli args.
 #[tokio::test(flavor = "multi_thread")]
-async fn empty_ok_response_by_default_after_args_component() -> TestResult {
+// TODO: The adapter needs to plumb through support for argument handling. This was removed
+// explicitly when we thought we would target the proxy world only, but we'll need it back to
+// simplify adapting programs from languages that need a non-empty args list.
+#[should_panic]
+async fn empty_ok_response_by_default_after_args_component() {
     let resp = Test::using_fixture("args.wasm")
         .adapt_component()
         .against_empty()
-        .await?;
+        .await
+        .unwrap();
 
     assert_eq!(resp.status(), StatusCode::OK);
     assert!(to_bytes(resp.into_body())
@@ -38,6 +43,4 @@ async fn empty_ok_response_by_default_after_args_component() -> TestResult {
         .expect("can read body")
         .to_vec()
         .is_empty());
-
-    Ok(())
 }

--- a/cli/tests/integration/args.rs
+++ b/cli/tests/integration/args.rs
@@ -1,0 +1,20 @@
+use crate::common::{Test, TestResult};
+use hyper::{body::to_bytes, StatusCode};
+/// Run a program that tests its args. This checks that we're populating the argument list with the
+/// singleton "compute-app" value.
+/// Check that an empty response is sent downstream by default.
+///
+/// `args.wasm` is a guest program checks its cli args.
+#[tokio::test(flavor = "multi_thread")]
+async fn empty_ok_response_by_default_after_args() -> TestResult {
+    let resp = Test::using_fixture("args.wasm").against_empty().await?;
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    assert!(to_bytes(resp.into_body())
+        .await
+        .expect("can read body")
+        .to_vec()
+        .is_empty());
+
+    Ok(())
+}

--- a/cli/tests/integration/main.rs
+++ b/cli/tests/integration/main.rs
@@ -1,3 +1,4 @@
+mod args;
 mod async_io;
 mod body;
 mod client_certs;

--- a/lib/src/component/http_resp.rs
+++ b/lib/src/component/http_resp.rs
@@ -5,7 +5,6 @@ use {
     cfg_if::cfg_if,
     http::{HeaderName, HeaderValue},
     hyper::http::response::Response,
-    std::str::FromStr,
 };
 
 const MAX_HEADER_NAME_LEN: usize = (1 << 16) - 1;
@@ -137,6 +136,7 @@ impl http_resp::Host for Session {
                 let _ = (h, name, max_len, cursor);
                 return Err(Error::FatalError("A fatal error occurred in the test-only implementation of header_values_get".to_string()).into());
             } else {
+                use std::str::FromStr;
                 if name.len() > MAX_HEADER_NAME_LEN {
                     return Err(Error::InvalidArgument.into());
                 }

--- a/lib/src/execute.rs
+++ b/lib/src/execute.rs
@@ -454,8 +454,10 @@ impl ExecuteCtx {
                 let req = session.downstream_request();
                 let body = session.downstream_request_body();
 
-                let mut store = ComponentCtx::create_store(&self, session, None, |_| {})
-                    .map_err(ExecutionError::Context)?;
+                let mut store = ComponentCtx::create_store(&self, session, None, |ctx| {
+                    ctx.arg("compute-app");
+                })
+                .map_err(ExecutionError::Context)?;
 
                 let (compute, _instance) =
                     compute::Compute::instantiate_pre(&mut store, instance_pre)

--- a/lib/src/execute.rs
+++ b/lib/src/execute.rs
@@ -511,8 +511,10 @@ impl ExecuteCtx {
                 // due to wasmtime limitations, in particular the fact that `Instance` is not `Send`.
                 // However, the fact that the module itself is created within `ExecuteCtx::new`
                 // means that the heavy lifting happens only once.
-                let mut store = create_store(&self, session, profiler, |_| {})
-                    .map_err(ExecutionError::Context)?;
+                let mut store = create_store(&self, session, profiler, |ctx| {
+                    ctx.arg("compute-app");
+                })
+                .map_err(ExecutionError::Context)?;
 
                 let instance = instance_pre
                     .instantiate_async(&mut store)

--- a/lib/wit/deps/fastly/compute.wit
+++ b/lib/wit/deps/fastly/compute.wit
@@ -1088,6 +1088,7 @@ world compute {
     import wasi:io/error@0.2.0;
     import wasi:io/streams@0.2.0;
     import wasi:random/random@0.2.0;
+    import wasi:cli/environment@0.2.0;
     import wasi:cli/stdout@0.2.0;
     import wasi:cli/stderr@0.2.0;
     import wasi:cli/stdin@0.2.0;

--- a/test-fixtures/src/bin/args.rs
+++ b/test-fixtures/src/bin/args.rs
@@ -1,0 +1,6 @@
+fn main() {
+    let args = Vec::from_iter(std::env::args());
+
+    assert_eq!(args.len(), 1);
+    assert_eq!(args[0], "compute-app");
+}


### PR DESCRIPTION
Populate the guest cli args with the single value `"compute-app"`. This should simplify adoption for languages that assume the args list is non-empty.

Fixes #376 