### PR TITLE
⬅ Switch back to `ubuntu-20.04` runners for CI and release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,13 +10,13 @@ jobs:
     strategy:
       matrix:
         rust-toolchain: [stable]
-        os: [ubuntu-24.04, macos-14, windows-2022]
+        os: [ubuntu-20.04, macos-14, windows-2022]
         arch: [amd64, arm64]
         exclude:
           - os: windows-2022
             arch: arm64
         include:
-          - os: ubuntu-24.04
+          - os: ubuntu-20.04
             name: linux
             rust_abi: unknown-linux-gnu
           - os: macos-14
@@ -86,7 +86,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   publish:
     needs: build
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-20.04
     steps:
       - name: publish
         uses: actions/github-script@v6

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
   test:
     strategy:
       matrix:
-        platform: [ubuntu-24.04, windows-2022, macos-14]
+        platform: [ubuntu-20.04, windows-2022, macos-14]
     runs-on: ${{ matrix.platform }}
     steps:
     - name: Checkout code
@@ -52,7 +52,7 @@ jobs:
   trap-test:
     strategy:
       matrix:
-        platform: [ubuntu-24.04, windows-2022, macos-14]
+        platform: [ubuntu-20.04, windows-2022, macos-14]
     runs-on: ${{ matrix.platform }}
     steps:
     - name: Checkout code
@@ -82,7 +82,7 @@ jobs:
       shell: bash
 
   package-check:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
The previous change in #388 inadvertently raised the required minimum glibc versions for our Linux release binaries. This patch returns the runners to 20.04 for the moment, though testing against multiple `ubuntu` runners may be added in the future.