### PR TITLE
:straight_ruler:  Known length option for core cache

### DIFF
--- a/lib/src/cache.rs
+++ b/lib/src/cache.rs
@@ -185,6 +185,11 @@ impl Found {
     pub fn meta(&self) -> &ObjectMeta {
         self.data.get_meta()
     }
+
+    /// The length of the cached object, if known.
+    pub fn length(&self) -> Option<u64> {
+        self.data.length()
+    }
 }
 
 /// Cache for a service.
@@ -276,6 +281,7 @@ pub struct WriteOptions {
     pub initial_age: Duration,
     pub vary_rule: VaryRule,
     pub user_metadata: Bytes,
+    pub length: Option<u64>,
 }
 
 impl WriteOptions {
@@ -285,6 +291,7 @@ impl WriteOptions {
             initial_age: Duration::ZERO,
             vary_rule: VaryRule::default(),
             user_metadata: Bytes::new(),
+            length: None,
         }
     }
 }

--- a/lib/src/cache/store.rs
+++ b/lib/src/cache/store.rs
@@ -313,7 +313,7 @@ impl CacheKeyObjects {
             cache_key_objects.vary_rules.push_front(vary_rule);
 
             let variant = meta.variant();
-            let body = CollectingBody::new(body);
+            let body = CollectingBody::new(body, meta.length);
             let object = Arc::new(CacheData { body, meta });
 
             cache_key_objects

--- a/lib/src/cache/store.rs
+++ b/lib/src/cache/store.rs
@@ -36,6 +36,8 @@ pub struct ObjectMeta {
     vary_rule: VaryRule,
 
     user_metadata: Bytes,
+
+    length: Option<u64>,
     // TODO: cceckman-at-fastly: for future work!
     /*
     never_cache: bool, // Aka "hit for pass"
@@ -43,7 +45,6 @@ pub struct ObjectMeta {
     edge_ok_until: Option<Instant>,
 
     surrogate_keys: HashSet<String>,
-    length: Option<usize>,
     sensitive_data: Option<bool>,
     */
 }
@@ -93,6 +94,7 @@ impl ObjectMeta {
             max_age,
             initial_age,
             user_metadata,
+            length,
             ..
         } = value;
         ObjectMeta {
@@ -102,6 +104,7 @@ impl ObjectMeta {
             request_headers,
             vary_rule,
             user_metadata,
+            length,
         }
     }
 }
@@ -412,6 +415,11 @@ impl CacheData {
     /// Access to object's metadata
     pub(crate) fn get_meta(&self) -> &ObjectMeta {
         &self.meta
+    }
+
+    /// Return the length of this object, if known.
+    pub fn length(&self) -> Option<u64> {
+        self.body.length().or_else(|| self.meta.length)
     }
 }
 

--- a/lib/src/collecting_body.rs
+++ b/lib/src/collecting_body.rs
@@ -38,6 +38,18 @@ impl Default for CollectingBodyInner {
 }
 
 impl CollectingBody {
+    /// Returns the length of the body, if it is complete.
+    pub fn length(&self) -> Option<u64> {
+        let state = self.inner.borrow();
+        match *state {
+            CollectingBodyInner::Streaming(_) => None,
+            CollectingBodyInner::Complete { ref body, .. } => {
+                Some(body.iter().map(|chunk| chunk.len()).sum::<usize>() as u64)
+            }
+            CollectingBodyInner::Error(_) => None,
+        }
+    }
+
     /// Create a new CollectingBody that stores & streams from the provided Body.
     ///
     /// Writes to the StreamingBody are collected, and propagated to all readers of this

--- a/test-fixtures/src/bin/cache.rs
+++ b/test-fixtures/src/bin/cache.rs
@@ -38,7 +38,7 @@ fn main() {
 /// may still observe the body as "streaming" for a period of time.
 ///
 /// If we didn't provide a known .length() along with the insert data, we can sleep+poll until the
-/// length is known, implying that the whole bosy is available.
+/// length is known, implying that the whole body is available.
 ///
 /// This is an ugly hack. Sorry.
 fn poll_known_length(found: &Found) {


### PR DESCRIPTION
Support `known_length` insert option.

Generate an error on body read if the `known_length` provided does not match the total number of bytes written.
(The fixture test passes on the compute platform and in Viceroy.)


