### PR TITLE
Accept all valid environment variables

### DIFF
--- a/lib/src/linking.rs
+++ b/lib/src/linking.rs
@@ -255,6 +255,8 @@ fn make_wasi_ctx(ctx: &ExecuteCtx, session: &Session) -> WasiCtxBuilder {
         .env("FASTLY_SERVICE_VERSION", "0")
         // signal that we're in a local testing environment
         .env("FASTLY_HOSTNAME", "localhost")
+        // ...which is not the staging environment
+        .env("FASTLY_IS_STAGING", "0")
         // request IDs start at 0 and increment, rather than being UUIDs, for ease of testing
         .env("FASTLY_TRACE_ID", &format!("{:032x}", session.req_id()));
 

--- a/test-fixtures/src/bin/env-vars.rs
+++ b/test-fixtures/src/bin/env-vars.rs
@@ -31,4 +31,7 @@ fn main() {
 
     let host_name = env::var("FASTLY_HOSTNAME").expect("host name available");
     assert_eq!(host_name, "localhost");
+
+    let is_staging = env::var("FASTLY_IS_STAGING").expect("staging variable set");
+    assert!(is_staging == "0" || is_staging == "1");
 }

--- a/test-fixtures/src/bin/env-vars.rs
+++ b/test-fixtures/src/bin/env-vars.rs
@@ -9,29 +9,28 @@ fn main() {
         .expect("parses as u64");
 
     let cid = env::var("FASTLY_CUSTOMER_ID").expect("customer ID available");
-    assert_eq!(cid, "0000000000000000000000");
+    assert!(!cid.is_empty());
 
     let pop = env::var("FASTLY_POP").expect("POP available");
-    assert_eq!(pop, "XXX");
+    assert_eq!(pop.len(), 3);
 
     let region = env::var("FASTLY_REGION").expect("region available");
-    assert_eq!(region, "Somewhere");
+    assert!(!region.is_empty());
 
     let sid = env::var("FASTLY_SERVICE_ID").expect("service ID available");
-    assert_eq!(sid, "0000000000000000000000");
+    assert!(!sid.is_empty());
 
-    let version: u64 = env::var("FASTLY_SERVICE_VERSION")
+    let _version: u64 = env::var("FASTLY_SERVICE_VERSION")
         .expect("service version available")
         .parse()
         .expect("parses as u64");
-    assert_eq!(version, 0);
 
     let id = env::var("FASTLY_TRACE_ID").expect("trace ID available");
-    assert_eq!(u64::from_str_radix(&id, 16).expect("parses as u64"), 0);
+    u64::from_str_radix(&id, 16).expect("parses as u64");
 
     let host_name = env::var("FASTLY_HOSTNAME").expect("host name available");
     assert_eq!(host_name, "localhost");
 
     let is_staging = env::var("FASTLY_IS_STAGING").expect("staging variable set");
-    assert!(is_staging == "0");
+    assert!(is_staging == "0" || is_staging == "1");
 }

--- a/test-fixtures/src/bin/env-vars.rs
+++ b/test-fixtures/src/bin/env-vars.rs
@@ -33,5 +33,5 @@ fn main() {
     assert_eq!(host_name, "localhost");
 
     let is_staging = env::var("FASTLY_IS_STAGING").expect("staging variable set");
-    assert!(is_staging == "0" || is_staging == "1");
+    assert!(is_staging == "0");
 }


### PR DESCRIPTION
Pursuant to #336.

If we were to implement #336 today, this test would fail off the bat:
not because the implementation is incorrect, but because the test
does not verify correct behavior, only the current behavior.
That is, it is a change-detector test [1].

A directed test should admit any correct implementation.

To that end, refactor so that this tests presence and (where applicable)
structure of environment variables, but does not validate that they have
particualr values. (Except in the case of `FASTLY_HOSTNAME`,
which has one correct value for Viceroy.)

[1]: https://testing.googleblog.com/2015/01/testing-on-toilet-change-detector-tests.html
