### PR TITLE
Age and vary_by

### DIFF
--- a/cli/tests/integration/cache.rs
+++ b/cli/tests/integration/cache.rs
@@ -6,7 +6,7 @@ use {
     hyper::StatusCode,
 };
 
-viceroy_test!(request_works, |is_component| {
+viceroy_test!(cache_request_works, |is_component| {
     if !std::env::var("ENABLE_EXPERIMENTAL_CACHE_API").is_ok_and(|v| v == "1") {
         eprintln!("WARNING: Skipping cache tests.");
         eprintln!(

--- a/lib/proptest-regressions/cache.txt
+++ b/lib/proptest-regressions/cache.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 59cac97c28e31b87da4163d47031bc52ca7e07f8e90887911c569a29fbdc75c0 # shrinks to key = CacheKey([]), max_age = 9223372036854481161.46386714s, initial_age = None, value = []

--- a/lib/src/cache.rs
+++ b/lib/src/cache.rs
@@ -164,8 +164,6 @@ impl Cache {
     /// Perform a non-transactional lookup for the given cache key.
     /// Note: races with other insertions, including transactional insertions.
     /// Last writer wins!
-    // TODO: cceckman-at-fastly 2025-02-26:
-    // - use request headers; vary_by; streaming body
     pub async fn insert(&self, key: &CacheKey, options: WriteOptions, body: Body) {
         self.inner
             .get_with_by_ref(&key, async { Default::default() })

--- a/lib/src/cache.rs
+++ b/lib/src/cache.rs
@@ -147,12 +147,12 @@ impl Cache {
     /// Perform a non-transactional lookup for the given cache key.
     // TODO: cceckman-at-fastly:
     // - use request headers; vary_by
-    pub async fn lookup(&self, key: &CacheKey) -> CacheEntry {
+    pub async fn lookup(&self, key: &CacheKey, headers: &HeaderMap) -> CacheEntry {
         let found = self
             .inner
             .get_with_by_ref(&key, async { Default::default() })
             .await
-            .get()
+            .get(headers)
             .map(|data| Found {
                 data,
                 last_body_handle: None,
@@ -182,7 +182,7 @@ pub struct WriteOptions {
     pub initial_age: Option<Duration>,
 
     pub request_headers: HeaderMap,
-    pub vary_rule: Option<VaryRule>,
+    pub vary_rule: VaryRule,
 }
 
 /// Optional override for response caching behavior.

--- a/lib/src/cache.rs
+++ b/lib/src/cache.rs
@@ -12,6 +12,7 @@ use fastly_shared::FastlyStatus;
 use http::HeaderValue;
 
 mod store;
+mod variance;
 
 use store::{CacheData, CacheKeyObjects, ObjectMeta};
 

--- a/lib/src/cache.rs
+++ b/lib/src/cache.rs
@@ -177,7 +177,7 @@ impl Cache {
 /// Options that can be applied to a write, e.g. insert or transaction_insert.
 pub struct WriteOptions {
     pub max_age: Duration,
-    pub initial_age: Option<Duration>,
+    pub initial_age: Duration,
 
     pub request_headers: HeaderMap,
     pub vary_rule: VaryRule,
@@ -278,7 +278,7 @@ mod tests {
         fn nontransactional_insert_lookup(
                 key in any::<CacheKey>(),
                 max_age in any::<u32>(),
-                initial_age in any::<Option<u32>>(),
+                initial_age in any::<u32>(),
                 value in any::<Vec<u8>>()) {
             let cache = Cache::default();
 
@@ -292,7 +292,7 @@ mod tests {
 
                 let write_options = WriteOptions {
                     max_age: Duration::from_secs(max_age as u64),
-                    initial_age: initial_age.map(|v| Duration::from_secs(v as u64)),
+                    initial_age: Duration::from_secs(initial_age as u64),
                     request_headers: HeaderMap::default(),
                     vary_rule: VaryRule::default(),
                 };
@@ -315,7 +315,7 @@ mod tests {
         // Insert an already-stale entry:
         let write_options = WriteOptions {
             max_age: Duration::from_secs(1),
-            initial_age: Some(Duration::from_secs(2)),
+            initial_age: Duration::from_secs(2),
             request_headers: HeaderMap::default(),
             vary_rule: VaryRule::default(),
         };

--- a/lib/src/cache.rs
+++ b/lib/src/cache.rs
@@ -2,6 +2,7 @@ use std::{sync::Arc, time::Duration};
 
 #[cfg(test)]
 use proptest_derive::Arbitrary;
+use variance::VaryRule;
 
 use crate::{
     body::Body,
@@ -9,7 +10,7 @@ use crate::{
     Error,
 };
 use fastly_shared::FastlyStatus;
-use http::HeaderValue;
+use http::{HeaderMap, HeaderValue};
 
 mod store;
 mod variance;
@@ -179,6 +180,9 @@ impl Cache {
 pub struct WriteOptions {
     pub max_age: Duration,
     pub initial_age: Option<Duration>,
+
+    pub request_headers: HeaderMap,
+    pub vary_rule: Option<VaryRule>,
 }
 
 /// Optional override for response caching behavior.

--- a/lib/src/cache/store.rs
+++ b/lib/src/cache/store.rs
@@ -68,7 +68,7 @@ impl ObjectMeta {
     }
 
     /// The vary rule associated with this request.
-    pub fn vary_rule(&self) -> Option<&VaryRule> {
+    pub fn vary_rule(&self) -> &VaryRule {
         &self.vary_rule
     }
 
@@ -131,12 +131,12 @@ impl CacheKeyObjects {
         let meta: ObjectMeta = options.into();
 
         let mut cache_key_objects = self.0.lock().expect("failed to lock CacheKeyObjects");
-        if let Some(vary_rule) = meta.vary_rule() {
-            if !cache_key_objects.vary_rules.contains(vary_rule) {
-                // Insert at the front, run through the rules in order, so we tend towards fresher
-                // responses.
-                cache_key_objects.vary_rules.push_front(vary_rule.clone());
-            }
+        if !cache_key_objects.vary_rules.contains(meta.vary_rule()) {
+            // Insert at the front, run through the rules in order, so we tend towards fresher
+            // responses.
+            cache_key_objects
+                .vary_rules
+                .push_front(meta.vary_rule().clone());
         }
 
         let body = CollectingBody::new(body);

--- a/lib/src/cache/store.rs
+++ b/lib/src/cache/store.rs
@@ -81,11 +81,11 @@ impl ObjectMeta {
 impl From<WriteOptions> for ObjectMeta {
     fn from(value: WriteOptions) -> Self {
         let inserted = Instant::now();
-        let initial_age = value.initial_age.unwrap_or(Duration::ZERO);
         let WriteOptions {
             request_headers,
             vary_rule,
             max_age,
+            initial_age,
             ..
         } = value;
         ObjectMeta {

--- a/lib/src/cache/store.rs
+++ b/lib/src/cache/store.rs
@@ -49,7 +49,7 @@ impl ObjectMeta {
     /// Retrieve the current age of this object.
     pub fn age(&self) -> Duration {
         // Age in this cache, plus age upon insertion
-        Instant::now().duration_since(self.inserted) + self.initial_age
+        self.inserted.elapsed() + self.initial_age
     }
 
     /// Maximum fresh age of this object.

--- a/lib/src/cache/store.rs
+++ b/lib/src/cache/store.rs
@@ -104,9 +104,6 @@ pub struct CacheKeyObjects(Mutex<CacheKeyObjectsInner>);
 
 impl CacheKeyObjects {
     /// Get the applicable CacheData, if available.
-    ///
-    // TODO: cceckman-at-fastly 2025-02-26:
-    // Implement vary_by here
     pub fn get(&self, request_headers: &HeaderMap) -> Option<Arc<CacheData>> {
         let key_objects = self.0.lock().expect("failed to lock CacheKeyObjects");
 

--- a/lib/src/cache/variance.rs
+++ b/lib/src/cache/variance.rs
@@ -41,6 +41,12 @@ impl FromStr for VaryRule {
 }
 
 impl VaryRule {
+    pub fn new<'a>(headers: impl Iterator<Item = &'a HeaderName>) -> VaryRule {
+        VaryRule {
+            headers: headers.cloned().collect(),
+        }
+    }
+
     /// Construct the Variant for the given headers: the (header, value) pairs that must be present
     /// for a request to match a response.
     pub fn variant(&self, headers: &HeaderMap) -> Variant {

--- a/lib/src/cache/variance.rs
+++ b/lib/src/cache/variance.rs
@@ -23,7 +23,7 @@ use crate::Error;
 /// a previous response.
 ///
 /// VaryRule is canonicalized, with lowercase-named header names in sorted order.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct VaryRule {
     headers: Vec<HeaderName>,
 }

--- a/lib/src/cache/variance.rs
+++ b/lib/src/cache/variance.rs
@@ -23,7 +23,7 @@ use crate::Error;
 /// a previous response.
 ///
 /// VaryRule is canonicalized, with lowercase-named header names in sorted order.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct VaryRule {
     headers: Vec<HeaderName>,
 }
@@ -42,7 +42,7 @@ impl FromStr for VaryRule {
 
 impl VaryRule {
     /// Construct the Variant for the given headers: the (header, value) pairs that must be present
-    /// to match.
+    /// for a request to match a response.
     pub fn variant(&self, headers: &HeaderMap) -> Variant {
         let mut buf = BytesMut::new();
         for header in self.headers.iter() {
@@ -65,7 +65,7 @@ impl VaryRule {
 ///
 /// A `vary_by` directive indicates that a cached object should only be matched if the headers
 /// listed in `vary_by` match that of the request that generated the cached object.
-#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Default, Clone)]
 pub struct Variant {
     /// The internal representation is an HTTP header block: headers and values separated by a CRLF
     /// sequence. However, since header values may contain arbitrary bytes, this is a Bytes rather

--- a/lib/src/cache/variance.rs
+++ b/lib/src/cache/variance.rs
@@ -1,0 +1,38 @@
+//! Support for request- and response-keyed variance, per HTTP's vary rules
+//!
+//! HTTP caching as described in RFC 9111 has two components to a key. The first is the "request
+//! key", defined by the caching entity -- typically consisting of the URL and often the method.
+//! The response from the server may include a Vary header, which lists request field names
+//! (i.e. header names) that affect the cacheability of the response. A subsequent request must
+//! match all the Vary values in order to use the cached result.
+//!
+//! The core cache API provides the bones of this.
+//!
+
+use std::str::FromStr;
+
+use http::header::InvalidHeaderName;
+pub use http::HeaderName;
+
+use crate::Error;
+
+/// A rule for variance of a request.
+///
+/// This rule describes what fields (headers) are used to determine whether a new request "matches"
+/// a previous response.
+#[derive(Debug)]
+pub struct VaryRule {
+    headers: Vec<HeaderName>,
+}
+
+impl FromStr for VaryRule {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let headers: Result<Vec<HeaderName>, InvalidHeaderName> =
+            s.split(" ").map(HeaderName::try_from).collect();
+        let mut headers = headers?;
+        headers.sort_by(|a, b| a.as_str().cmp(b.as_str()));
+        Ok(VaryRule { headers })
+    }
+}

--- a/lib/src/component/cache.rs
+++ b/lib/src/component/cache.rs
@@ -24,9 +24,9 @@ fn load_write_options(
 ) -> Result<WriteOptions, Error> {
     let max_age = Duration::from_nanos(options.max_age_ns);
     let initial_age = if options_mask.contains(cache::WriteOptionsMask::INITIAL_AGE_NS) {
-        Some(Duration::from_nanos(options.initial_age_ns))
+        Duration::from_nanos(options.initial_age_ns)
     } else {
-        None
+        Duration::ZERO
     };
     let request_headers = if options_mask.contains(cache::WriteOptionsMask::REQUEST_HEADERS) {
         let handle = options.request_headers;

--- a/lib/src/wiggle_abi/cache.rs
+++ b/lib/src/wiggle_abi/cache.rs
@@ -3,7 +3,6 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use http::HeaderMap;
-use wiggle::GuestError;
 
 use crate::body::Body;
 use crate::cache::{CacheKey, WriteOptions};

--- a/lib/src/wiggle_abi/cache.rs
+++ b/lib/src/wiggle_abi/cache.rs
@@ -29,9 +29,9 @@ fn load_write_options(
 ) -> Result<WriteOptions, Error> {
     let max_age = Duration::from_nanos(options.max_age_ns);
     let initial_age = if options_mask.contains(CacheWriteOptionsMask::INITIAL_AGE_NS) {
-        Some(Duration::from_nanos(options.initial_age_ns))
+        Duration::from_nanos(options.initial_age_ns)
     } else {
-        None
+        Duration::ZERO
     };
     let request_headers = if options_mask.contains(CacheWriteOptionsMask::REQUEST_HEADERS) {
         let handle = options.request_headers;

--- a/test-fixtures/src/bin/cache.rs
+++ b/test-fixtures/src/bin/cache.rs
@@ -1,6 +1,7 @@
 //! A guest program to test the core cache API works properly.
 
 use fastly::cache::core::*;
+use fastly::http::HeaderName;
 use std::io::Write;
 use std::time::Duration;
 use uuid::Uuid;
@@ -11,6 +12,9 @@ fn main() {
 
     test_single_body();
     test_insert_stale();
+    test_vary();
+    test_vary_multiple();
+    test_novary_ignore_headers();
     // We don't have a way of testing "incomplete streaming results in an error"
     // in a single instance. If we fail to close the (write) body handle, the underlying host object
     // is still hanging around, ready for more writes, until the instance is done.
@@ -134,7 +138,7 @@ fn test_insert_stale() {
     let found = lookup(key.clone()).execute().unwrap().unwrap();
 
     // NOTE: from cceckman-at-fastly:
-    // The compute platform currently does not return stale objects
+    // The compute platform currently does not return stale objects unless
     // they have stale_while_revalidate semantics. This may change in the future.
     // Viceroy _may_ return stale objects, i.e. it presents a superset of the compute platform's
     // behavior.
@@ -142,6 +146,143 @@ fn test_insert_stale() {
     assert!(found.is_stale());
     assert!(found.age() >= Duration::from_secs(2));
     assert!(found.ttl() == Duration::from_secs(1));
+}
+
+fn test_vary() {
+    let key = new_key();
+
+    let header_name = HeaderName::from_static("x-viceroy-test");
+
+    {
+        let mut writer = insert(key.clone(), Duration::from_secs(1000))
+            .header(&header_name, "foo")
+            .vary_by([&header_name])
+            .execute()
+            .unwrap();
+        write!(writer, "hello").unwrap();
+        writer.finish().unwrap();
+    }
+
+    // Lookup with just the key should return "not found";
+    // the request's headers don't match the rule.
+    let r1 = lookup(key.clone()).execute().unwrap();
+    assert!(r1.is_none());
+
+    // Lookup with the key & matching header value should work:
+    let r2 = lookup(key.clone())
+        .header(&header_name, "foo")
+        .execute()
+        .unwrap();
+    assert!(r2.is_some());
+
+    // Lookup with the key & non-matching header value should be "not found":
+    let r3 = lookup(key.clone())
+        .header(&header_name, "bar")
+        .execute()
+        .unwrap();
+    assert!(r3.is_none());
+}
+
+fn test_vary_multiple() {
+    let key = new_key();
+
+    // Set up three objects with different vary_by headers:
+    // The first varies by h1 and expects "test", with body "hello"
+    // The second varies by h2 and expects "assert", with body "world"
+    // The third varies by h3 and expects nothing, with body "goodbye"
+    let h1 = HeaderName::from_static("x-viceroy-test");
+    let h2 = HeaderName::from_static("x-viceroy-assert");
+    let h3 = HeaderName::from_static("x-viceroy-verify");
+
+    {
+        let mut writer = insert(key.clone(), Duration::from_secs(1000))
+            .header(&h1, "test")
+            .vary_by([&h1])
+            .execute()
+            .unwrap();
+        write!(writer, "hello").unwrap();
+        writer.finish().unwrap();
+    }
+
+    {
+        let mut writer = insert(key.clone(), Duration::from_secs(1000))
+            .header(&h2, "assert")
+            .vary_by([&h2])
+            .execute()
+            .unwrap();
+        write!(writer, "world").unwrap();
+        writer.finish().unwrap();
+    }
+
+    {
+        let mut writer = insert(key.clone(), Duration::from_secs(1000))
+            .vary_by([&h3])
+            .execute()
+            .unwrap();
+        write!(writer, "goodbye").unwrap();
+        writer.finish().unwrap();
+    }
+
+    {
+        // Match values for all three.
+        // Should return the most-recently-inserted, i.e. "goodbye"
+        let r = lookup(key.clone())
+            .header(&h1, "test")
+            .header(&h2, "assert")
+            // no h3
+            .execute()
+            .unwrap();
+        let body = r.unwrap().to_stream().unwrap().into_string();
+        assert_eq!(&body, "goodbye");
+    }
+
+    {
+        // Match values for just the first.
+        let r = lookup(key.clone())
+            .header(&h1, "test")
+            .header(&h3, "verify")
+            .execute()
+            .unwrap();
+        let body = r.unwrap().to_stream().unwrap().into_string();
+        assert_eq!(&body, "hello");
+    }
+
+    {
+        // Match values for the last, by providing no headers.
+        let r = lookup(key.clone()).execute().unwrap();
+        let body = r.unwrap().to_stream().unwrap().into_string();
+        assert_eq!(&body, "goodbye");
+    }
+}
+
+fn test_novary_ignore_headers() {
+    let key = new_key();
+
+    // The response and request have headers included, but don't have vary_by.
+    // That means the headers shouldn't matter.
+    let h1 = HeaderName::from_static("x-viceroy-test");
+    {
+        let mut writer = insert(key.clone(), Duration::from_secs(1000))
+            .header(&h1, "test")
+            .execute()
+            .unwrap();
+        write!(writer, "hello").unwrap();
+        writer.finish().unwrap();
+    }
+
+    {
+        // Header present: should retrieve the result.
+        let r = lookup(key.clone()).header(&h1, "test").execute().unwrap();
+        let body = r.unwrap().to_stream().unwrap().into_string();
+        assert_eq!(&body, "hello");
+    }
+
+    {
+        // Header missing: no vary_by, so shouldn't matter.
+        let r = lookup(key.clone()).execute().unwrap();
+        let body = r.unwrap().to_stream().unwrap().into_string();
+        assert_eq!(&body, "hello");
+    }
 }
 
 fn new_key() -> CacheKey {


### PR DESCRIPTION
Implement two important metadata items:
- `max_age` and initial age, for computing staleness
- request/response headers and `vary_by`

And along with that... implement lookup according to HTTP's vary semantics, adding another layer to the internal data structures.

