### PR TITLE
Add support for the on_behalf_of endpoints

### DIFF
--- a/crates/adapter/src/fastly/core.rs
+++ b/crates/adapter/src/fastly/core.rs
@@ -1854,6 +1854,11 @@ pub mod fastly_http_req {
 
         res
     }
+
+    #[export_name = "fastly_http_req#on_behalf_of"]
+    pub fn on_behalf_of(_: RequestHandle, _: *const u8, _: usize) -> FastlyStatus {
+        FastlyStatus::UNKNOWN_ERROR
+    }
 }
 
 pub mod fastly_http_resp {

--- a/lib/compute-at-edge-abi/cache.witx
+++ b/lib/compute-at-edge-abi/cache.witx
@@ -14,6 +14,8 @@
 (typename $cache_lookup_options
     (record
         (field $request_headers $request_handle) ;; a full request handle, but used only for its headers
+        (field $service_id (@witx pointer (@witx char8)))
+        (field $service_id_len u32)
     )
 )
 
@@ -21,6 +23,7 @@
     (flags (@witx repr u32)
         $reserved
         $request_headers
+        $service_id
     )
 )
 
@@ -29,6 +32,8 @@
     (record
         (field $request_headers $request_handle) ;; a full request handle, but used only for its headers
         (field $replace_strategy $cache_replace_strategy)
+        (field $service_id (@witx pointer (@witx char8)))
+        (field $service_id_len u32)
     )
 )
 
@@ -37,6 +42,7 @@
         $reserved
         $request_headers
         $replace_strategy
+        $service_id
     )
 )
 
@@ -65,6 +71,8 @@
         (field $user_metadata_ptr (@witx pointer u8))
         (field $user_metadata_len (@witx usize))
         (field $edge_max_age_ns $cache_duration_ns)
+        (field $service_id (@witx pointer (@witx char8)))
+        (field $service_id_len u32)
     )
 )
 
@@ -80,6 +88,7 @@
         $user_metadata
         $sensitive_data
         $edge_max_age_ns
+        $service_id
     )
 )
 

--- a/lib/compute-at-edge-abi/compute-at-edge.witx
+++ b/lib/compute-at-edge-abi/compute-at-edge.witx
@@ -577,6 +577,14 @@
         (param $buf_len (@witx usize))
         (result $err (expected $num_bytes (error $fastly_status)))
     )
+
+    ;;; Instead of having this request cache in this service's space, use the
+    ;;; cache of the named service
+    (@interface func (export "on_behalf_of")
+        (param $req $request_handle)
+        (param $service string)
+        (result $err (expected (error $fastly_status)))
+    )
 )
 
 (module $fastly_http_resp

--- a/lib/src/component/http_req.rs
+++ b/lib/src/component/http_req.rs
@@ -901,4 +901,12 @@ impl http_req::Host for ComponentCtx {
             too_large => Err(types::Error::BufferLen(too_large.unwrap_or(0))),
         }
     }
+
+    async fn on_behalf_of(
+        &mut self,
+        _: http_req::RequestHandle,
+        _: Vec<u8>,
+    ) -> Result<(), types::Error> {
+        Err(types::Error::Unsupported)
+    }
 }

--- a/lib/src/wiggle_abi/req_impl.rs
+++ b/lib/src/wiggle_abi/req_impl.rs
@@ -1095,4 +1095,15 @@ impl FastlyHttpReq for Session {
             }),
         }
     }
+
+    fn on_behalf_of(
+        &mut self,
+        _memory: &mut GuestMemory<'_>,
+        _ds_req: RequestHandle,
+        _service: GuestPtr<str>,
+    ) -> Result<(), Error> {
+        Err(Error::Unsupported {
+            msg: "on_behalf_of is not supported in Viceroy",
+        })
+    }
 }

--- a/lib/wit/deps/fastly/compute.wit
+++ b/lib/wit/deps/fastly/compute.wit
@@ -482,6 +482,11 @@ result<pending-request-handle, error>;
     info: inspect-config,
     max-len: u64
   ) -> result<string, error>;
+
+  on-behalf-of: func(
+    h: request-handle,
+    service: list<u8>,
+  ) -> result<_, error>;
 }
 
 /*


### PR DESCRIPTION
These are a privileged set of operations, which we don't actually support in Viceroy. However, we want to make sure that these endpoints exist so that newer SDK builds don't run into any problems.