### PR TITLE
Transactional cache API, missing some options

### DIFF
--- a/cli/tests/integration/cache.rs
+++ b/cli/tests/integration/cache.rs
@@ -6,7 +6,7 @@ use {
     hyper::StatusCode,
 };
 
-viceroy_test!(cache_request_works, |is_component| {
+viceroy_test!(cache_nontransactional, |is_component| {
     if !std::env::var("ENABLE_EXPERIMENTAL_CACHE_API").is_ok_and(|v| v == "1") {
         eprintln!("WARNING: Skipping cache tests.");
         eprintln!(
@@ -16,6 +16,23 @@ viceroy_test!(cache_request_works, |is_component| {
     }
 
     let resp = Test::using_fixture("cache.wasm")
+        .adapt_component(is_component)
+        .against_empty()
+        .await?;
+    assert_eq!(resp.status(), StatusCode::OK);
+    Ok(())
+});
+
+viceroy_test!(cache_transactional, |is_component| {
+    if !std::env::var("ENABLE_EXPERIMENTAL_CACHE_API").is_ok_and(|v| v == "1") {
+        eprintln!("WARNING: Skipping cache tests.");
+        eprintln!(
+            "Set ENABLE_EXPERIMENTAL_CACHE_API=1 to enable experimental cache API and run tests."
+        );
+        return Ok(());
+    }
+
+    let resp = Test::using_fixture("cache_transactional.wasm")
         .adapt_component(is_component)
         .against_empty()
         .await?;

--- a/cli/tests/integration/cache.rs
+++ b/cli/tests/integration/cache.rs
@@ -17,7 +17,6 @@ viceroy_test!(cache_nontransactional, |is_component| {
 
     let resp = Test::using_fixture("cache.wasm")
         .adapt_component(is_component)
-        .log_stderr()
         .against_empty()
         .await?;
     assert_eq!(resp.status(), StatusCode::OK);
@@ -35,7 +34,6 @@ viceroy_test!(cache_transactional, |is_component| {
 
     let resp = Test::using_fixture("cache_transactional.wasm")
         .adapt_component(is_component)
-        .log_stderr()
         .against_empty()
         .await?;
     assert_eq!(resp.status(), StatusCode::OK);

--- a/cli/tests/integration/cache.rs
+++ b/cli/tests/integration/cache.rs
@@ -17,6 +17,7 @@ viceroy_test!(cache_nontransactional, |is_component| {
 
     let resp = Test::using_fixture("cache.wasm")
         .adapt_component(is_component)
+        .log_stderr()
         .against_empty()
         .await?;
     assert_eq!(resp.status(), StatusCode::OK);
@@ -34,6 +35,7 @@ viceroy_test!(cache_transactional, |is_component| {
 
     let resp = Test::using_fixture("cache_transactional.wasm")
         .adapt_component(is_component)
+        .log_stderr()
         .against_empty()
         .await?;
     assert_eq!(resp.status(), StatusCode::OK);

--- a/lib/src/cache.rs
+++ b/lib/src/cache.rs
@@ -74,13 +74,7 @@ impl TryFrom<&str> for CacheKey {
 pub struct CacheEntry {
     key: CacheKey,
     found: Option<Found>,
-    go_get: Option<GoGet>,
-}
-
-/// If the result needs to be fetched, an indicator of that.
-#[derive(Debug)]
-pub struct GoGet {
-    obligation: Obligation,
+    go_get: Option<Obligation>,
 }
 
 impl CacheEntry {
@@ -99,8 +93,13 @@ impl CacheEntry {
     }
 
     /// Returns the obligation to fetch, if required
-    pub fn go_get(&self) -> Option<&GoGet> {
+    pub fn go_get(&self) -> Option<&Obligation> {
         self.go_get.as_ref()
+    }
+
+    /// Extract the write obligation, if present.
+    pub fn take_go_get(&mut self) -> Option<Obligation> {
+        self.go_get.take()
     }
 }
 
@@ -186,7 +185,7 @@ impl Cache {
                 data,
                 last_body_handle: None,
             }),
-            go_get: obligation.map(|obligation| GoGet { obligation }),
+            go_get: obligation,
         }
     }
 

--- a/lib/src/cache.rs
+++ b/lib/src/cache.rs
@@ -173,7 +173,7 @@ impl Cache {
         self.inner
             .get_with_by_ref(&key, async { Default::default() })
             .await
-            .insert(request_headers, options, body);
+            .insert(request_headers, options, body, None);
     }
 }
 

--- a/lib/src/cache.rs
+++ b/lib/src/cache.rs
@@ -229,12 +229,17 @@ impl Cache {
     }
 
     /// Perform a transactional lookup.
-    pub async fn transaction_lookup(&self, key: &CacheKey, headers: &HeaderMap) -> CacheEntry {
+    pub async fn transaction_lookup(
+        &self,
+        key: &CacheKey,
+        headers: &HeaderMap,
+        ok_to_wait: bool,
+    ) -> CacheEntry {
         let (found, obligation) = self
             .inner
             .get_with_by_ref(&key, async { Default::default() })
             .await
-            .transaction_get(headers)
+            .transaction_get(headers, ok_to_wait)
             .await;
         CacheEntry {
             key: key.clone(),

--- a/lib/src/cache.rs
+++ b/lib/src/cache.rs
@@ -178,6 +178,7 @@ impl Cache {
 }
 
 /// Options that can be applied to a write, e.g. insert or transaction_insert.
+#[derive(Default)]
 pub struct WriteOptions {
     pub max_age: Duration,
     pub initial_age: Duration,

--- a/lib/src/cache.rs
+++ b/lib/src/cache.rs
@@ -8,6 +8,7 @@ use crate::{
     component::fastly::api::types::Error as ComponentError,
     wiggle_abi::types::{BodyHandle, CacheOverrideTag, FastlyStatus},
 };
+
 use http::{HeaderMap, HeaderValue};
 
 mod store;
@@ -125,6 +126,15 @@ pub struct CacheEntry {
 }
 
 impl CacheEntry {
+    /// Return a stub entry to hold in CacheBusy.
+    pub fn stub(&self) -> CacheEntry {
+        Self {
+            key: self.key.clone(),
+            found: None,
+            go_get: None,
+        }
+    }
+
     /// Returns the key used to generate this CacheEntry.
     pub fn key(&self) -> &CacheKey {
         &self.key

--- a/lib/src/cache.rs
+++ b/lib/src/cache.rs
@@ -123,7 +123,6 @@ impl Found {
 ///
 // TODO: cceckman-at-fastly:
 // Explain some about how this works:
-// - Request-keyed vs. response-keyed items; variance
 // - Request collapsing
 // - Stale-while-revalidate
 pub struct Cache {

--- a/lib/src/cache/store.rs
+++ b/lib/src/cache/store.rs
@@ -194,6 +194,10 @@ impl CacheKeyObjects {
                     .iter()
                     .map(|v| v.variant(request_headers))
                     .collect();
+                // These are the existing cache entries that would be valid for this request,
+                // taking into account vary rules.
+                // They may be stale or not-yet-filled (i.e. obligation-only); let's see what we
+                // can get out of them.
                 let response_keyed_objects: Vec<_> = response_keys
                     .iter()
                     .filter_map(|v| key_objects.objects.get(v))
@@ -263,7 +267,8 @@ impl CacheKeyObjects {
     ///
     /// If a clear_obligation is provided, clear the "obligated" bit on that Variant in the same
     /// transaction (so there's only one wakeup). Note the clear_obligation variant may differ from
-    /// the variant inserted.
+    /// the variant inserted: we place the obligation marker based on the _existing_ Vary rules,
+    /// but we insert based on the Vary rule received in the response.
     pub fn insert(
         &self,
         request_headers: HeaderMap,

--- a/lib/src/cache/store.rs
+++ b/lib/src/cache/store.rs
@@ -359,7 +359,7 @@ pub(crate) struct CacheData {
 
 impl CacheData {
     /// Get a Body to read the cached object with.
-    pub(crate) fn get_body(&self) -> Result<Body, Error> {
+    pub(crate) fn get_body(&self) -> Result<Body, crate::Error> {
         self.body.read()
     }
 

--- a/lib/src/cache/store.rs
+++ b/lib/src/cache/store.rs
@@ -346,10 +346,8 @@ pub struct Obligation {
 impl Obligation {
     /// Fulfill the obligation by providing write options and a body.
     pub fn complete(mut self, options: WriteOptions, body: Body) {
-        let mut request_headers = HeaderMap::default();
-        let mut variant = Variant::default();
-        std::mem::swap(&mut self.request_headers, &mut request_headers);
-        std::mem::swap(&mut self.variant, &mut variant);
+        let request_headers = std::mem::take(&mut self.request_headers);
+        let variant = std::mem::take(&mut self.variant);
         self.object
             .insert(request_headers, options, body, Some(variant));
         // Mild optimization: avoid re-acquiring the lock when we drop.

--- a/lib/src/cache/store.rs
+++ b/lib/src/cache/store.rs
@@ -99,7 +99,7 @@ impl ObjectMeta {
 }
 
 /// Object(s) indexed by a CacheKey.
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub struct CacheKeyObjects(watch::Sender<CacheKeyObjectsInner>);
 
 impl CacheKeyObjects {
@@ -277,7 +277,7 @@ impl CacheKeyObjects {
     }
 }
 
-#[derive(Default)]
+#[derive(Debug, Default)]
 struct CacheKeyObjectsInner {
     /// All the vary rules that might apply.
     /// Most-recent at the front, so we tend towards fresher responses.
@@ -307,6 +307,7 @@ struct CacheValue {
 }
 
 /// An obligation to fetch & update the cache.
+#[derive(Debug)]
 pub struct Obligation {
     object: Arc<CacheKeyObjects>,
     request_headers: HeaderMap,

--- a/lib/src/cache/store.rs
+++ b/lib/src/cache/store.rs
@@ -79,11 +79,10 @@ impl ObjectMeta {
     }
 }
 
-impl From<WriteOptions> for ObjectMeta {
-    fn from(value: WriteOptions) -> Self {
+impl ObjectMeta {
+    fn new(value: WriteOptions, request_headers: HeaderMap) -> Self {
         let inserted = Instant::now();
         let WriteOptions {
-            request_headers,
             vary_rule,
             max_age,
             initial_age,
@@ -124,8 +123,8 @@ impl CacheKeyObjects {
     // get_or_obligate, for transactional API
 
     /// Insert into the given CacheData.
-    pub fn insert(&self, options: WriteOptions, body: Body) {
-        let meta: ObjectMeta = options.into();
+    pub fn insert(&self, request_headers: HeaderMap, options: WriteOptions, body: Body) {
+        let meta = ObjectMeta::new(options, request_headers);
 
         self.0.send_modify(|cache_key_objects| {
             if !cache_key_objects.vary_rules.contains(meta.vary_rule()) {

--- a/lib/src/cache/store.rs
+++ b/lib/src/cache/store.rs
@@ -324,6 +324,9 @@ impl Obligation {
         std::mem::swap(&mut self.variant, &mut variant);
         self.object
             .insert(request_headers, options, body, Some(variant));
+        // Mild optimization: avoid re-acquiring the lock when we drop.
+        // We've already cleared the obligation flag.
+        self.completed = true;
     }
 }
 

--- a/lib/src/cache/store.rs
+++ b/lib/src/cache/store.rs
@@ -10,7 +10,7 @@ use tokio::sync::watch;
 
 use http::HeaderMap;
 
-use crate::{body::Body, collecting_body::CollectingBody, Error};
+use crate::{body::Body, collecting_body::CollectingBody};
 
 use super::{variance::Variant, WriteOptions};
 

--- a/lib/src/component/cache.rs
+++ b/lib/src/component/cache.rs
@@ -373,11 +373,13 @@ impl cache::Host for ComponentCtx {
         .into())
     }
 
-    async fn transaction_cancel(&mut self, _handle: cache::Handle) -> Result<(), types::Error> {
-        Err(Error::Unsupported {
-            msg: "Cache API primitives not yet supported",
+    async fn transaction_cancel(&mut self, handle: cache::Handle) -> Result<(), types::Error> {
+        let entry = self.session.cache_entry_mut(handle.into()).await?;
+        if let Some(_) = entry.take_go_get() {
+            Ok(())
+        } else {
+            Err(crate::cache::Error::CannotWrite.into())
         }
-        .into())
     }
 
     async fn close_busy(&mut self, _handle: cache::BusyHandle) -> Result<(), types::Error> {

--- a/lib/src/component/error.rs
+++ b/lib/src/component/error.rs
@@ -226,6 +226,7 @@ impl From<error::Error> for types::Error {
             Error::ObjectStoreError(e) => e.into(),
             Error::KvStoreError(e) => e.into(),
             Error::SecretStoreError(e) => e.into(),
+            Error::CacheError(e) => e.into(),
             // All other hostcall errors map to a generic `ERROR` value.
             Error::AbiVersionMismatch
             | Error::BackendUrl(_)
@@ -258,8 +259,7 @@ impl From<error::Error> for types::Error {
             | Error::InvalidAlpnRepsonse { .. }
             | Error::DeviceDetectionError(_)
             | Error::Again
-            | Error::SharedMemory
-            | Error::CacheError(_) => types::Error::GenericError,
+            | Error::SharedMemory => types::Error::GenericError,
         }
     }
 }

--- a/lib/src/error.rs
+++ b/lib/src/error.rs
@@ -192,6 +192,7 @@ impl Error {
             Error::KvStoreError(e) => e.into(),
             Error::SecretStoreError(e) => e.into(),
             Error::Again => FastlyStatus::Again,
+            Error::CacheError(e) => e.into(),
             // All other hostcall errors map to a generic `ERROR` value.
             Error::AbiVersionMismatch
             | Error::BackendUrl(_)
@@ -218,8 +219,7 @@ impl Error {
             | Error::UnfinishedStreamingBody
             | Error::SharedMemory
             | Error::ToStr(_)
-            | Error::InvalidAlpnRepsonse(_, _)
-            | Error::CacheError(_) => FastlyStatus::Error,
+            | Error::InvalidAlpnRepsonse(_, _) => FastlyStatus::Error,
         }
     }
 

--- a/lib/src/error.rs
+++ b/lib/src/error.rs
@@ -150,8 +150,8 @@ pub enum Error {
     Again,
 
     // TODO: cceckman-at-fastly ; better error types
-    #[error("Error from cache: {0}")]
-    CacheError(String),
+    #[error("cache error: {0}")]
+    CacheError(crate::cache::Error),
 }
 
 impl Error {

--- a/test-fixtures/src/bin/cache.rs
+++ b/test-fixtures/src/bin/cache.rs
@@ -116,12 +116,11 @@ fn test_single_body() {
     // We should be able to get two bodies from two different lookups:
     let b1 = f1.to_stream().unwrap();
     let _b2 = f2.to_stream().unwrap();
-    // But a second body from the same lookup should cause an error, while the first is
-    // outstanding:
-    // TODO: cceckman-at-fastly: Tidy up error types. This should return InvalidOperation per the
-    // API.
-    // assert!(matches!(f1.to_stream(), Err(CacheError::InvalidOperation)));
-    assert!(f1.to_stream().is_err());
+    // But a second body from the same lookup should cause an error-
+    // specifically an InvalidOperation error, per the API docs-
+    // while the first is outstanding:
+    eprintln!("{}", f1.to_stream().unwrap_err());
+    assert!(matches!(f1.to_stream(), Err(CacheError::InvalidOperation)));
     std::mem::drop(b1);
     // Now the prior read from that lookup can proceed:
     let _ = f1.to_stream().unwrap();

--- a/test-fixtures/src/bin/cache_transactional.rs
+++ b/test-fixtures/src/bin/cache_transactional.rs
@@ -1,4 +1,5 @@
 use fastly::cache::core::*;
+use http::HeaderName;
 use std::io::{Read, Write};
 use std::time::Duration;
 use uuid::Uuid;
@@ -8,6 +9,7 @@ fn main() {
     test_implicit_cancel_of_fetch();
     test_implicit_cancel_of_pending();
     test_explicit_cancel();
+    test_collapse_across_vary();
 }
 
 fn new_key() -> CacheKey {
@@ -98,4 +100,53 @@ fn test_explicit_cancel() {
     let t2 = pending.wait().unwrap();
     assert!(!t2.found().is_some());
     assert!(t2.must_insert_or_update());
+}
+
+fn test_collapse_across_vary() {
+    let key = new_key();
+
+    let header1 = HeaderName::from_static("header1");
+    let header2 = HeaderName::from_static("header2");
+
+    // Prefill with distinct vary rules, with stale responses:
+    let b = insert(key.clone(), Duration::ZERO)
+        .header(&header1, "value1")
+        .vary_by([&header1].into_iter())
+        .execute()
+        .unwrap();
+    b.finish().unwrap();
+
+    let b = insert(key.clone(), Duration::ZERO)
+        .header(&header2, "value2")
+        .vary_by([&header2].into_iter())
+        .execute()
+        .unwrap();
+    b.finish().unwrap();
+
+    // vary: header2 is the most recent value.
+    // If we start a transaction that matches both rules:
+    let txn2 = Transaction::lookup(key.clone())
+        .header(&header2, "value2")
+        .header(&header1, "value1")
+        .execute_async()
+        .unwrap();
+    // And a transaction that matches only the header1 rule:
+    let txn1 = Transaction::lookup(key.clone())
+        .header(&header1, "value1")
+        .execute_async()
+        .unwrap();
+
+    // Are these requests collapsed?
+    //
+    // If we are using the most-recent-received Vary rule as a heuristic for "what do we expect the
+    // next Vary rule to be", then we should *not* collapse them: the most recent vary rule is
+    // `header2`, and these have distinct `header2` values.
+    //
+    // However, if we're saying "collapse based on any vary rule received in the past", they would
+    // not be collapsed.
+    //
+    // We err on the side of "less latency, more requests": both of these should be outstanding,
+    // because according to the most recent vary rule they are distinct.
+    assert!(!txn2.pending().unwrap());
+    assert!(!txn1.pending().unwrap());
 }

--- a/test-fixtures/src/bin/cache_transactional.rs
+++ b/test-fixtures/src/bin/cache_transactional.rs
@@ -1,0 +1,93 @@
+use fastly::cache::core::*;
+use std::io::{Read, Write};
+use std::time::Duration;
+use uuid::Uuid;
+
+fn main() {
+    test_racing_transactions();
+    test_implicit_cancel();
+    test_explicit_cancel();
+}
+
+fn new_key() -> CacheKey {
+    Uuid::new_v4().into_bytes().to_vec().into()
+}
+
+/// Among two transactions, pick the one "ready" and the one "pending", in that order.
+fn ready_and_pending(
+    busy1: PendingTransaction,
+    busy2: PendingTransaction,
+) -> (Transaction, PendingTransaction) {
+    // Exactly one should become pending:
+    let (ready, pending) = loop {
+        let p1 = busy1.pending().unwrap();
+        let p2 = busy2.pending().unwrap();
+        if !p1 {
+            assert!(p2);
+            break (busy1, busy2);
+        }
+        if !p2 {
+            assert!(p1);
+            break (busy2, busy1);
+        }
+        std::thread::sleep(Duration::from_millis(4));
+    };
+    (ready.wait().unwrap(), pending)
+}
+
+fn test_racing_transactions() {
+    let key = new_key();
+
+    let busy1 = Transaction::lookup(key.clone()).execute_async().unwrap();
+    let busy2 = Transaction::lookup(key.clone()).execute_async().unwrap();
+    let (tx, pending) = ready_and_pending(busy1, busy2);
+    assert!(tx.found().is_none());
+    // The first to resolve should have the obligation to insert:
+    assert!(tx.must_insert());
+    let mut body = tx.insert(Duration::from_secs(100)).execute().unwrap();
+
+    // Once we've started streaming, the other transaction should complete:
+    let tx = pending.wait().unwrap();
+    assert!(!tx.must_insert());
+    let found = tx.found().unwrap();
+    assert_eq!(found.ttl(), Duration::from_secs(100));
+    let mut rd_body = found.to_stream().unwrap();
+
+    // Write the body and read it back:
+    body.write(b"hello").unwrap();
+    body.finish().unwrap();
+
+    let mut read = String::new();
+    rd_body.read_to_string(&mut read).unwrap();
+    assert_eq!(&read, "hello");
+}
+
+fn test_implicit_cancel() {
+    let key = new_key();
+
+    let busy1 = Transaction::lookup(key.clone()).execute_async().unwrap();
+    let busy2 = Transaction::lookup(key.clone()).execute_async().unwrap();
+    let (tx, pending) = ready_and_pending(busy1, busy2);
+
+    // Cancel via dropping:
+    assert!(tx.must_insert_or_update());
+    std::mem::drop(tx);
+    //let t2 = pending.wait().unwrap();
+    //assert!(!t2.found().is_some());
+}
+
+fn test_explicit_cancel() {
+    let key = new_key();
+
+    let busy1 = Transaction::lookup(key.clone()).execute_async().unwrap();
+    let busy2 = Transaction::lookup(key.clone()).execute_async().unwrap();
+    let (tx, pending) = ready_and_pending(busy1, busy2);
+
+    // Cancel explicitly:
+    assert!(tx.must_insert_or_update());
+    tx.cancel_insert_or_update().unwrap();
+
+    let t2 = pending.wait().unwrap();
+    assert!(!t2.found().is_some());
+    assert!(t2.must_insert_or_update());
+}


### PR DESCRIPTION
Start implementing the transactional side of the core cache API.

Transactions begin with a `transaction_lookup` or `transaction_lookup_async`. When the `CacheBusyHandle` is `await`ed, it either returns a result immediately; returns an obligation indicating "you should fulfill this"; or blocks, until the obligatee abandons or fulfills their obligation.

NB, the implementation of `cancel` here matches a recent change to Fastly's Compute Platform. Previously, `close(BusyHandle)` would block until the obligation was fulfilled or granted to the closer; now, `close` doesn't block. This shouldn't really matter to anyone other than making e.g. timeouts to origin fail in better ways.