### PR TITLE
Rework component testing support to make test updates easier

### DIFF
--- a/cli/tests/integration/args.rs
+++ b/cli/tests/integration/args.rs
@@ -32,7 +32,7 @@ async fn empty_ok_response_by_default_after_args() -> TestResult {
 #[should_panic]
 async fn empty_ok_response_by_default_after_args_component() {
     let resp = Test::using_fixture("args.wasm")
-        .adapt_component()
+        .adapt_component(true)
         .against_empty()
         .await
         .unwrap();

--- a/cli/tests/integration/common.rs
+++ b/cli/tests/integration/common.rs
@@ -21,6 +21,29 @@ pub use self::backends::TestBackends;
 
 mod backends;
 
+#[macro_export]
+macro_rules! viceroy_test {
+    ($name:ident, |$is_component:ident| $body:block) => {
+        mod $name {
+            use super::*;
+
+            async fn test_impl($is_component: bool) -> TestResult {
+                $body
+            }
+
+            #[tokio::test(flavor = "multi_thread")]
+            async fn core_wasm() -> TestResult {
+                test_impl(false).await
+            }
+
+            #[tokio::test(flavor = "multi_thread")]
+            async fn component() -> TestResult {
+                test_impl(true).await
+            }
+        }
+    };
+}
+
 /// A shorthand for the path to our test fixtures' build artifacts for Rust tests.
 ///
 /// This value can be appended with the name of a fixture's `.wasm` in a test program, using the
@@ -238,8 +261,8 @@ impl Test {
     }
 
     /// Automatically adapt the wasm to a component before running.
-    pub fn adapt_component(mut self) -> Self {
-        self.adapt_component = true;
+    pub fn adapt_component(mut self, adapt: bool) -> Self {
+        self.adapt_component = adapt;
         self
     }
 

--- a/cli/tests/integration/request.rs
+++ b/cli/tests/integration/request.rs
@@ -1,21 +1,16 @@
 use {
-    crate::common::{Test, TestResult},
+    crate::{
+        common::{Test, TestResult},
+        viceroy_test,
+    },
     hyper::StatusCode,
 };
 
-#[tokio::test(flavor = "multi_thread")]
-async fn request_works() -> TestResult {
-    let resp = Test::using_fixture("request.wasm").against_empty().await?;
-    assert_eq!(resp.status(), StatusCode::OK);
-    Ok(())
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn request_works_component() -> TestResult {
+viceroy_test!(request_works, |is_component| {
     let resp = Test::using_fixture("request.wasm")
-        .adapt_component()
+        .adapt_component(is_component)
         .against_empty()
         .await?;
     assert_eq!(resp.status(), StatusCode::OK);
     Ok(())
-}
+});

--- a/cli/tests/integration/response.rs
+++ b/cli/tests/integration/response.rs
@@ -1,21 +1,16 @@
 use {
-    crate::common::{Test, TestResult},
+    crate::{
+        common::{Test, TestResult},
+        viceroy_test,
+    },
     hyper::StatusCode,
 };
 
-#[tokio::test(flavor = "multi_thread")]
-async fn response_works() -> TestResult {
-    let resp = Test::using_fixture("response.wasm").against_empty().await?;
-    assert_eq!(resp.status(), StatusCode::OK);
-    Ok(())
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn response_works_component() -> TestResult {
+viceroy_test!(response_works, |is_component| {
     let resp = Test::using_fixture("response.wasm")
-        .adapt_component()
+        .adapt_component(is_component)
         .against_empty()
         .await?;
     assert_eq!(resp.status(), StatusCode::OK);
     Ok(())
-}
+});


### PR DESCRIPTION
Add a macro for generating the core wasm and component versions of a test, and
modify the `.adapt_component` builder function on `Test` to accept a bool. This
simplifies modifying existing tests to support components by doing the work of
abstracting out the body in a macro.
