### PR TITLE
Remove env var guard for cache features

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,8 +18,7 @@ test: test-crates trap-test
 
 .PHONY: test-crates
 test-crates: fix-build
-	# TODO: cceckman-at-fastly: When all cache APIs match Compute Platform, remove the environment flag.
-	RUST_BACKTRACE=1 ENABLE_EXPERIMENTAL_CACHE_API=1 $(VICEROY_CARGO) test --all
+	RUST_BACKTRACE=1 $(VICEROY_CARGO) test --all
 
 .PHONY: fix-build
 fix-build:

--- a/cli/tests/integration/cache.rs
+++ b/cli/tests/integration/cache.rs
@@ -7,14 +7,6 @@ use {
 };
 
 viceroy_test!(cache, |is_component| {
-    if !std::env::var("ENABLE_EXPERIMENTAL_CACHE_API").is_ok_and(|v| v == "1") {
-        eprintln!("WARNING: Skipping cache tests.");
-        eprintln!(
-            "Set ENABLE_EXPERIMENTAL_CACHE_API=1 to enable experimental cache API and run tests."
-        );
-        return Ok(());
-    }
-
     let resp = Test::using_fixture("cache.wasm")
         .adapt_component(is_component)
         .against_empty()

--- a/lib/src/cache.rs
+++ b/lib/src/cache.rs
@@ -172,15 +172,18 @@ impl CacheEntry {
         Ok(())
     }
 
-    /// Freshen the existing body according to the provided options.
+    /// Freshen the existing cache item according to the new write options,
+    /// without changing the body.
     pub fn update(&mut self, options: WriteOptions) -> Result<(), crate::Error> {
         let go_get = self.take_go_get().ok_or(Error::NotRevalidatable)?;
-        let Err((go_get, err)) = go_get.update(options) else {
-            return Ok(());
-        };
-        // On failure, preserve the obligation.
-        self.go_get = Some(go_get);
-        Err(err)
+        match go_get.update(options) {
+            Ok(()) => Ok(()),
+            Err((go_get, err)) => {
+                // On failure, preserve the obligation.
+                self.go_get = Some(go_get);
+                Err(err)
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Prior to this change, the entry points to the core cache API (`insert`) required that the `ENABLE_EXPERIMENTAL_CACHE_API` be set. This was because not all options were handled; we wouldn't want to complete the hostcall while ignoring an option, without the caller opting in.

However, this means that a user can't use *any* of the core cache API without opting in to the "partially correct" behavior. e.g., a user can't stick to the implemented subset without setting the environment flag.

In this PR, instead, return `NotSupported` for any hostcall options that are not yet implemented. Consume the `options_mask` bits as each option is consumed, and check that the remaining mask is empty at the end of processing.

Note that this is future-compatible when new options are added. If a guest program attempts to invoke an option that is not handled in Viceroy, they'll (correctly) get `NotSupported` with no special changes to Viceroy. Put differently, going forward, Viceroy won't silently discard unknown options bits.

This removes the `ENABLE_EXPERIMENTAL_CACHE_API` environment variable as a guard. A couple of options are still not handled (surrogate keys + range requests), but per the above, they'll return `NotSupported` if invoked.


