### PR TITLE
Add `downstream_server_ip_addr` hostcall

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -681,12 +681,12 @@ checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
 
 [[package]]
 name = "fastly-shared"
-version = "0.9.12"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "276812acf6f1b34029a5eb6ff3add7fe11452e1513762d02263a031097e68761"
+checksum = "68b32d7c7a252c40a66621410fdf1519a8ff50b0f77ec81c83d69db7ec2377f5"
 dependencies = [
  "bitflags 1.3.2",
- "http",
+ "http 1.1.0",
 ]
 
 [[package]]
@@ -902,7 +902,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "http",
+ "http 0.2.12",
  "indexmap",
  "slab",
  "tokio",
@@ -959,13 +959,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
 name = "http-body"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
 dependencies = [
  "bytes",
- "http",
+ "http 0.2.12",
  "pin-project-lite",
 ]
 
@@ -998,7 +1009,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http",
+ "http 0.2.12",
  "http-body",
  "httparse",
  "httpdate",
@@ -2407,7 +2418,7 @@ dependencies = [
  "fastly-shared",
  "flate2",
  "futures",
- "http",
+ "http 0.2.12",
  "http-body",
  "hyper",
  "itertools 0.10.5",

--- a/cli/tests/integration/common.rs
+++ b/cli/tests/integration/common.rs
@@ -398,9 +398,11 @@ impl Test {
                     .build()
                     .unwrap();
                 *req.uri_mut() = new_uri;
+                let local = (Ipv4Addr::LOCALHOST, 80).into();
+                let remote = (Ipv4Addr::LOCALHOST, 0).into();
                 let resp = ctx
                     .clone()
-                    .handle_request(req.map(Into::into), Ipv4Addr::LOCALHOST.into())
+                    .handle_request(req.map(Into::into), local, remote)
                     .await
                     .map(|result| {
                         match result {

--- a/cli/tests/trap-test/Cargo.lock
+++ b/cli/tests/trap-test/Cargo.lock
@@ -691,12 +691,12 @@ checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
 
 [[package]]
 name = "fastly-shared"
-version = "0.9.12"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "276812acf6f1b34029a5eb6ff3add7fe11452e1513762d02263a031097e68761"
+checksum = "68b32d7c7a252c40a66621410fdf1519a8ff50b0f77ec81c83d69db7ec2377f5"
 dependencies = [
  "bitflags 1.3.2",
- "http",
+ "http 1.1.0",
 ]
 
 [[package]]
@@ -906,7 +906,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "http",
+ "http 0.2.12",
  "indexmap",
  "slab",
  "tokio",
@@ -963,13 +963,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
 name = "http-body"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
 dependencies = [
  "bytes",
- "http",
+ "http 0.2.12",
  "pin-project-lite",
 ]
 
@@ -1002,7 +1013,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http",
+ "http 0.2.12",
  "http-body",
  "httparse",
  "httpdate",
@@ -2224,7 +2235,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "futures",
- "http",
+ "http 0.2.12",
  "hyper",
  "tokio",
  "tracing-subscriber",
@@ -2331,7 +2342,7 @@ dependencies = [
  "fastly-shared",
  "flate2",
  "futures",
- "http",
+ "http 0.2.12",
  "http-body",
  "hyper",
  "itertools 0.10.5",

--- a/cli/tests/trap-test/src/main.rs
+++ b/cli/tests/trap-test/src/main.rs
@@ -24,8 +24,10 @@ async fn fatal_error_traps_impl(adapt_core_wasm: bool) -> TestResult {
         adapt_core_wasm,
     )?;
     let req = Request::get("http://127.0.0.1:7676/").body(Body::from(""))?;
+    let local = "127.0.0.1:80".parse().unwrap();
+    let remote = "127.0.0.1:0".parse().unwrap();
     let resp = ctx
-        .handle_request_with_runtime_error(req, "127.0.0.1".parse().unwrap())
+        .handle_request_with_runtime_error(req, local, remote)
         .await?;
 
     // The Guest was terminated and so should return a 500.

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -32,7 +32,7 @@ bytesize = "^1.1.0"
 cfg-if = "^1.0"
 clap = { workspace = true }
 cranelift-entity = "^0.88.1"
-fastly-shared = "^0.9.11"
+fastly-shared = "^0.10.1"
 flate2 = "^1.0.24"
 futures = { workspace = true }
 http = "^0.2.8"

--- a/lib/compute-at-edge-abi/compute-at-edge.witx
+++ b/lib/compute-at-edge-abi/compute-at-edge.witx
@@ -172,6 +172,12 @@
         (result $err (expected $num_bytes (error $fastly_status)))
     )
 
+    (@interface func (export "downstream_server_ip_addr")
+        ;; must be a 16-byte array
+        (param $addr_octets_out (@witx pointer (@witx char8)))
+        (result $err (expected $num_bytes (error $fastly_status)))
+    )
+
     (@interface func (export "downstream_client_h2_fingerprint")
         (param $h2fp_out (@witx pointer (@witx char8)))
         (param $h2fp_max_len (@witx usize))

--- a/lib/src/component/http_req.rs
+++ b/lib/src/component/http_req.rs
@@ -18,6 +18,7 @@ use {
         request::Request,
         Method, Uri,
     },
+    std::net::IpAddr,
     std::str::FromStr,
 };
 
@@ -107,7 +108,6 @@ impl http_req::Host for Session {
     }
 
     async fn downstream_client_ip_addr(&mut self) -> Result<Vec<u8>, types::Error> {
-        use std::net::IpAddr;
         match self.downstream_client_ip() {
             IpAddr::V4(addr) => {
                 let octets = addr.octets();
@@ -123,7 +123,18 @@ impl http_req::Host for Session {
     }
 
     async fn downstream_server_ip_addr(&mut self) -> Result<Vec<u8>, types::Error> {
-        Err(Error::NotAvailable("Downstream server ip address").into())
+        match self.downstream_server_ip() {
+            IpAddr::V4(addr) => {
+                let octets = addr.octets();
+                debug_assert_eq!(octets.len(), 4);
+                Ok(Vec::from(octets))
+            }
+            IpAddr::V6(addr) => {
+                let octets = addr.octets();
+                debug_assert_eq!(octets.len(), 16);
+                Ok(Vec::from(octets))
+            }
+        }
     }
 
     async fn downstream_tls_cipher_openssl_name(

--- a/test-fixtures/Cargo.lock
+++ b/test-fixtures/Cargo.lock
@@ -61,9 +61,9 @@ dependencies = [
 
 [[package]]
 name = "fastly"
-version = "0.9.12"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ce91a71c1576ca56ff2de349550d175e70004515499c64c845b1b40a017b075"
+checksum = "a5a264a5d96c95d4417ec84325d9da58a6790fa856365f87bb66bd27ee3c65da"
 dependencies = [
  "anyhow",
  "bytes",
@@ -84,9 +84,9 @@ dependencies = [
 
 [[package]]
 name = "fastly-macros"
-version = "0.9.12"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5d5de12e9bc451138b281cee3cc57e8b1f3b46b7afb8d0d201e6b50d1f6b574"
+checksum = "9bc9655039ed2895c60f644fb7c68abf29f0b0a5b01dd76f2a9d2745665773ab"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -95,9 +95,9 @@ dependencies = [
 
 [[package]]
 name = "fastly-shared"
-version = "0.9.12"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "276812acf6f1b34029a5eb6ff3add7fe11452e1513762d02263a031097e68761"
+checksum = "68b32d7c7a252c40a66621410fdf1519a8ff50b0f77ec81c83d69db7ec2377f5"
 dependencies = [
  "bitflags",
  "http",
@@ -105,9 +105,9 @@ dependencies = [
 
 [[package]]
 name = "fastly-sys"
-version = "0.9.12"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b71f4531944113114b69571608a2d9a98bca6a656ff6d7b87cac726ff70e00d"
+checksum = "da26ca0ff94d3bd29e38e86be8c57495fe21ae0cf1203cc2f9106255478e6df2"
 dependencies = [
  "bitflags",
  "fastly-shared",
@@ -140,9 +140,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.12"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
 dependencies = [
  "bytes",
  "fnv",

--- a/test-fixtures/Cargo.toml
+++ b/test-fixtures/Cargo.toml
@@ -9,10 +9,10 @@ publish = false
 
 [dependencies]
 base64 = "0.21.2"
-fastly = "0.9.11"
-fastly-shared = "0.9.11"
-fastly-sys = "0.9.11"
+fastly = "0.10.1"
+fastly-shared = "0.10.1"
+fastly-sys = "0.10.1"
 bytes = "1.0.0"
-http = "0.2.9"
+http = "1.1.0"
 rustls-pemfile = "1.0.3"
 serde = "1.0.114"

--- a/test-fixtures/src/bin/downstream-req.rs
+++ b/test-fixtures/src/bin/downstream-req.rs
@@ -25,6 +25,9 @@ fn main() {
     let localhost: IpAddr = "127.0.0.1".parse().unwrap();
     assert_eq!(client_req.get_client_ip_addr().unwrap(), localhost);
 
+    let localhost: IpAddr = "127.0.0.1".parse().unwrap();
+    assert_eq!(client_req.get_server_ip_addr().unwrap(), localhost);
+
     assert_eq!(client_req.get_tls_cipher_openssl_name(), None);
     assert_eq!(client_req.get_tls_cipher_openssl_name_bytes(), None);
     assert_eq!(client_req.get_tls_client_hello(), None);


### PR DESCRIPTION
A customer noticed when trying to use the Rust SDK's `Request::get_server_ip` method that the  `downstream_server_ip_addr` hostcall is not yet implemented in Viceroy. This PR adds support for it. I've also updated the SDK version used in the tests to be the latest release.