### PR TITLE
Allow capturing logging endpoint messages

### DIFF
--- a/lib/src/linking.rs
+++ b/lib/src/linking.rs
@@ -259,13 +259,13 @@ fn make_wasi_ctx(ctx: &ExecuteCtx, session: &Session) -> WasiCtxBuilder {
         .env("FASTLY_TRACE_ID", &format!("{:032x}", session.req_id()));
 
     if ctx.log_stdout() {
-        wasi_ctx.stdout(LogEndpoint::new(b"stdout"));
+        wasi_ctx.stdout(LogEndpoint::new(b"stdout", ctx.capture_logs()));
     } else {
         wasi_ctx.inherit_stdout();
     }
 
     if ctx.log_stderr() {
-        wasi_ctx.stderr(LogEndpoint::new(b"stderr"));
+        wasi_ctx.stderr(LogEndpoint::new(b"stderr", ctx.capture_logs()));
     } else {
         wasi_ctx.inherit_stderr();
     }


### PR DESCRIPTION
Some integration tests need to capture log output in order to verify that logging endpoints work correctly from guests, but it's also potentially useful for people using Viceroy as a library.

The previous way that the integration tests did this was not reliable when multiple tests ran in parallel, because there was only one global hook for capturing logs. Exposing this as a configuration option on execution contexts instead allows each test to set independent capture buffers.

I guess this should be considered a breaking API change since `viceroy_lib::logging::LOG_WRITER` was exported publicly from the crate.