### PR TITLE
Fix bug in `inspect` implementation and add a test

### DIFF
--- a/cli/tests/integration/inspect.rs
+++ b/cli/tests/integration/inspect.rs
@@ -1,0 +1,25 @@
+use {
+    crate::{
+        common::{Test, TestResult},
+        viceroy_test,
+    },
+    hyper::{Request, StatusCode},
+};
+
+viceroy_test!(upstream_sync, |is_component| {
+    // Set up the test harness:
+    let test = Test::using_fixture("inspect.wasm").adapt_component(is_component);
+
+    // And send a request to exercise the hostcall:
+    let resp = test
+        .against(Request::post("/").body("Hello, Viceroy!").unwrap())
+        .await?;
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    assert_eq!(
+        resp.into_body().read_into_string().await?,
+        "inspect result: waf_response=200, tags=[], decision_ms=0ms, verdict=Allow"
+    );
+
+    Ok(())
+});

--- a/cli/tests/integration/main.rs
+++ b/cli/tests/integration/main.rs
@@ -12,6 +12,7 @@ mod env_vars;
 mod geolocation_lookup;
 mod grpc;
 mod http_semantics;
+mod inspect;
 mod kv_store;
 mod logging;
 mod memory;

--- a/lib/src/wiggle_abi/req_impl.rs
+++ b/lib/src/wiggle_abi/req_impl.rs
@@ -1056,7 +1056,7 @@ impl FastlyHttpReq for Session {
 
         match u32::try_from(ngwaf_resp_len) {
             Ok(ngwaf_resp_len) if ngwaf_resp_len <= buf_len => {
-                memory.copy_from_slice(ngwaf_resp.as_bytes(), buf.as_array(buf_len))?;
+                memory.copy_from_slice(ngwaf_resp.as_bytes(), buf.as_array(ngwaf_resp_len))?;
 
                 Ok(ngwaf_resp_len)
             }

--- a/test-fixtures/Cargo.lock
+++ b/test-fixtures/Cargo.lock
@@ -99,13 +99,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "fastly"
-version = "0.10.3"
+name = "elsa"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e154b2ca5f18a5f9d09a6f1b992a0d87a549a3d3ad387e67309522818357a8ec"
+checksum = "d98e71ae4df57d214182a2e5cb90230c0192c6ddfcaa05c36453d46a54713e10"
+dependencies = [
+ "stable_deref_trait",
+]
+
+[[package]]
+name = "fastly"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2afee1dc886cbae0525020cc8e788ac9678744c311399c022913a5e06f19b52f"
 dependencies = [
  "anyhow",
  "bytes",
+ "elsa",
  "fastly-macros",
  "fastly-shared",
  "fastly-sys",
@@ -116,6 +126,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "sha2 0.9.9",
+ "smallvec",
  "thiserror",
  "time",
  "url",
@@ -123,9 +134,9 @@ dependencies = [
 
 [[package]]
 name = "fastly-macros"
-version = "0.10.3"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79bc80908a6372725a4b1f213cec21c574606dbd23871848e52165913270602e"
+checksum = "372765a9863aaeaac2faed544b364387f6500be423f384b6e7e30dc1e7ca65ce"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -134,9 +145,9 @@ dependencies = [
 
 [[package]]
 name = "fastly-shared"
-version = "0.10.3"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82b46a88123dbaed2b245ed9a49a3f2e78e627136b8760511298c799be8d6f8e"
+checksum = "00c7cd62059abdcc8d2565e9c1e63c195a7cd0fddd4851148265c6c428471b0d"
 dependencies = [
  "bitflags",
  "http",
@@ -144,9 +155,9 @@ dependencies = [
 
 [[package]]
 name = "fastly-sys"
-version = "0.10.3"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "430408d9fc9ed37b6b718bd69cc8b3e79148ed0c685174b2220ee8637afafc17"
+checksum = "b3810e682832f22d7ec021dab9262d2157e09980bd4d509ee60aa485761cfc5e"
 dependencies = [
  "bitflags",
  "fastly-shared",
@@ -358,6 +369,18 @@ dependencies = [
  "cpufeatures",
  "digest 0.10.7",
 ]
+
+[[package]]
+name = "smallvec"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "syn"

--- a/test-fixtures/Cargo.toml
+++ b/test-fixtures/Cargo.toml
@@ -10,9 +10,9 @@ publish = false
 [dependencies]
 anyhow = "1.0.86"
 base64 = "0.21.2"
-fastly = "0.10.1"
-fastly-shared = "0.10.1"
-fastly-sys = "0.10.1"
+fastly = "0.10.4"
+fastly-shared = "0.10.4"
+fastly-sys = "0.10.4"
 hex-literal = "0.4.1"
 bytes = "1.0.0"
 http = "1.1.0"

--- a/test-fixtures/src/bin/inspect.rs
+++ b/test-fixtures/src/bin/inspect.rs
@@ -1,0 +1,37 @@
+use fastly::experimental::{inspect, InspectConfig, InspectError, InspectVerdict};
+use fastly::handle::{BodyHandle, RequestHandle};
+use fastly::http::{HeaderName, HeaderValue, Method, StatusCode};
+use fastly::{Error, Request, Response};
+
+#[fastly::main]
+fn main(mut req: Request) -> Result<Response, Error> {
+    let (req, body) = req.into_handles();
+    let body = body.unwrap_or_else(BodyHandle::new);
+
+    let inspectconf = InspectConfig::new(&req, &body)
+        .corp("junichi-lab")
+        .workspace("lab");
+
+    let resp = match inspect(inspectconf) {
+        Ok(x) => {
+            let body = format!(
+                "inspect result: waf_response={}, tags={:?}, decision_ms={}ms, verdict={:?}",
+                x.waf_response(),
+                x.tags(),
+                x.decision_ms().as_millis(),
+                x.verdict()
+            );
+
+            Response::from_status(StatusCode::OK)
+                .with_body_text_plain(&body)
+        }
+        Err(e) => {
+            let body = format!("Error: {e:?}");
+
+            Response::from_status(StatusCode::BAD_REQUEST)
+                .with_body_text_plain(&body)
+        },
+    };
+
+    Ok(resp)
+}


### PR DESCRIPTION
This fixes an issue @junichi-hata reported with using the `inspect` hostcall. I called `GuestPtr::array` with the full length of the buffer the guest had allocated instead of the length of the source slice, which results in `copy_from_slice` returning a `SliceLengthsDiffer` error when used. This fixes which length is used, and, now that the updated SDK is available, adds a test to exercise the `inspect` path.