### PR TITLE
Support execute_and_stream_back

### DIFF
--- a/lib/src/body.rs
+++ b/lib/src/body.rs
@@ -504,7 +504,7 @@ mod tests {
             }),
         ) {
             let rt = tokio::runtime::Builder::new_current_thread().build().unwrap();
-            return rt.block_on(test_gzip_body(body, chunk_lengths));
+            rt.block_on(test_gzip_body(body, chunk_lengths))?
         }
 
     }
@@ -519,7 +519,7 @@ mod tests {
             }),
         ) {
             let rt = tokio::runtime::Builder::new_current_thread().build().unwrap();
-            return rt.block_on(test_chunked_body(body, chunk_lengths));
+            rt.block_on(test_chunked_body(body, chunk_lengths))?
         }
 
     }

--- a/test-fixtures/src/bin/expects-hello.rs
+++ b/test-fixtures/src/bin/expects-hello.rs
@@ -1,5 +1,5 @@
 use fastly::Request;
-use http::{HeaderName, StatusCode, Version};
+use http::{HeaderName, StatusCode};
 
 fn main() {
     let mut resp = Request::get("https://fastly.com/")

--- a/test-fixtures/src/bin/write-and-read-body.rs
+++ b/test-fixtures/src/bin/write-and-read-body.rs
@@ -1,14 +1,14 @@
 use fastly::Body;
-use std::io::Read;
+use std::io::{Read, Write};
 
 fn main() {
     let mut body = Body::new();
-    body.write_str("Hello");
-    body.write_str(", ");
+    body.write(b"Hello").unwrap();
+    body.write(b", ").unwrap();
 
     let mut body2 = Body::new();
-    body2.write_str("Viceroy");
-    body2.write_str("!");
+    body2.write(b"Viceroy").unwrap();
+    body2.write(b"!").unwrap();
 
     body.append(body2);
 


### PR DESCRIPTION
I had missed this; but some of the "range request" tests uncovered that I had missed it.

- Address several lints
- Sync tests with internal copy
- Test and implement insert_and_stream_back
