### PR TITLE
Implement component traits on ComponentCtx

### DIFF
--- a/lib/src/component/async_io.rs
+++ b/lib/src/component/async_io.rs
@@ -1,12 +1,12 @@
 use {
     super::fastly::api::{async_io, types},
-    crate::{session::Session, wiggle_abi},
+    crate::{linking::ComponentCtx, wiggle_abi},
     futures::FutureExt,
     std::time::Duration,
 };
 
 #[async_trait::async_trait]
-impl async_io::Host for Session {
+impl async_io::Host for ComponentCtx {
     async fn select(
         &mut self,
         hs: Vec<async_io::Handle>,
@@ -16,7 +16,7 @@ impl async_io::Host for Session {
             return Err(types::Error::InvalidArgument.into());
         }
 
-        let select_fut = self.select_impl(
+        let select_fut = self.session.select_impl(
             hs.iter()
                 .copied()
                 .map(|i| wiggle_abi::types::AsyncItemHandle::from(i).into()),
@@ -44,6 +44,7 @@ impl async_io::Host for Session {
     async fn is_ready(&mut self, handle: async_io::Handle) -> Result<bool, types::Error> {
         let handle = wiggle_abi::types::AsyncItemHandle::from(handle);
         Ok(self
+            .session
             .async_item_mut(handle.into())?
             .await_ready()
             .now_or_never()

--- a/lib/src/component/backend.rs
+++ b/lib/src/component/backend.rs
@@ -1,12 +1,12 @@
 use {
     super::fastly::api::{backend, http_types, types},
-    crate::{error::Error, session::Session},
+    crate::{error::Error, linking::ComponentCtx},
 };
 
 #[async_trait::async_trait]
-impl backend::Host for Session {
+impl backend::Host for ComponentCtx {
     async fn exists(&mut self, backend: String) -> Result<bool, types::Error> {
-        Ok(self.backend(&backend).is_some())
+        Ok(self.session.backend(&backend).is_some())
     }
 
     async fn is_healthy(
@@ -14,14 +14,17 @@ impl backend::Host for Session {
         backend: String,
     ) -> Result<backend::BackendHealth, types::Error> {
         // just doing this to get a different error if the backend doesn't exist
-        let _ = self.backend(&backend).ok_or(Error::InvalidArgument)?;
+        let _ = self
+            .session
+            .backend(&backend)
+            .ok_or(Error::InvalidArgument)?;
         Ok(backend::BackendHealth::Unknown)
     }
 
     async fn is_dynamic(&mut self, backend: String) -> Result<bool, types::Error> {
-        if self.dynamic_backend(&backend).is_some() {
+        if self.session.dynamic_backend(&backend).is_some() {
             Ok(true)
-        } else if self.backend(&backend).is_some() {
+        } else if self.session.backend(&backend).is_some() {
             Ok(false)
         } else {
             Err(Error::InvalidArgument.into())
@@ -29,7 +32,10 @@ impl backend::Host for Session {
     }
 
     async fn get_host(&mut self, backend: String, max_len: u64) -> Result<String, types::Error> {
-        let backend = self.backend(&backend).ok_or(Error::InvalidArgument)?;
+        let backend = self
+            .session
+            .backend(&backend)
+            .ok_or(Error::InvalidArgument)?;
 
         let host = backend.uri.host().expect("backend uri has host");
 
@@ -49,7 +55,10 @@ impl backend::Host for Session {
         backend: String,
         max_len: u64,
     ) -> Result<Option<Vec<u8>>, types::Error> {
-        let backend = self.backend(&backend).ok_or(Error::InvalidArgument)?;
+        let backend = self
+            .session
+            .backend(&backend)
+            .ok_or(Error::InvalidArgument)?;
         if let Some(host) = backend.override_host.as_ref() {
             let host = host.to_str()?;
 
@@ -68,7 +77,10 @@ impl backend::Host for Session {
     }
 
     async fn get_port(&mut self, backend: String) -> Result<u16, types::Error> {
-        let backend = self.backend(&backend).ok_or(Error::InvalidArgument)?;
+        let backend = self
+            .session
+            .backend(&backend)
+            .ok_or(Error::InvalidArgument)?;
         match backend.uri.port_u16() {
             Some(port) => Ok(port),
             None => {
@@ -83,7 +95,10 @@ impl backend::Host for Session {
 
     async fn get_connect_timeout_ms(&mut self, backend: String) -> Result<u32, types::Error> {
         // just doing this to get a different error if the backend doesn't exist
-        let _ = self.backend(&backend).ok_or(Error::InvalidArgument)?;
+        let _ = self
+            .session
+            .backend(&backend)
+            .ok_or(Error::InvalidArgument)?;
         Err(Error::Unsupported {
             msg: "connection timing is not actually supported in Viceroy",
         }
@@ -92,7 +107,10 @@ impl backend::Host for Session {
 
     async fn get_first_byte_timeout_ms(&mut self, backend: String) -> Result<u32, types::Error> {
         // just doing this to get a different error if the backend doesn't exist
-        let _ = self.backend(&backend).ok_or(Error::InvalidArgument)?;
+        let _ = self
+            .session
+            .backend(&backend)
+            .ok_or(Error::InvalidArgument)?;
         Err(Error::Unsupported {
             msg: "connection timing is not actually supported in Viceroy",
         }
@@ -101,7 +119,10 @@ impl backend::Host for Session {
 
     async fn get_between_bytes_timeout_ms(&mut self, backend: String) -> Result<u32, types::Error> {
         // just doing this to get a different error if the backend doesn't exist
-        let _ = self.backend(&backend).ok_or(Error::InvalidArgument)?;
+        let _ = self
+            .session
+            .backend(&backend)
+            .ok_or(Error::InvalidArgument)?;
         Err(Error::Unsupported {
             msg: "connection timing is not actually supported in Viceroy",
         }
@@ -109,7 +130,10 @@ impl backend::Host for Session {
     }
 
     async fn is_ssl(&mut self, backend: String) -> Result<bool, types::Error> {
-        let backend = self.backend(&backend).ok_or(Error::InvalidArgument)?;
+        let backend = self
+            .session
+            .backend(&backend)
+            .ok_or(Error::InvalidArgument)?;
         Ok(backend.uri.scheme() == Some(&http::uri::Scheme::HTTPS))
     }
 
@@ -118,7 +142,10 @@ impl backend::Host for Session {
         backend: String,
     ) -> Result<Option<http_types::TlsVersion>, types::Error> {
         // just doing this to get a different error if the backend doesn't exist
-        let _ = self.backend(&backend).ok_or(Error::InvalidArgument)?;
+        let _ = self
+            .session
+            .backend(&backend)
+            .ok_or(Error::InvalidArgument)?;
         // health checks are not enabled in Viceroy :(
         Err(Error::Unsupported {
             msg: "ssl version flags are not supported in Viceroy",
@@ -131,7 +158,10 @@ impl backend::Host for Session {
         backend: String,
     ) -> Result<Option<http_types::TlsVersion>, types::Error> {
         // just doing this to get a different error if the backend doesn't exist
-        let _ = self.backend(&backend).ok_or(Error::InvalidArgument)?;
+        let _ = self
+            .session
+            .backend(&backend)
+            .ok_or(Error::InvalidArgument)?;
         // health checks are not enabled in Viceroy :(
         Err(Error::Unsupported {
             msg: "ssl version flags are not supported in Viceroy",

--- a/lib/src/component/cache.rs
+++ b/lib/src/component/cache.rs
@@ -1,10 +1,10 @@
 use {
     super::fastly::api::{cache, http_types, types},
-    crate::{error::Error, session::Session},
+    crate::{error::Error, linking::ComponentCtx},
 };
 
 #[async_trait::async_trait]
-impl cache::Host for Session {
+impl cache::Host for ComponentCtx {
     async fn lookup(
         &mut self,
         _key: String,

--- a/lib/src/component/compute_runtime.rs
+++ b/lib/src/component/compute_runtime.rs
@@ -1,10 +1,10 @@
 use super::fastly::api::{compute_runtime, types};
-use crate::session::Session;
+use crate::linking::ComponentCtx;
 use std::sync::atomic::Ordering;
 
 #[async_trait::async_trait]
-impl compute_runtime::Host for Session {
+impl compute_runtime::Host for ComponentCtx {
     async fn get_vcpu_ms(&mut self) -> Result<u64, types::Error> {
-        Ok(self.active_cpu_time_us.load(Ordering::SeqCst) / 1000)
+        Ok(self.session.active_cpu_time_us.load(Ordering::SeqCst) / 1000)
     }
 }

--- a/lib/src/component/config_store.rs
+++ b/lib/src/component/config_store.rs
@@ -1,12 +1,12 @@
 use {
     super::fastly::api::{config_store, types},
-    crate::session::Session,
+    crate::linking::ComponentCtx,
 };
 
 #[async_trait::async_trait]
-impl config_store::Host for Session {
+impl config_store::Host for ComponentCtx {
     async fn open(&mut self, name: String) -> Result<config_store::Handle, types::Error> {
-        let handle = self.dictionary_handle(name.as_str())?;
+        let handle = self.session.dictionary_handle(name.as_str())?;
         Ok(handle.into())
     }
 
@@ -16,7 +16,7 @@ impl config_store::Host for Session {
         name: String,
         max_len: u64,
     ) -> Result<Option<Vec<u8>>, types::Error> {
-        let dict = &self.dictionary(store.into())?.contents;
+        let dict = &self.session.dictionary(store.into())?.contents;
 
         let item = if let Some(item) = dict.get(&name) {
             item

--- a/lib/src/component/device_detection.rs
+++ b/lib/src/component/device_detection.rs
@@ -1,16 +1,16 @@
 use {
     super::fastly::api::{device_detection, types},
-    crate::session::Session,
+    crate::linking::ComponentCtx,
 };
 
 #[async_trait::async_trait]
-impl device_detection::Host for Session {
+impl device_detection::Host for ComponentCtx {
     async fn lookup(
         &mut self,
         user_agent: String,
         max_len: u64,
     ) -> Result<Option<Vec<u8>>, types::Error> {
-        if let Some(result) = self.device_detection_lookup(&user_agent) {
+        if let Some(result) = self.session.device_detection_lookup(&user_agent) {
             if result.len() > max_len as usize {
                 return Err(types::Error::BufferLen(
                     u64::try_from(result.len()).unwrap_or(0),

--- a/lib/src/component/dictionary.rs
+++ b/lib/src/component/dictionary.rs
@@ -1,12 +1,12 @@
 use {
     super::fastly::api::{dictionary, types},
-    crate::session::Session,
+    crate::linking::ComponentCtx,
 };
 
 #[async_trait::async_trait]
-impl dictionary::Host for Session {
+impl dictionary::Host for ComponentCtx {
     async fn open(&mut self, name: String) -> Result<dictionary::Handle, types::Error> {
-        let handle = self.dictionary_handle(name.as_str())?;
+        let handle = self.session.dictionary_handle(name.as_str())?;
         Ok(handle.into())
     }
 
@@ -16,7 +16,7 @@ impl dictionary::Host for Session {
         key: String,
         max_len: u64,
     ) -> Result<Option<Vec<u8>>, types::Error> {
-        let dict = &self.dictionary(h.into())?.contents;
+        let dict = &self.session.dictionary(h.into())?.contents;
 
         let item = if let Some(item) = dict.get(&key) {
             item

--- a/lib/src/component/erl.rs
+++ b/lib/src/component/erl.rs
@@ -1,10 +1,10 @@
 use {
     super::fastly::api::{erl, types},
-    crate::session::Session,
+    crate::linking::ComponentCtx,
 };
 
 #[async_trait::async_trait]
-impl erl::Host for Session {
+impl erl::Host for ComponentCtx {
     async fn check_rate(
         &mut self,
         _rc: String,

--- a/lib/src/component/geo.rs
+++ b/lib/src/component/geo.rs
@@ -1,11 +1,11 @@
 use {
     super::fastly::api::{geo, types},
-    crate::{error, session::Session},
+    crate::{error, linking::ComponentCtx},
     std::net::{IpAddr, Ipv4Addr, Ipv6Addr},
 };
 
 #[async_trait::async_trait]
-impl geo::Host for Session {
+impl geo::Host for ComponentCtx {
     async fn lookup(&mut self, octets: Vec<u8>, max_len: u64) -> Result<Vec<u8>, types::Error> {
         let ip_addr: IpAddr = match octets.len() {
             4 => IpAddr::V4(Ipv4Addr::from(
@@ -18,6 +18,7 @@ impl geo::Host for Session {
         };
 
         let json = self
+            .session
             .geolocation_lookup(&ip_addr)
             .ok_or(geo::Error::UnknownError)?;
 

--- a/lib/src/component/http_resp.rs
+++ b/lib/src/component/http_resp.rs
@@ -1,7 +1,7 @@
 use {
     super::fastly::api::{http_resp, http_types, types},
     super::{headers::write_values, types::TrappableError},
-    crate::{error::Error, session::Session, upstream},
+    crate::{error::Error, linking::ComponentCtx, upstream},
     cfg_if::cfg_if,
     http::{HeaderName, HeaderValue},
     hyper::http::response::Response,
@@ -11,17 +11,17 @@ use {
 const MAX_HEADER_NAME_LEN: usize = (1 << 16) - 1;
 
 #[async_trait::async_trait]
-impl http_resp::Host for Session {
+impl http_resp::Host for ComponentCtx {
     async fn new(&mut self) -> Result<http_types::ResponseHandle, types::Error> {
         let (parts, _) = Response::new(()).into_parts();
-        Ok(self.insert_response_parts(parts).into())
+        Ok(self.session.insert_response_parts(parts).into())
     }
 
     async fn status_get(
         &mut self,
         h: http_types::ResponseHandle,
     ) -> Result<http_types::HttpStatus, types::Error> {
-        let parts = self.response_parts(h.into())?;
+        let parts = self.session.response_parts(h.into())?;
         Ok(parts.status.as_u16())
     }
 
@@ -30,7 +30,7 @@ impl http_resp::Host for Session {
         h: http_types::ResponseHandle,
         status: http_types::HttpStatus,
     ) -> Result<(), types::Error> {
-        let resp = self.response_parts_mut(h.into())?;
+        let resp = self.session.response_parts_mut(h.into())?;
         let status = hyper::StatusCode::from_u16(status)?;
         resp.status = status;
         Ok(())
@@ -46,7 +46,7 @@ impl http_resp::Host for Session {
             Err(types::Error::InvalidArgument)?;
         }
 
-        let headers = &mut self.response_parts_mut(h.into())?.headers;
+        let headers = &mut self.session.response_parts_mut(h.into())?.headers;
         let name = HeaderName::from_bytes(name.as_bytes())?;
         let value = HeaderValue::from_bytes(value.as_slice())?;
         headers.append(name, value);
@@ -62,15 +62,15 @@ impl http_resp::Host for Session {
         let resp = {
             // Take the response parts and body from the session, and use them to build a response.
             // Return an `FastlyStatus::Badf` error code if either of the given handles are invalid.
-            let resp_parts = self.take_response_parts(h.into())?;
+            let resp_parts = self.session.take_response_parts(h.into())?;
             let body = if streaming {
-                self.begin_streaming(b.into())?
+                self.session.begin_streaming(b.into())?
             } else {
-                self.take_body(b.into())?
+                self.session.take_body(b.into())?
             };
             Response::from_parts(resp_parts, body)
         }; // Set the downstream response, and return.
-        self.send_downstream_response(resp)?;
+        self.session.send_downstream_response(resp)?;
         Ok(())
     }
 
@@ -80,7 +80,7 @@ impl http_resp::Host for Session {
         max_len: u64,
         cursor: u32,
     ) -> Result<Option<(Vec<u8>, Option<u32>)>, types::Error> {
-        let headers = &self.response_parts(h.into())?.headers;
+        let headers = &self.session.response_parts(h.into())?.headers;
 
         let (buf, next) = write_values(
             headers.keys(),
@@ -110,7 +110,7 @@ impl http_resp::Host for Session {
             return Err(Error::InvalidArgument.into());
         }
 
-        let headers = &self.response_parts(h.into())?.headers;
+        let headers = &self.session.response_parts(h.into())?.headers;
         let value = if let Some(value) = headers.get(&name) {
             value
         } else {
@@ -142,7 +142,7 @@ impl http_resp::Host for Session {
                     return Err(Error::InvalidArgument.into());
                 }
 
-                let headers = &self.response_parts(h.into())?.headers;
+                let headers = &self.session.response_parts(h.into())?.headers;
 
                 let values = headers.get_all(HeaderName::from_str(&name)?);
 
@@ -176,7 +176,7 @@ impl http_resp::Host for Session {
             return Err(Error::InvalidArgument.into());
         }
 
-        let headers = &mut self.response_parts_mut(h.into())?.headers;
+        let headers = &mut self.session.response_parts_mut(h.into())?.headers;
 
         let name = HeaderName::from_bytes(name.as_bytes())?;
         let values = {
@@ -210,7 +210,7 @@ impl http_resp::Host for Session {
             return Err(Error::InvalidArgument.into());
         }
 
-        let headers = &mut self.response_parts_mut(h.into())?.headers;
+        let headers = &mut self.session.response_parts_mut(h.into())?.headers;
         let name = HeaderName::from_bytes(name.as_bytes())?;
         let value = HeaderValue::from_bytes(value.as_slice())?;
         headers.insert(name, value);
@@ -227,7 +227,7 @@ impl http_resp::Host for Session {
             return Err(Error::InvalidArgument.into());
         }
 
-        let headers = &mut self.response_parts_mut(h.into())?.headers;
+        let headers = &mut self.session.response_parts_mut(h.into())?.headers;
         let name = HeaderName::from_bytes(name.as_bytes())?;
         headers
             .remove(name)
@@ -240,7 +240,7 @@ impl http_resp::Host for Session {
         &mut self,
         h: http_types::ResponseHandle,
     ) -> Result<http_types::HttpVersion, types::Error> {
-        let req = self.response_parts(h.into())?;
+        let req = self.session.response_parts(h.into())?;
         let version = http_types::HttpVersion::try_from(req.version)?;
         Ok(version)
     }
@@ -250,7 +250,7 @@ impl http_resp::Host for Session {
         h: http_types::ResponseHandle,
         version: http_types::HttpVersion,
     ) -> Result<(), types::Error> {
-        let req = self.response_parts_mut(h.into())?;
+        let req = self.session.response_parts_mut(h.into())?;
         req.version = hyper::Version::from(version);
         Ok(())
     }
@@ -258,7 +258,7 @@ impl http_resp::Host for Session {
     async fn close(&mut self, h: http_types::ResponseHandle) -> Result<(), types::Error> {
         // We don't do anything with the parts, but we do pass the error up if
         // the handle given doesn't exist
-        self.take_response_parts(h.into())?;
+        self.session.take_response_parts(h.into())?;
         Ok(())
     }
 
@@ -292,7 +292,7 @@ impl http_resp::Host for Session {
         &mut self,
         resp_handle: http_types::ResponseHandle,
     ) -> Result<Vec<u8>, types::Error> {
-        let resp = self.response_parts(resp_handle.into())?;
+        let resp = self.session.response_parts(resp_handle.into())?;
         let md = resp
             .extensions
             .get::<upstream::ConnMetadata>()
@@ -316,7 +316,7 @@ impl http_resp::Host for Session {
         &mut self,
         resp_handle: http_types::ResponseHandle,
     ) -> Result<u16, types::Error> {
-        let resp = self.response_parts(resp_handle.into())?;
+        let resp = self.session.response_parts(resp_handle.into())?;
         let md = resp
             .extensions
             .get::<upstream::ConnMetadata>()

--- a/lib/src/component/http_types.rs
+++ b/lib/src/component/http_types.rs
@@ -1,9 +1,9 @@
 use {
     super::fastly::api::{http_types, types},
-    crate::session::Session,
+    crate::linking::ComponentCtx,
 };
 
-impl http_types::Host for Session {}
+impl http_types::Host for ComponentCtx {}
 
 // The http crate's `Version` is a struct that has a bunch of
 // associated constants, not an enum; this is only a partial conversion.

--- a/lib/src/component/kv_store.rs
+++ b/lib/src/component/kv_store.rs
@@ -1,12 +1,12 @@
 use {
     super::fastly::api::{http_body, kv_store, types},
-    crate::session::Session,
+    crate::linking::ComponentCtx,
 };
 
 pub struct LookupResult;
 
 #[async_trait::async_trait]
-impl kv_store::HostLookupResult for Session {
+impl kv_store::HostLookupResult for ComponentCtx {
     async fn body(
         &mut self,
         _self_: wasmtime::component::Resource<kv_store::LookupResult>,
@@ -38,7 +38,7 @@ impl kv_store::HostLookupResult for Session {
 }
 
 #[async_trait::async_trait]
-impl kv_store::Host for Session {
+impl kv_store::Host for ComponentCtx {
     async fn open(&mut self, _name: String) -> Result<Option<kv_store::Handle>, types::Error> {
         todo!()
     }

--- a/lib/src/component/log.rs
+++ b/lib/src/component/log.rs
@@ -1,6 +1,6 @@
 use {
     super::fastly::api::{log, types},
-    crate::session::Session,
+    crate::linking::ComponentCtx,
     lazy_static::lazy_static,
 };
 
@@ -17,7 +17,7 @@ fn is_reserved_endpoint(name: &[u8]) -> bool {
 }
 
 #[async_trait::async_trait]
-impl log::Host for Session {
+impl log::Host for ComponentCtx {
     async fn endpoint_get(&mut self, name: String) -> Result<log::Handle, types::Error> {
         let name = name.as_bytes();
 
@@ -25,11 +25,11 @@ impl log::Host for Session {
             return Err(types::Error::InvalidArgument.into());
         }
 
-        Ok(self.log_endpoint_handle(name).into())
+        Ok(self.session.log_endpoint_handle(name).into())
     }
 
     async fn write(&mut self, h: log::Handle, msg: String) -> Result<u32, types::Error> {
-        let endpoint = self.log_endpoint(h.into())?;
+        let endpoint = self.session.log_endpoint(h.into())?;
         let msg = msg.as_bytes();
         endpoint.write_entry(&msg)?;
         Ok(u32::try_from(msg.len()).unwrap())

--- a/lib/src/component/mod.rs
+++ b/lib/src/component/mod.rs
@@ -41,26 +41,26 @@ pub fn link_host_functions(linker: &mut component::Linker<ComponentCtx>) -> anyh
     wasmtime_wasi::bindings::cli::stdout::add_to_linker_get_host(linker, wrap)?;
     wasmtime_wasi::bindings::cli::stderr::add_to_linker_get_host(linker, wrap)?;
 
-    fastly::api::async_io::add_to_linker(linker, |x| x.session())?;
-    fastly::api::backend::add_to_linker(linker, |x| x.session())?;
-    fastly::api::cache::add_to_linker(linker, |x| x.session())?;
-    fastly::api::device_detection::add_to_linker(linker, |x| x.session())?;
-    fastly::api::dictionary::add_to_linker(linker, |x| x.session())?;
-    fastly::api::erl::add_to_linker(linker, |x| x.session())?;
-    fastly::api::geo::add_to_linker(linker, |x| x.session())?;
-    fastly::api::http_body::add_to_linker(linker, |x| x.session())?;
-    fastly::api::http_req::add_to_linker(linker, |x| x.session())?;
-    fastly::api::http_resp::add_to_linker(linker, |x| x.session())?;
-    fastly::api::http_types::add_to_linker(linker, |x| x.session())?;
-    fastly::api::log::add_to_linker(linker, |x| x.session())?;
-    fastly::api::object_store::add_to_linker(linker, |x| x.session())?;
-    fastly::api::kv_store::add_to_linker(linker, |x| x.session())?;
-    fastly::api::purge::add_to_linker(linker, |x| x.session())?;
-    fastly::api::secret_store::add_to_linker(linker, |x| x.session())?;
-    fastly::api::types::add_to_linker(linker, |x| x.session())?;
-    fastly::api::uap::add_to_linker(linker, |x| x.session())?;
-    fastly::api::config_store::add_to_linker(linker, |x| x.session())?;
-    fastly::api::compute_runtime::add_to_linker(linker, |x| x.session())?;
+    fastly::api::async_io::add_to_linker(linker, |x| x)?;
+    fastly::api::backend::add_to_linker(linker, |x| x)?;
+    fastly::api::cache::add_to_linker(linker, |x| x)?;
+    fastly::api::device_detection::add_to_linker(linker, |x| x)?;
+    fastly::api::dictionary::add_to_linker(linker, |x| x)?;
+    fastly::api::erl::add_to_linker(linker, |x| x)?;
+    fastly::api::geo::add_to_linker(linker, |x| x)?;
+    fastly::api::http_body::add_to_linker(linker, |x| x)?;
+    fastly::api::http_req::add_to_linker(linker, |x| x)?;
+    fastly::api::http_resp::add_to_linker(linker, |x| x)?;
+    fastly::api::http_types::add_to_linker(linker, |x| x)?;
+    fastly::api::log::add_to_linker(linker, |x| x)?;
+    fastly::api::object_store::add_to_linker(linker, |x| x)?;
+    fastly::api::kv_store::add_to_linker(linker, |x| x)?;
+    fastly::api::purge::add_to_linker(linker, |x| x)?;
+    fastly::api::secret_store::add_to_linker(linker, |x| x)?;
+    fastly::api::types::add_to_linker(linker, |x| x)?;
+    fastly::api::uap::add_to_linker(linker, |x| x)?;
+    fastly::api::config_store::add_to_linker(linker, |x| x)?;
+    fastly::api::compute_runtime::add_to_linker(linker, |x| x)?;
 
     Ok(())
 }

--- a/lib/src/component/object_store.rs
+++ b/lib/src/component/object_store.rs
@@ -2,18 +2,17 @@ use {
     super::fastly::api::{http_types, object_store, types},
     crate::{
         body::Body,
+        linking::ComponentCtx,
         object_store::{ObjectKey, ObjectStoreError},
-        session::{
-            PeekableTask, PendingKvDeleteTask, PendingKvInsertTask, PendingKvLookupTask, Session,
-        },
+        session::{PeekableTask, PendingKvDeleteTask, PendingKvInsertTask, PendingKvLookupTask},
     },
 };
 
 #[async_trait::async_trait]
-impl object_store::Host for Session {
+impl object_store::Host for ComponentCtx {
     async fn open(&mut self, name: String) -> Result<Option<object_store::Handle>, types::Error> {
-        if self.object_store.store_exists(&name)? {
-            let handle = self.obj_store_handle(&name)?;
+        if self.session.object_store.store_exists(&name)? {
+            let handle = self.session.obj_store_handle(&name)?;
             Ok(Some(handle.into()))
         } else {
             Ok(None)
@@ -25,11 +24,11 @@ impl object_store::Host for Session {
         store: object_store::Handle,
         key: String,
     ) -> Result<Option<object_store::BodyHandle>, types::Error> {
-        let store = self.get_obj_store_key(store.into()).unwrap();
+        let store = self.session.get_obj_store_key(store.into()).unwrap();
         let key = ObjectKey::new(&key)?;
-        match self.obj_lookup(store, &key) {
+        match self.session.obj_lookup(store, &key) {
             Ok(obj) => {
-                let new_handle = self.insert_body(Body::from(obj));
+                let new_handle = self.session.insert_body(Body::from(obj));
                 Ok(Some(new_handle.into()))
             }
             // Don't write to the invalid handle as the SDK will return Ok(None)
@@ -45,12 +44,12 @@ impl object_store::Host for Session {
         store: object_store::Handle,
         key: String,
     ) -> Result<object_store::PendingLookupHandle, types::Error> {
-        let store = self.get_obj_store_key(store.into()).unwrap();
+        let store = self.session.get_obj_store_key(store.into()).unwrap();
         let key = ObjectKey::new(key)?;
         // just create a future that's already ready
-        let fut = futures::future::ok(self.obj_lookup(store, &key));
+        let fut = futures::future::ok(self.session.obj_lookup(store, &key));
         let task = PendingKvLookupTask::new(PeekableTask::spawn(fut).await);
-        Ok(self.insert_pending_kv_lookup(task).into())
+        Ok(self.session.insert_pending_kv_lookup(task).into())
     }
 
     async fn pending_lookup_wait(
@@ -58,13 +57,14 @@ impl object_store::Host for Session {
         pending: object_store::PendingLookupHandle,
     ) -> Result<Option<object_store::BodyHandle>, types::Error> {
         let pending_obj = self
+            .session
             .take_pending_kv_lookup(pending.into())?
             .task()
             .recv()
             .await?;
         // proceed with the normal match from lookup()
         match pending_obj {
-            Ok(obj) => Ok(Some(self.insert_body(Body::from(obj)).into())),
+            Ok(obj) => Ok(Some(self.session.insert_body(Body::from(obj)).into())),
             Err(ObjectStoreError::MissingObject) => Ok(None),
             Err(err) => Err(err.into()),
         }
@@ -76,10 +76,18 @@ impl object_store::Host for Session {
         key: String,
         body_handle: http_types::BodyHandle,
     ) -> Result<(), types::Error> {
-        let store = self.get_obj_store_key(store.into()).unwrap().clone();
+        let store = self
+            .session
+            .get_obj_store_key(store.into())
+            .unwrap()
+            .clone();
         let key = ObjectKey::new(&key)?;
-        let bytes = self.take_body(body_handle.into())?.read_into_vec().await?;
-        self.obj_insert(store, key, bytes)?;
+        let bytes = self
+            .session
+            .take_body(body_handle.into())?
+            .read_into_vec()
+            .await?;
+        self.session.obj_insert(store, key, bytes)?;
 
         Ok(())
     }
@@ -90,13 +98,22 @@ impl object_store::Host for Session {
         key: String,
         body_handle: http_types::BodyHandle,
     ) -> Result<object_store::PendingInsertHandle, types::Error> {
-        let store = self.get_obj_store_key(store.into()).unwrap().clone();
+        let store = self
+            .session
+            .get_obj_store_key(store.into())
+            .unwrap()
+            .clone();
         let key = ObjectKey::new(&key)?;
-        let bytes = self.take_body(body_handle.into())?.read_into_vec().await?;
-        let fut = futures::future::ok(self.obj_insert(store, key, bytes));
+        let bytes = self
+            .session
+            .take_body(body_handle.into())?
+            .read_into_vec()
+            .await?;
+        let fut = futures::future::ok(self.session.obj_insert(store, key, bytes));
         let task = PeekableTask::spawn(fut).await;
 
         Ok(self
+            .session
             .insert_pending_kv_insert(PendingKvInsertTask::new(task))
             .into())
     }
@@ -106,6 +123,7 @@ impl object_store::Host for Session {
         handle: object_store::PendingInsertHandle,
     ) -> Result<(), types::Error> {
         Ok((self
+            .session
             .take_pending_kv_insert(handle.into())?
             .task()
             .recv()
@@ -117,12 +135,17 @@ impl object_store::Host for Session {
         store: object_store::Handle,
         key: String,
     ) -> Result<object_store::PendingDeleteHandle, types::Error> {
-        let store = self.get_obj_store_key(store.into()).unwrap().clone();
+        let store = self
+            .session
+            .get_obj_store_key(store.into())
+            .unwrap()
+            .clone();
         let key = ObjectKey::new(&key)?;
-        let fut = futures::future::ok(self.obj_delete(store, key));
+        let fut = futures::future::ok(self.session.obj_delete(store, key));
         let task = PeekableTask::spawn(fut).await;
 
         Ok(self
+            .session
             .insert_pending_kv_delete(PendingKvDeleteTask::new(task))
             .into())
     }
@@ -132,6 +155,7 @@ impl object_store::Host for Session {
         handle: object_store::PendingDeleteHandle,
     ) -> Result<(), types::Error> {
         Ok((self
+            .session
             .take_pending_kv_delete(handle.into())?
             .task()
             .recv()

--- a/lib/src/component/purge.rs
+++ b/lib/src/component/purge.rs
@@ -1,10 +1,10 @@
 use {
     super::fastly::api::{purge, types},
-    crate::{error::Error, session::Session},
+    crate::{error::Error, linking::ComponentCtx},
 };
 
 #[async_trait::async_trait]
-impl purge::Host for Session {
+impl purge::Host for ComponentCtx {
     async fn purge_surrogate_key(
         &mut self,
         _surrogate_key: String,

--- a/lib/src/component/types.rs
+++ b/lib/src/component/types.rs
@@ -2,7 +2,7 @@ use {
     super::fastly::api::types,
     crate::{
         error::{self, HandleError},
-        session::Session,
+        linking::ComponentCtx,
     },
     http::header::InvalidHeaderName,
 };
@@ -12,7 +12,7 @@ pub enum TrappableError {
     Trap(anyhow::Error),
 }
 
-impl types::Host for Session {
+impl types::Host for ComponentCtx {
     fn convert_error(&mut self, err: TrappableError) -> wasmtime::Result<types::Error> {
         match err {
             TrappableError::Error(err) => Ok(err),

--- a/lib/src/component/uap.rs
+++ b/lib/src/component/uap.rs
@@ -1,6 +1,6 @@
 use {
     super::fastly::api::{types, uap},
-    crate::{error::Error, session::Session},
+    crate::{error::Error, linking::ComponentCtx},
     wasmtime::component::Resource,
 };
 
@@ -8,7 +8,7 @@ use {
 pub struct UserAgent {}
 
 #[async_trait::async_trait]
-impl uap::HostUserAgent for Session {
+impl uap::HostUserAgent for ComponentCtx {
     async fn family(
         &mut self,
         _agent: Resource<UserAgent>,
@@ -47,7 +47,7 @@ impl uap::HostUserAgent for Session {
 }
 
 #[async_trait::async_trait]
-impl uap::Host for Session {
+impl uap::Host for ComponentCtx {
     async fn parse(&mut self, _user_agent: String) -> Result<Resource<UserAgent>, types::Error> {
         // not available
         Err(Error::NotAvailable("User-agent parsing is not available").into())

--- a/lib/src/linking.rs
+++ b/lib/src/linking.rs
@@ -95,7 +95,7 @@ impl wasmtime::ResourceLimiter for Limiter {
 pub struct ComponentCtx {
     table: wasmtime_wasi::ResourceTable,
     wasi: wasmtime_wasi::WasiCtx,
-    session: Session,
+    pub(crate) session: Session,
     guest_profiler: Option<Box<GuestProfiler>>,
     limiter: Limiter,
 }


### PR DESCRIPTION
Switch to implementing component traits on `ComponentCtx` instead of `Session`. This gives us access to the resource table, which will allow us to support the use of resources like the new `fastly:api/kv-store/lookup-result` resource.

The change was pretty mechanical:

* all component traits are now implemented on `ComponentCtx`
* many uses of `self` needed to change to `self.session`

cc @computermouth 
