### PR TITLE
make `SecretStore` available publicly so we can use secrets in integration tests

### DIFF
--- a/lib/src/config.rs
+++ b/lib/src/config.rs
@@ -53,7 +53,7 @@ pub use crate::object_store::ObjectStores;
 
 /// Types and deserializers for secret store configuration settings.
 mod secret_store;
-pub use crate::secret_store::SecretStores;
+pub use crate::secret_store::{SecretStore, SecretStores};
 
 pub use crate::shielding_site::ShieldingSites;
 


### PR DESCRIPTION
When writing integration tests with `ExecuteCtx` I want to provide secrets for the service to use. 

This wasn't possible without having access to the `SecretStore` object. 