### PR TITLE
Add support for "metadata" field for local_server KV Store entry configs in fastly.toml

### DIFF
--- a/cli/tests/integration/kv_store.rs
+++ b/cli/tests/integration/kv_store.rs
@@ -12,7 +12,7 @@ viceroy_test!(kv_store, |is_component| {
         language = "rust"
         [local_server]
         kv_stores.empty_store = []
-        kv_stores.store_one = [{key = "first", data = "This is some data"},{key = "second", file = "../test-fixtures/data/kv-store.txt"}]
+        kv_stores.store_one = [{key = "first", data = "This is some data"},{key = "second", file = "../test-fixtures/data/kv-store.txt"},{key = "third", data = "third", metadata = "some metadata"}]
     "#;
 
     let resp = Test::using_fixture("kv_store.wasm")
@@ -42,7 +42,7 @@ viceroy_test!(object_stores_backward_compat, |is_component| {
         language = "rust"
         [local_server]
         object_stores.empty_store = []
-        object_stores.store_one = [{key = "first", data = "This is some data"},{key = "second", path = "../test-fixtures/data/kv-store.txt"}]
+        object_stores.store_one = [{key = "first", data = "This is some data"},{key = "second", path = "../test-fixtures/data/kv-store.txt"},{key = "third", data = "third", metadata = "some metadata"}]
     "#;
 
     let resp = Test::using_fixture("kv_store.wasm")
@@ -102,7 +102,7 @@ viceroy_test!(object_store_backward_compat, |is_component| {
         language = "rust"
         [local_server]
         object_store.empty_store = []
-        object_store.store_one = [{key = "first", data = "This is some data"},{key = "second", path = "../test-fixtures/data/kv-store.txt"}]
+        object_store.store_one = [{key = "first", data = "This is some data"},{key = "second", path = "../test-fixtures/data/kv-store.txt"},{key = "third", data = "third", metadata = "some metadata"}]
     "#;
 
     let resp = Test::using_fixture("kv_store.wasm")
@@ -336,6 +336,25 @@ viceroy_test!(kv_store_bad_configs, |is_component| {
     "#;
     match Test::using_fixture("kv_store.wasm").using_fastly_toml(BAD_14_FASTLY_TOML) {
         Err(e) => assert_eq!("invalid configuration for 'store_one': The file is of the wrong format. The file is expected to contain a single JSON Object.", &e.to_string()),
+        _ => panic!(),
+    }
+
+    const BAD_15_FASTLY_TOML: &str = r#"
+        name = "kv-store-test"
+        description = "kv store test"
+        authors = ["Jill Bryson <jbryson@fastly.com>", "Rose McDowall <rmcdowall@fastly.com>"]
+        language = "rust"
+        [local_server]
+        kv_stores.store_one = [{key = "first", data = "This is some data", metadata = 5}]
+    "#;
+    match Test::using_fixture("kv_store.wasm")
+        .adapt_component(is_component)
+        .using_fastly_toml(BAD_15_FASTLY_TOML)
+    {
+        Err(e) => assert_eq!(
+            "invalid configuration for 'store_one': The `metadata` value for the object `first` is not a string.",
+            &e.to_string()
+        ),
         _ => panic!(),
     }
 

--- a/lib/src/config/object_store.rs
+++ b/lib/src/config/object_store.rs
@@ -230,8 +230,8 @@ fn read_json_contents(
                 data: s,
                 metadata: None,
             },
-            serde_json::Value::Object(mut obj) => {
-                let data = obj.remove("data").ok_or_else(|| {
+            serde_json::Value::Object(obj) => {
+                let data = obj.get("data").ok_or_else(|| {
                     ObjectStoreConfigError::FileValueWrongFormat { key: key.clone() }
                 })?;
 
@@ -242,7 +242,7 @@ fn read_json_contents(
                     })?
                     .to_string();
 
-                let metadata = match obj.remove("metadata") {
+                let metadata = match obj.get("metadata") {
                     Some(val) => Some(
                         val.as_str()
                             .ok_or_else(|| ObjectStoreConfigError::FileValueWrongFormat {

--- a/lib/src/error.rs
+++ b/lib/src/error.rs
@@ -670,6 +670,8 @@ pub enum ObjectStoreConfigError {
     NoFileOrData(String),
     #[error("The `data` value for the object `{0}` is not a string.")]
     DataNotAString(String),
+    #[error("The `metadata` value for the object `{0}` is not a string.")]
+    MetadataNotAString(String),
     #[error("The `file` value for the object `{0}` is not a string.")]
     FileNotAString(String),
     #[error("The `key` key for an object is not set. It must be used.")]

--- a/test-fixtures/data/json-kv_store.json
+++ b/test-fixtures/data/json-kv_store.json
@@ -1,4 +1,8 @@
 {
     "first": "This is some data",
-    "second": "More data"
+    "second": "More data",
+    "third": {
+        "data": "third",
+        "metadata": "some metadata"
+    }
 }

--- a/test-fixtures/src/bin/kv_store.rs
+++ b/test-fixtures/src/bin/kv_store.rs
@@ -27,6 +27,16 @@ fn main() {
             .into_string(),
         "More data"
     );
+    // Test that we can get metadata using the `metadata` config key
+    assert_eq!(
+        store_one.lookup("third").unwrap().metadata().unwrap(),
+        "some metadata"
+    );
+    // Test that we cannot get metadata if it's not set
+    assert_eq!(
+        store_one.lookup("first").unwrap().metadata(),
+        None
+    );
 
     let empty_store = KVStore::open("empty_store").unwrap().unwrap();
     // Check that the value "bar" is not in the store


### PR DESCRIPTION
This PR adds support for an optional `metadata` string field in `[local_server.kv_stores]` of the `fastly.toml` config file.

It's used something like this:
```toml
[[local_server.kv_stores.example_store]]
key = "entry"
data = "this is some data"
metadata = "this is some metadata"
```

Now it can be accessed, e.g., in a JavaScript application:
```javascript
const entry = await kv.get('entry');
console.log('metadata', entry.metadataText());    // this is some metadata
console.log('text', await entry.text());          // this is some data
```

As described on [KV Store Item - Metadata](https://www.fastly.com/documentation/reference/api/services/resources/kv-store-item/#metadata), `metadata` can only be a UTF-8 string up to 2000 characters, so I didn't add support for non-strings or for external files at this time.

I've also updated the `file` / `format` handling as well so you can specify:
```json
{
  "entry": {
    "data": "this is some data",
    "metadata": "this is some metadata"
  }
}
```

this is done in a backwards-compatible way, so that the following two are functionally identical:
```json
{
  "entry": "this is some data",
}
```
```json
{
  "entry": {
    "data": "this is some data",
    "metadata": null
  }
}
```
