### PR TITLE
Release on macOS amd64

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,8 +15,6 @@ jobs:
         exclude:
           - os: windows-2022
             arch: arm64
-          - os: macos-14
-            arch: amd64
         include:
           - os: ubuntu-24.04
             name: linux

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,10 +10,6 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-24.04, windows-2022, macos-14]
-        arch: [amd64, arm64]
-        exclude:
-          - os: windows-2022
-            arch: arm64
     runs-on: ${{ matrix.platform }}
     steps:
     - name: Checkout code
@@ -57,10 +53,6 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-24.04, windows-2022, macos-14]
-        arch: [amd64, arm64]
-        exclude:
-          - os: windows-2022
-            arch: arm64
     runs-on: ${{ matrix.platform }}
     steps:
     - name: Checkout code

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,10 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-24.04, windows-2022, macos-14]
+        arch: [amd64, arm64]
+        exclude:
+          - os: windows-2022
+            arch: arm64
     runs-on: ${{ matrix.platform }}
     steps:
     - name: Checkout code
@@ -53,6 +57,10 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-24.04, windows-2022, macos-14]
+        arch: [amd64, arm64]
+        exclude:
+          - os: windows-2022
+            arch: arm64
     runs-on: ${{ matrix.platform }}
     steps:
     - name: Checkout code


### PR DESCRIPTION
Reverts a change made in #388 that prevented builds being generated for macOS amd64 machines.