### PR TITLE
Guest Profile sample period configuration support

### DIFF
--- a/cli/src/opts.rs
+++ b/cli/src/opts.rs
@@ -94,7 +94,7 @@ pub struct SharedArgs {
     ///
     /// The `guest` option can be additionally configured as:
     ///
-    ///     --profile=guest[[,path],sample]
+    ///     --profile=guest[,path[,sample]]
     ///
     /// where `path` is the directory or filename to write the profile(s) to and
     /// `sample` is the duration between profiler samples (default 50μs). Time

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -36,6 +36,6 @@ mod upstream;
 pub mod wiggle_abi;
 
 pub use {
-    error::Error, execute::ExecuteCtx, service::ViceroyService, upstream::BackendConnector,
-    wasmtime::ProfilingStrategy,
+    error::Error, execute::ExecuteCtx, execute::GuestProfileConfig, service::ViceroyService,
+    upstream::BackendConnector, wasmtime::ProfilingStrategy,
 };


### PR DESCRIPTION
This change matches the configuration support for guest profling provided by wasmtime and is useful for integrators making use of guest profiling to be able to get a more fine/coarse grained view of the execution of their services (and also balance data generated, overhead, etc.).

In preparing to submit this change for review, I first saw that there is an alternative implementation of this with
https://github.com/fastly/Viceroy/pull/437, doing mostly the same things in a slightly different form.