### PR TITLE
Include FASTLY_IS_STAGING environment variable

### DIFF
--- a/lib/src/linking.rs
+++ b/lib/src/linking.rs
@@ -255,6 +255,8 @@ fn make_wasi_ctx(ctx: &ExecuteCtx, session: &Session) -> WasiCtxBuilder {
         .env("FASTLY_SERVICE_VERSION", "0")
         // signal that we're in a local testing environment
         .env("FASTLY_HOSTNAME", "localhost")
+        // ...which is not the staging environment
+        .env("FASTLY_IS_STAGING", "0")
         // request IDs start at 0 and increment, rather than being UUIDs, for ease of testing
         .env("FASTLY_TRACE_ID", &format!("{:032x}", session.req_id()));
 

--- a/test-fixtures/src/bin/env-vars.rs
+++ b/test-fixtures/src/bin/env-vars.rs
@@ -31,4 +31,7 @@ fn main() {
 
     let host_name = env::var("FASTLY_HOSTNAME").expect("host name available");
     assert_eq!(host_name, "localhost");
+
+    let is_staging = env::var("FASTLY_IS_STAGING").expect("staging variable set");
+    assert!(is_staging == "0" || is_staging == "1");
 }

--- a/test-fixtures/src/bin/env-vars.rs
+++ b/test-fixtures/src/bin/env-vars.rs
@@ -33,5 +33,5 @@ fn main() {
     assert_eq!(host_name, "localhost");
 
     let is_staging = env::var("FASTLY_IS_STAGING").expect("staging variable set");
-    assert!(is_staging == "0" || is_staging == "1");
+    assert!(is_staging == "0");
 }


### PR DESCRIPTION
See https://docs.fastly.com/en/guides/working-with-staging for more on staging.

This environment variable [indicates](https://docs.fastly.com/en/guides/working-with-staging#compute) the request is running in the staging environment. Viceroy is not "the staging environment", so we return 0. (Admittedly, it's also not running in production...)

Relevant to #336.

