### PR TITLE
Remove ubuntu-20.04 from CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,15 +10,12 @@ jobs:
     strategy:
       matrix:
         rust-toolchain: ["1.83"]
-        os: [ubuntu-20.04, macos-14, windows-2022]
+        os: [macos-14, windows-2022]
         arch: [amd64, arm64]
         exclude:
           - os: windows-2022
             arch: arm64
         include:
-          - os: ubuntu-20.04
-            name: linux
-            rust_abi: unknown-linux-gnu
           - os: macos-14
             name: darwin
             rust_abi: apple-darwin
@@ -86,7 +83,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   publish:
     needs: build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: publish
         uses: actions/github-script@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,12 +10,15 @@ jobs:
     strategy:
       matrix:
         rust-toolchain: ["1.83"]
-        os: [macos-14, windows-2022]
+        os: [ubuntu-24.04, macos-14, windows-2022]
         arch: [amd64, arm64]
         exclude:
           - os: windows-2022
             arch: arm64
         include:
+          - os: ubuntu-24.04
+            name: linux
+            rust_abi: unknown-linux-gnu
           - os: macos-14
             name: darwin
             rust_abi: apple-darwin

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
   test:
     strategy:
       matrix:
-        platform: [ubuntu-20.04, ubuntu-22.04, ubuntu-24.04, windows-2022, macos-13, macos-14, macos-15]
+        platform: [ubuntu-22.04, ubuntu-24.04, windows-2022, macos-13, macos-14, macos-15]
     runs-on: ${{ matrix.platform }}
     env:
       SCCACHE_GHA_ENABLED: "true"
@@ -52,7 +52,7 @@ jobs:
   trap-test:
     strategy:
       matrix:
-        platform: [ubuntu-20.04, ubuntu-22.04, ubuntu-24.04, windows-2022, macos-13, macos-14, macos-15]
+        platform: [ubuntu-22.04, ubuntu-24.04, windows-2022, macos-13, macos-14, macos-15]
     runs-on: ${{ matrix.platform }}
     env:
       SCCACHE_GHA_ENABLED: "true"
@@ -82,7 +82,7 @@ jobs:
       shell: bash
 
   package-check:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
Per https://github.com/actions/runner-images/issues/11101, Github is turning down 20.04 actions, and is issuing brownouts that cause CI failures. (I saw it fail the 20.04 matrix steps and the package-check step on my PRs.)

To keep the CI flowing, remove 20.04 from the matrices, and upgrade package-check to 24.04.
