### PR TITLE
Use mozilla-actions/sccache-action for caching builds

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,9 @@ jobs:
       matrix:
         platform: [ubuntu-20.04, ubuntu-22.04, ubuntu-24.04, windows-2022, macos-12, macos-13, macos-14]
     runs-on: ${{ matrix.platform }}
+    env:
+      SCCACHE_GHA_ENABLED: "true"
+      RUSTC_WRAPPER: "sccache"
     steps:
     - name: Checkout code
       uses: actions/checkout@v3
@@ -27,13 +30,10 @@ jobs:
       uses: actions/cache@v3
       with:
         path: |
-          ~/.cargo/bin/
-          ~/.cargo/registry/index/
-          ~/.cargo/registry/cache/
-          ~/.cargo/git/db/
-          target/
-          test-fixtures/target/
+          ~/.cargo/registry
         key: ${{ runner.os }}-cargo-v${{ env.CACHE_GENERATION }}-${{ steps.toolchain.outputs.rustc_hash }}-${{ hashFiles('**/Cargo.lock') }}
+    - name: Run sccache-cache
+      uses: mozilla-actions/sccache-action@v0.0.5
     - name: Install rustfmt
       run: rustup component add rustfmt
       shell: bash
@@ -54,6 +54,9 @@ jobs:
       matrix:
         platform: [ubuntu-20.04, ubuntu-22.04, ubuntu-24.04, windows-2022, macos-12, macos-13, macos-14]
     runs-on: ${{ matrix.platform }}
+    env:
+      SCCACHE_GHA_ENABLED: "true"
+      RUSTC_WRAPPER: "sccache"
     steps:
     - name: Checkout code
       uses: actions/checkout@v3
@@ -70,13 +73,10 @@ jobs:
       uses: actions/cache@v3
       with:
         path: |
-          ~/.cargo/bin/
-          ~/.cargo/registry/index/
-          ~/.cargo/registry/cache/
-          ~/.cargo/git/db/
-          cli/tests/trap-test/target/
-          test-fixtures/target/
+          ~/.cargo/registry
         key: ${{ runner.os }}-cargo-trap-v${{ env.CACHE_GENERATION }}-${{ steps.toolchain.outputs.rustc_hash }}-${{ hashFiles('**/Cargo.lock') }}
+    - name: Run sccache-cache
+      uses: mozilla-actions/sccache-action@v0.0.5
     - name: trap-test
       run: make trap-test-ci
       shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,7 +74,7 @@ jobs:
       with:
         path: |
           ~/.cargo/registry
-        key: ${{ runner.os }}-cargo-trap-v${{ env.CACHE_GENERATION }}-${{ steps.toolchain.outputs.rustc_hash }}-${{ hashFiles('**/Cargo.lock') }}
+        key: ${{ matrix.platform }}-cargo-trap-v${{ env.CACHE_GENERATION }}-${{ steps.toolchain.outputs.rustc_hash }}-${{ hashFiles('**/Cargo.lock') }}
     - name: Run sccache-cache
       uses: mozilla-actions/sccache-action@v0.0.5
     - name: trap-test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
       with:
         path: |
           ~/.cargo/registry
-        key: ${{ runner.os }}-cargo-v${{ env.CACHE_GENERATION }}-${{ steps.toolchain.outputs.rustc_hash }}-${{ hashFiles('**/Cargo.lock') }}
+        key: ${{ matrix.platform }}-cargo-v${{ env.CACHE_GENERATION }}-${{ steps.toolchain.outputs.rustc_hash }}-${{ hashFiles('**/Cargo.lock') }}
     - name: Run sccache-cache
       uses: mozilla-actions/sccache-action@v0.0.5
     - name: Install rustfmt


### PR DESCRIPTION
There seems to be something weird with with how we're using the GitHub Action cache that both @kpfleming and I have hit today that's breaking the test CI. I've had a good experience using [mozilla-actions/sccache-action](https://github.com/mozilla-actions/sccache-action) elsewhere, so I've made this PR to try out using it instead of saving and restoring the `target/` directories. I've adjusted `actions/cache` to only save `~/.cargo/registry`.