### PR TITLE
feat: Add Pushpin proxying support for local testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 ## Unreleased
 
+- Add support for integrating with a local Pushpin instance ([#497](https://github.com/fastly/Viceroy/pull/497))
+
+  Viceroy can be invoked with `--local-pushpin-proxy-port=<port>` to cause
+  requests that invoke the `fastly_http_req.redirect_to_grip_proxy` and `_v2`
+  hostcalls to be proxied through a local Pushpin instance running on the
+  specified port. This enables developers to locally test Fanout (real-time
+  messaging) features like HTTP streaming or WebSockets-over-HTTP.
+
+  Requests forwarded this way will be replayed:
+   - Method, headers, path, and query of the forwarded request will be based on
+     the request whose handle is passed to `redirect_to_grip_proxy_v2` (or from
+     the downstream request if `redirect_to_grip_proxy` was called).
+   - The request header `pushpin-route` will be added, its value set to the backend name.
+   - Request body of the forwarded request will contain the full body of the
+     downstream request.
+
+  This mechanism expects Pushpin to be configured with `accept_pushpin_route`
+  to be set to `true` and for its routes to be set up properly. This is
+  configured automatically if Viceroy is called through the Fastly CLI's
+  `fastly compute serve` command.
+
 ## 0.13.0
 
 - Add support for shielding primitives in Viceroy ([#455](https://github.com/fastly/Viceroy/pull/455)

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -318,7 +318,8 @@ async fn create_execution_context(
         args.adapt(),
     )?
     .with_log_stderr(args.log_stderr())
-    .with_log_stdout(args.log_stdout());
+    .with_log_stdout(args.log_stdout())
+    .with_local_pushpin_proxy_port(args.local_pushpin_proxy_port());
 
     let Some(config_path) = args.config_path() else {
         event!(

--- a/cli/src/opts.rs
+++ b/cli/src/opts.rs
@@ -102,6 +102,10 @@ pub struct SharedArgs {
     /// (microseconds), and "ns" (nanoseconds).
     #[arg(long = "profile", value_name = "STRATEGY", value_parser = check_wasmtime_profiler_mode)]
     profile: Option<Profile>,
+    /// Port running local Pushpin proxy. If not provided, Pushpin functionality
+    /// is disabled.
+    #[arg(long = "local-pushpin-proxy-port")]
+    local_pushpin_proxy_port: Option<u16>,
     /// Set of experimental WASI modules to link against.
     #[arg(value_enum, long = "experimental_modules", required = false)]
     experimental_modules: Vec<ExperimentalModuleArg>,
@@ -181,6 +185,11 @@ impl SharedArgs {
             Some(Profile::Native(s)) => s,
             _ => ProfilingStrategy::None,
         }
+    }
+
+    /// Port running local Pushpin proxy.
+    pub fn local_pushpin_proxy_port(&self) -> Option<u16> {
+        self.local_pushpin_proxy_port
     }
 
     /// Configuration for guest profiling if enabled

--- a/lib/src/body_tee.rs
+++ b/lib/src/body_tee.rs
@@ -1,0 +1,347 @@
+use futures::stream::{Stream, StreamExt};
+use hyper::body::{Body, Bytes, HttpBody};
+use std::collections::VecDeque;
+use std::fmt;
+use std::pin::Pin;
+use std::sync::{Arc, Mutex};
+use std::task::{Context, Poll, Waker};
+
+/// The "tee" needs a cloneable error that can be given to both forks of the output stream.
+#[derive(Clone, Debug)]
+pub struct StringError(String);
+
+impl fmt::Display for StringError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl std::error::Error for StringError {}
+
+#[derive(Debug, Default, Clone)]
+struct ConsumerState {
+    waker: Option<Waker>,
+    cursor: usize,
+    active: bool,
+}
+
+/// The shared state between the two output streams.
+#[derive(Debug)]
+struct SharedState {
+    /// The buffer holds chunks or an error from the source stream.
+    buffer: VecDeque<Result<Bytes, StringError>>,
+    /// The absolute index of the first element in the buffer.
+    offset: usize,
+    /// True if the source stream has finished.
+    is_done: bool,
+    /// State for the two consumer streams.
+    consumers: [ConsumerState; 2],
+}
+
+impl Default for SharedState {
+    fn default() -> Self {
+        Self {
+            buffer: VecDeque::new(),
+            offset: 0,
+            is_done: false,
+            consumers: [
+                ConsumerState {
+                    active: true,
+                    ..Default::default()
+                },
+                ConsumerState {
+                    active: true,
+                    ..Default::default()
+                },
+            ],
+        }
+    }
+}
+
+/// A stream that is one of two outputs from the tee operation.
+#[derive(Debug)]
+pub struct BodyTeeStream {
+    shared: Arc<Mutex<SharedState>>,
+    id: usize,
+}
+
+/// Tees a Body into two independent, error-propagating, and memory-safe streams.
+pub async fn tee(mut hyper_body: Body) -> (Body, Body) {
+    if HttpBody::size_hint(&hyper_body).exact().is_some() {
+        // If the size is known, we MUST buffer the body to preserve the
+        // Content-Length.
+        let bytes = hyper::body::to_bytes(hyper_body)
+            .await
+            .expect("Failed to buffer known-size body");
+        // `Bytes` is cheap to clone.
+        return (hyper::Body::from(bytes.clone()), hyper::Body::from(bytes));
+    }
+
+    let shared_state = Arc::new(Mutex::new(SharedState::default()));
+
+    let s1 = BodyTeeStream {
+        shared: shared_state.clone(),
+        id: 0,
+    };
+
+    let s2 = BodyTeeStream {
+        shared: shared_state.clone(),
+        id: 1,
+    };
+
+    tokio::spawn(async move {
+        loop {
+            let result = hyper_body.next().await;
+            let mut state = shared_state.lock().unwrap();
+
+            let finished = if let Some(item) = result {
+                // Convert any error into our simple, cloneable StringError.
+                let item_to_store = item.map_err(|e| StringError(e.to_string()));
+                let is_err = item_to_store.is_err();
+                state.buffer.push_back(item_to_store);
+                is_err
+            } else {
+                true
+            };
+
+            if finished {
+                state.is_done = true;
+            }
+
+            for consumer in state.consumers.iter_mut().filter(|c| c.active) {
+                if let Some(waker) = consumer.waker.take() {
+                    waker.wake();
+                }
+            }
+
+            drain_buffer(&mut state);
+
+            if finished {
+                break;
+            }
+        }
+    });
+
+    (Body::wrap_stream(s1), Body::wrap_stream(s2))
+}
+
+impl HttpBody for BodyTeeStream {
+    type Data = Bytes;
+    // The error type must be convertible into hyper's error type. A boxed
+    // standard error is the idiomatic way to do this.
+    type Error = Box<dyn std::error::Error + Send + Sync>;
+
+    fn poll_data(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<Self::Data, Self::Error>>> {
+        let this = self.get_mut();
+        let mut state = this.shared.lock().unwrap();
+
+        let SharedState {
+            buffer,
+            offset,
+            is_done,
+            consumers,
+            ..
+        } = &mut *state;
+
+        let consumer = &mut consumers[this.id];
+
+        if consumer.cursor >= *offset {
+            let buffer_index = consumer.cursor - *offset;
+            if let Some(result) = buffer.get(buffer_index) {
+                consumer.cursor += 1;
+                // FIX: When we read from the buffer, explicitly cast the boxed concrete
+                // error to a boxed trait object to satisfy the type checker.
+                return Poll::Ready(Some(result.clone().map_err(|e| Box::new(e) as Self::Error)));
+            }
+        }
+
+        if *is_done {
+            return Poll::Ready(None);
+        }
+
+        consumer.waker = Some(cx.waker().clone());
+        Poll::Pending
+    }
+
+    fn poll_trailers(
+        self: Pin<&mut Self>,
+        _cx: &mut Context<'_>,
+    ) -> Poll<Result<Option<http::HeaderMap>, Self::Error>> {
+        Poll::Ready(Ok(None))
+    }
+
+    fn is_end_stream(&self) -> bool {
+        let state = self.shared.lock().unwrap();
+        if !state.is_done {
+            return false;
+        }
+        let consumer = &state.consumers[self.id];
+        let total_buffered_chunks = state.offset + state.buffer.len();
+        consumer.cursor >= total_buffered_chunks
+    }
+}
+
+// so it can be used with `Body::wrap_stream`.
+impl Stream for BodyTeeStream {
+    type Item = Result<Bytes, Box<dyn std::error::Error + Send + Sync>>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        self.poll_data(cx)
+    }
+}
+
+impl Drop for BodyTeeStream {
+    fn drop(&mut self) {
+        let mut state = self.shared.lock().unwrap();
+        state.consumers[self.id].active = false;
+
+        let other_id = 1 - self.id;
+        if state.consumers[other_id].active {
+            if let Some(waker) = state.consumers[other_id].waker.take() {
+                waker.wake();
+            }
+        }
+
+        drain_buffer(&mut state);
+    }
+}
+
+/// Helper to remove chunks from the buffer that all active consumers have read.
+fn drain_buffer(state: &mut SharedState) {
+    let min_cursor = state
+        .consumers
+        .iter()
+        .filter(|c| c.active)
+        .map(|c| c.cursor)
+        .min()
+        .unwrap_or(state.offset + state.buffer.len());
+
+    let to_drain = min_cursor.saturating_sub(state.offset);
+    if to_drain > 0 {
+        state.buffer.drain(0..to_drain);
+        state.offset += to_drain;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::stream::{self, StreamExt};
+    use hyper::{body::Bytes, Body};
+    use std::convert::Infallible;
+
+    #[tokio::test]
+    async fn test_simple_duplication() {
+        let chunks = vec!["hello", " ", "world"];
+        let stream = stream::iter(chunks.clone()).map(|s| Ok::<_, Infallible>(Bytes::from(s)));
+        let body = Body::wrap_stream(stream);
+
+        let (body1, body2) = tee(body).await;
+
+        let res1_fut = body1
+            .map(|chunk_res| chunk_res.unwrap())
+            .collect::<Vec<_>>();
+        let res2_fut = body2
+            .map(|chunk_res| chunk_res.unwrap())
+            .collect::<Vec<_>>();
+
+        let (res1, res2) = futures::join!(res1_fut, res2_fut);
+
+        let res1_str: Vec<&str> = res1
+            .iter()
+            .map(|b| std::str::from_utf8(b).unwrap())
+            .collect();
+        let res2_str: Vec<&str> = res2
+            .iter()
+            .map(|b| std::str::from_utf8(b).unwrap())
+            .collect();
+
+        assert_eq!(res1_str, chunks);
+        assert_eq!(res2_str, chunks);
+    }
+
+    #[tokio::test]
+    async fn test_error_propagation() {
+        let error = std::io::Error::new(std::io::ErrorKind::Other, "test error");
+        let stream = stream::iter(vec![
+            Ok(Bytes::from("one")),
+            Err(error),
+            Ok(Bytes::from("two")),
+        ]);
+        let body = Body::wrap_stream(stream);
+
+        let (mut body1, mut body2) = tee(body).await;
+
+        assert_eq!(body1.next().await.unwrap().unwrap(), Bytes::from("one"));
+        let err1 = body1.next().await.unwrap().unwrap_err();
+        assert!(
+            err1.to_string().contains("test error"),
+            "Got error: {}",
+            err1
+        );
+        assert!(
+            body1.next().await.is_none(),
+            "Stream should end after error"
+        );
+
+        assert_eq!(body2.next().await.unwrap().unwrap(), Bytes::from("one"));
+        let err2 = body2.next().await.unwrap().unwrap_err();
+        assert!(
+            err2.to_string().contains("test error"),
+            "Got error: {}",
+            err1
+        );
+        assert!(
+            body2.next().await.is_none(),
+            "Stream should end after error"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_error_with_one_consumer_dropped() {
+        let error = std::io::Error::new(std::io::ErrorKind::ConnectionAborted, "aborted");
+        let stream = stream::iter(vec![Ok(Bytes::from("first")), Err(error)]);
+        let body = Body::wrap_stream(stream);
+
+        let (mut body1, body2) = tee(body).await;
+
+        drop(body2);
+
+        assert_eq!(body1.next().await.unwrap().unwrap(), Bytes::from("first"));
+        let err1 = body1.next().await.unwrap().unwrap_err();
+        assert!(err1.to_string().contains("aborted"));
+        assert!(
+            body1.next().await.is_none(),
+            "Stream should end after error"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_size_hint_preservation() {
+        let data = "this has a known size";
+        let body = Body::from(data);
+        let original_size_hint = HttpBody::size_hint(&body);
+
+        assert_eq!(original_size_hint.exact(), Some(data.len() as u64));
+
+        let (body1, body2) = tee(body).await;
+
+        assert_eq!(
+            HttpBody::size_hint(&body1).exact(),
+            original_size_hint.exact()
+        );
+        assert_eq!(
+            HttpBody::size_hint(&body2).exact(),
+            original_size_hint.exact()
+        );
+
+        let body1_bytes = hyper::body::to_bytes(body1).await.unwrap();
+        let body2_bytes = hyper::body::to_bytes(body2).await.unwrap();
+
+        assert_eq!(body1_bytes, data.as_bytes());
+        assert_eq!(body2_bytes, data.as_bytes());
+    }
+}

--- a/lib/src/component/http_req.rs
+++ b/lib/src/component/http_req.rs
@@ -9,6 +9,7 @@ use {
         config::{Backend, ClientCertInfo},
         error::Error,
         linking::ComponentCtx,
+        pushpin::{PushpinRedirectInfo, PushpinRedirectRequestInfo},
         secret_store::SecretLookup,
         session::{AsyncItem, AsyncItemHandle, PeekableTask, ViceroyRequestMetadata},
         upstream,
@@ -645,16 +646,29 @@ impl http_req::Host for ComponentCtx {
         Err(Error::NotAvailable("Redirect to WebSocket proxy").into())
     }
 
-    async fn redirect_to_grip_proxy(&mut self, _backend: String) -> Result<(), types::Error> {
-        Err(Error::NotAvailable("Redirect to Fanout/GRIP proxy").into())
+    async fn redirect_to_grip_proxy(&mut self, backend_name: String) -> Result<(), types::Error> {
+        let redirect_info = PushpinRedirectInfo {
+            backend_name,
+            request_info: None,
+        };
+
+        self.session.redirect_downstream_to_pushpin(redirect_info)?;
+        Ok(())
     }
 
     async fn redirect_to_grip_proxy_v2(
         &mut self,
-        _handle: http_req::RequestHandle,
-        _backend: String,
+        req_handle: http_req::RequestHandle,
+        backend_name: String,
     ) -> Result<(), types::Error> {
-        Err(Error::NotAvailable("Redirect to Fanout/GRIP proxy").into())
+        let req = self.session.request_parts(req_handle.into())?;
+        let redirect_info = PushpinRedirectInfo {
+            backend_name,
+            request_info: Some(PushpinRedirectRequestInfo::from_parts(req)),
+        };
+
+        self.session.redirect_downstream_to_pushpin(redirect_info)?;
+        Ok(())
     }
 
     async fn framing_headers_mode_set(

--- a/lib/src/downstream.rs
+++ b/lib/src/downstream.rs
@@ -3,7 +3,7 @@ use std::net::SocketAddr;
 
 use crate::body::Body;
 use crate::error::DownstreamRequestError;
-use http::{HeaderMap, Request};
+use http::{HeaderMap, Request, Response};
 use hyper::Uri;
 use tokio::sync::oneshot::Sender;
 
@@ -29,7 +29,12 @@ pub struct DownstreamMetadata {
 pub struct DownstreamRequest {
     pub req: hyper::Request<Body>,
     pub metadata: DownstreamMetadata,
-    pub sender: Sender<hyper::Response<Body>>,
+    pub sender: Sender<DownstreamResponse>,
+}
+
+#[derive(Debug)]
+pub enum DownstreamResponse {
+    Http(Response<Body>),
 }
 
 /// Canonicalize the incoming request into the form expected by host calls.

--- a/lib/src/downstream.rs
+++ b/lib/src/downstream.rs
@@ -3,6 +3,7 @@ use std::net::SocketAddr;
 
 use crate::body::Body;
 use crate::error::DownstreamRequestError;
+use crate::pushpin::PushpinRedirectInfo;
 use http::{HeaderMap, Request, Response};
 use hyper::Uri;
 use tokio::sync::oneshot::Sender;
@@ -35,6 +36,7 @@ pub struct DownstreamRequest {
 #[derive(Debug)]
 pub enum DownstreamResponse {
     Http(Response<Body>),
+    RedirectToPushpin(PushpinRedirectInfo),
 }
 
 /// Canonicalize the incoming request into the form expected by host calls.

--- a/lib/src/error.rs
+++ b/lib/src/error.rs
@@ -1,8 +1,10 @@
 //! Error types.
 
+use crate::{pushpin::PushpinRedirectInfo, wiggle_abi::types::FastlyStatus};
 use std::error::Error as StdError;
 use std::io;
-use {crate::wiggle_abi::types::FastlyStatus, url::Url, wiggle::GuestError};
+use url::Url;
+use wiggle::GuestError;
 
 #[derive(Debug, thiserror::Error)]
 #[non_exhaustive]
@@ -800,4 +802,15 @@ pub enum DownstreamRequestError {
 
     #[error("Request URL is invalid")]
     InvalidUrl,
+}
+
+/// An enum representing outcomes where the guest does not produce a standard
+/// HTTP response, but instead signals for a different action.
+#[derive(Debug, thiserror::Error)]
+pub enum NonHttpResponse {
+    #[error("graceful Pushpin redirect")]
+    PushpinRedirect(PushpinRedirectInfo),
+    // In the future, e.g.
+    // #[error("websocket upgrade requested")]
+    // WebSocketUpgrade(WebSocketUpgradeInfo),
 }

--- a/lib/src/execute.rs
+++ b/lib/src/execute.rs
@@ -5,6 +5,7 @@ use {
         acl::Acls,
         adapt,
         body::Body,
+        body_tee::tee,
         cache::Cache,
         component as compute,
         config::{
@@ -12,9 +13,10 @@ use {
             UnknownImportBehavior,
         },
         downstream::{prepare_request, DownstreamMetadata, DownstreamRequest, DownstreamResponse},
-        error::ExecutionError,
+        error::{ExecutionError, NonHttpResponse},
         linking::{create_store, link_host_functions, ComponentCtx, WasmCtx},
         object_store::ObjectStores,
+        pushpin::{proxy_through_pushpin, PushpinRedirectRequestInfo},
         secret_store::SecretStores,
         session::Session,
         shielding_site::ShieldingSites,
@@ -25,6 +27,7 @@ use {
         task::{Context, Poll},
         Future,
     },
+    http::StatusCode,
     hyper::{Request, Response},
     pin_project::pin_project,
     std::{
@@ -43,7 +46,7 @@ use {
     },
     tokio::sync::oneshot::{self, Sender},
     tokio::sync::Mutex as AsyncMutex,
-    tracing::{event, info, info_span, warn, Instrument, Level},
+    tracing::{error, event, info, info_span, warn, Instrument, Level},
     wasmtime::{
         component::{self, Component},
         Engine, GuestProfiler, InstancePre, Linker, Module, ProfilingStrategy,
@@ -137,6 +140,8 @@ pub struct ExecuteCtx {
     log_stdout: bool,
     /// Whether to treat stderr as a logging endpoint
     log_stderr: bool,
+    /// The local Pushpin proxy port
+    local_pushpin_proxy_port: Option<u16>,
     /// The ID to assign the next incoming request
     next_req_id: Arc<AtomicU64>,
     /// The ObjectStore associated with this instance of Viceroy
@@ -276,6 +281,7 @@ impl ExecuteCtx {
             capture_logs: Arc::new(Mutex::new(std::io::stdout())),
             log_stdout: false,
             log_stderr: false,
+            local_pushpin_proxy_port: None,
             next_req_id: Arc::new(AtomicU64::new(0)),
             object_store: ObjectStores::new(),
             secret_stores: SecretStores::new(),
@@ -366,6 +372,10 @@ impl ExecuteCtx {
         if let Ok(resp) = receiver.await {
             return match resp {
                 DownstreamResponse::Http(resp) => Some((resp, None)),
+                DownstreamResponse::RedirectToPushpin(info) => Some((
+                    Response::new(Body::empty()),
+                    Some(NonHttpResponse::PushpinRedirect(info).into()),
+                )),
             };
         }
         None
@@ -400,12 +410,20 @@ impl ExecuteCtx {
     /// ```
     pub async fn handle_request(
         self: Arc<Self>,
-        incoming_req: Request<hyper::Body>,
+        mut incoming_req: Request<hyper::Body>,
         local: SocketAddr,
         remote: SocketAddr,
     ) -> Result<(Response<Body>, Option<anyhow::Error>), Error> {
-        let original_headers = incoming_req.headers().clone();
-        let req = prepare_request(incoming_req)?;
+        let orig_req_on_upgrade = hyper::upgrade::on(&mut incoming_req);
+        let (incoming_req_parts, incoming_req_body) = incoming_req.into_parts();
+        let local_pushpin_proxy_port = self.local_pushpin_proxy_port.clone();
+
+        let (body_for_wasm, orig_body_tee) = tee(incoming_req_body).await;
+        let orig_request_info_for_pushpin =
+            PushpinRedirectRequestInfo::from_parts(&incoming_req_parts);
+
+        let original_headers = incoming_req_parts.headers.clone();
+        let req = prepare_request(Request::from_parts(incoming_req_parts, body_for_wasm))?;
 
         let req_id = self
             .next_req_id
@@ -419,14 +437,54 @@ impl ExecuteCtx {
             original_headers,
         };
 
-        let res = self.reuse_or_spawn_guest(req, metadata).await;
+        let (resp, mut err) = self.reuse_or_spawn_guest(req, metadata).await;
 
         let span = info_span!("request", id = req_id);
         let _span = span.enter();
 
-        info!("response status: {:?}", res.0.status());
+        info!("response status: {:?}", resp.status());
 
-        Ok(res)
+        if let Some(e) = err {
+            match e.downcast::<NonHttpResponse>() {
+                Ok(NonHttpResponse::PushpinRedirect(redirect_info)) => {
+                    let backend_name = redirect_info.backend_name;
+                    let redirect_request_info = redirect_info.request_info;
+                    info!("Pushpin redirect signaled to backend '{}'", backend_name);
+
+                    let local_pushpin_proxy_port = match local_pushpin_proxy_port {
+                        None => {
+                            error!("Pushpin redirect signaled, but Pushpin mode not enabled.");
+                            let err = anyhow::anyhow!(
+                                "Pushpin redirect signaled, but Pushpin mode not enabled."
+                            );
+                            let resp = Response::builder()
+                                .status(StatusCode::INTERNAL_SERVER_ERROR)
+                                .body(Body::from(hyper::Body::from(err.to_string())))?;
+                            return Ok((resp, Some(err)));
+                        }
+                        Some(port) => port,
+                    };
+
+                    let proxy_resp = proxy_through_pushpin(
+                        SocketAddr::new(Ipv4Addr::LOCALHOST.into(), local_pushpin_proxy_port),
+                        backend_name,
+                        redirect_request_info,
+                        orig_request_info_for_pushpin,
+                        orig_body_tee,
+                        orig_req_on_upgrade,
+                    )
+                    .await;
+
+                    let (p, hyper_body) = proxy_resp.into_parts();
+                    return Ok((Response::from_parts(p, Body::from(hyper_body)), None));
+                }
+                Err(e) => {
+                    err = Some(e);
+                }
+            }
+        }
+
+        Ok((resp, err))
     }
 
     /// Spawn a new guest to process a request whose processing was never attempted by
@@ -873,6 +931,12 @@ impl ExecuteCtxBuilder {
     /// Set the stderr logging policy for this execution context.
     pub fn with_log_stderr(mut self, log_stderr: bool) -> Self {
         self.inner.log_stderr = log_stderr;
+        self
+    }
+
+    /// Set the local Pushpin proxy port
+    pub fn with_local_pushpin_proxy_port(mut self, local_pushpin_proxy_port: Option<u16>) -> Self {
+        self.inner.local_pushpin_proxy_port = local_pushpin_proxy_port;
         self
     }
 }

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -23,6 +23,7 @@ pub mod session;
 
 mod acl;
 mod async_io;
+mod body_tee;
 mod collecting_body;
 pub mod component;
 mod downstream;

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -31,6 +31,7 @@ mod execute;
 mod headers;
 mod linking;
 mod object_store;
+mod pushpin;
 mod secret_store;
 mod service;
 mod shielding_site;

--- a/lib/src/pushpin.rs
+++ b/lib/src/pushpin.rs
@@ -1,0 +1,250 @@
+// Pushpin GRIP proxy
+
+use tracing::debug;
+use {
+    http::{
+        request::{Parts, Request},
+        HeaderMap, Response, StatusCode,
+    },
+    hyper::{client::conn::Parts as ConnParts, upgrade::OnUpgrade, Body},
+    std::net::SocketAddr,
+    tokio::{io::copy_bidirectional, net::TcpStream, task::JoinHandle},
+    tracing::{error, info, warn},
+};
+
+/// A signal to redirect the request to Pushpin
+#[derive(Debug)]
+pub struct PushpinRedirectInfo {
+    pub backend_name: String,
+    pub request_info: Option<PushpinRedirectRequestInfo>,
+}
+
+/// Information about the Pushpin request being redirected
+#[derive(Debug)]
+pub struct PushpinRedirectRequestInfo {
+    pub method: String,
+    pub scheme: Option<String>,
+    pub authority: Option<String>,
+    pub path_and_query: Option<String>,
+    pub headers: HeaderMap,
+}
+
+impl PushpinRedirectRequestInfo {
+    pub fn from_parts(parts: &Parts) -> Self {
+        PushpinRedirectRequestInfo {
+            method: parts.method.to_string(),
+            scheme: parts.uri.scheme().map(|x| x.to_string()),
+            authority: parts.uri.authority().map(|x| x.to_string()),
+            path_and_query: parts.uri.path_and_query().map(|p| p.to_string()),
+            headers: parts.headers.clone(),
+        }
+    }
+}
+/// The list of request header names that cannot be modified by backends in proxy_through_pushpin.
+const PROTECTED_REQ_HEADERS: &[&str] = &[
+    // WebSocket control
+    "host",
+    "connection",
+    "sec-websocket-version",
+    "sec-websocket-key",
+    "upgrade",
+    // Internal Fastly
+    "pushpin-route",
+    // VCL
+    "content-length",
+    "content-range",
+    "expect",
+    "fastly-ff",
+    "proxy-authenticate",
+    "proxy-authorization",
+    "te",
+    "trailer",
+    "transfer-encoding",
+    // Other
+    "cdn-loop",
+];
+
+/// Perform a proxy request to Pushpin using the provided request information and request body.
+/// If Pushpin responds with `101 Switching Protocols`, then use the provided `OnUpgrade` future
+/// to take over the incoming request connection and wire it up with the Pushpin connection.
+///
+/// To distinguish backends, `"/"` + `backend_name` is prepended to the request path.
+/// Pushpin routes should be configured with `path_beg=` and `path_rem=`.
+pub async fn proxy_through_pushpin(
+    pushpin_addr: SocketAddr,
+    backend_name: String,
+    redirect_request_info: Option<PushpinRedirectRequestInfo>,
+    original_request_info: PushpinRedirectRequestInfo,
+    original_request_body: Body,
+    original_request_on_upgrade: OnUpgrade,
+) -> Response<Body> {
+    debug!("Proxying through Pushpin backend '{}'.", backend_name);
+
+    let pushpin_stream = match TcpStream::connect(pushpin_addr).await {
+        Ok(str) => str,
+        Err(e) => {
+            error!("Could not connect to Pushpin: {e}.");
+            return build_error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Could not connect to Pushpin",
+            );
+        }
+    };
+
+    let (path_and_query, method) = if let Some(ref info) = redirect_request_info {
+        (
+            info.path_and_query.as_deref().unwrap_or(""),
+            info.method.as_str(),
+        )
+    } else {
+        (
+            original_request_info
+                .path_and_query
+                .as_deref()
+                .unwrap_or(""),
+            original_request_info.method.as_str(),
+        )
+    };
+    let mut req = Request::builder()
+        .method(method)
+        .uri(&format!("/{backend_name}{path_and_query}"))
+        .header("Host", pushpin_addr.to_string());
+
+    if let Some(redirect_request_info) = redirect_request_info {
+        // move the original headers defined in `PROTECTED_REQ_HEADERS` to the top of the req.headers
+        for (name, value) in &original_request_info.headers {
+            if PROTECTED_REQ_HEADERS
+                .iter()
+                .any(|h| h.eq_ignore_ascii_case(name.as_str()))
+            {
+                req = req.header(name, value);
+            }
+        }
+        // add the req headers received via pushpin_redirect, except for the ones in `PROTECTED_REQ_HEADERS`
+        for (name, value) in &redirect_request_info.headers {
+            if !PROTECTED_REQ_HEADERS
+                .iter()
+                .any(|h| h.eq_ignore_ascii_case(name.as_str()))
+            {
+                req = req.header(name, value);
+            }
+        }
+    } else {
+        for (name, value) in &original_request_info.headers {
+            req = req.header(name, value);
+        }
+    }
+
+    let req = match req.body(original_request_body) {
+        Ok(req) => req,
+        Err(e) => {
+            error!("Failed to build Pushpin proxy request: {}", e);
+            return build_error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Could not build proxy request",
+            );
+        }
+    };
+
+    let (mut sender, conn) = match hyper::client::conn::Builder::new()
+        .handshake(pushpin_stream)
+        .await
+    {
+        Ok(res) => res,
+        Err(e) => {
+            error!("Pushpin handshake failed: {}", e);
+            return build_error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("Could not connect to upstream service: {e}"),
+            );
+        }
+    };
+
+    // Spawn the connection driver and keep a handle to it.
+    // We need this future to complete so we can get the raw IO stream back after the HTTP response is parsed.
+    // `without_shutdown` prevents hyper from trying to gracefully close the connection,
+    // which is what we want when taking it over for a WebSocket.
+    let conn_fut = tokio::spawn(conn.without_shutdown());
+
+    let upstream_resp = match sender.send_request(req).await {
+        Ok(proxy_resp) => {
+            info!(
+                "Received response from Pushpin backend '{}'. Proxying response.",
+                backend_name
+            );
+            proxy_resp
+        }
+        Err(e) => {
+            error!("Pushpin proxy request failed: {}", e);
+            return build_error_response(
+                StatusCode::BAD_GATEWAY,
+                format!("Pushpin request failed: {e}"),
+            );
+        }
+    };
+
+    // If Pushpin responds with `101 Switching Protocols`, then we spawn an async task
+    // to attempt an upgrade
+    if upstream_resp.status() == StatusCode::SWITCHING_PROTOCOLS {
+        debug!("Pushpin responded with `101 Switching Protocols`, attempting upgrade...");
+        tokio::spawn(proxy_upgraded_connection(
+            original_request_on_upgrade,
+            conn_fut,
+        ));
+    }
+
+    upstream_resp
+}
+
+/// A background task to proxy an upgraded (e.g., WebSocket) connection
+async fn proxy_upgraded_connection(
+    downstream_req_on_upgrade: OnUpgrade,
+    upstream_conn_fut: JoinHandle<Result<ConnParts<TcpStream>, hyper::Error>>,
+) {
+    // Await the client-side upgrade. This future will not resolve until
+    // the `101` response is sent to the client by the main service.
+    let mut downstream_upgraded = match downstream_req_on_upgrade.await {
+        Ok(upgraded) => upgraded,
+        Err(e) => {
+            error!("Downstream client upgrade failed: {}", e);
+            return;
+        }
+    };
+
+    debug!("Downstream client connection upgraded.");
+
+    // Await the server-side connection driver to get the raw IO back.
+    let mut upstream_parts = match upstream_conn_fut.await {
+        Ok(Ok(parts)) => parts,
+        Ok(Err(e)) => {
+            error!("Upstream connection error: {}", e);
+            return;
+        }
+        Err(e) => {
+            warn!("Upstream connection task failed: {}", e);
+            return;
+        }
+    };
+
+    debug!("Upstream connection IO stream obtained.");
+
+    match copy_bidirectional(&mut downstream_upgraded, &mut upstream_parts.io).await {
+        Ok((from_client, from_server)) => {
+            info!(
+                "Upgraded proxy connection finished gracefully. Bytes transferred: client->server: {}, server->client: {}",
+                from_client, from_server
+            );
+        }
+        Err(e) => {
+            error!("Upgraded proxy I/O error: {e}");
+        }
+    }
+}
+
+/// A helper function to build a simple error response.
+fn build_error_response(status: StatusCode, message: impl ToString) -> Response<Body> {
+    Response::builder()
+        .status(status)
+        .body(Body::from(format!("Error: {}", message.to_string())))
+        .expect("Could not build error response")
+}

--- a/lib/src/pushpin.rs
+++ b/lib/src/pushpin.rs
@@ -105,10 +105,7 @@ pub async fn proxy_through_pushpin(
             original_request_info.method.as_str(),
         )
     };
-    let mut req = Request::builder()
-        .method(method)
-        .uri(&format!("/{backend_name}{path_and_query}"))
-        .header("Host", pushpin_addr.to_string());
+    let mut req = Request::builder().method(method).uri(path_and_query);
 
     if let Some(redirect_request_info) = redirect_request_info {
         // move the original headers defined in `PROTECTED_REQ_HEADERS` to the top of the req.headers
@@ -134,6 +131,8 @@ pub async fn proxy_through_pushpin(
             req = req.header(name, value);
         }
     }
+    req = req.header("host", pushpin_addr.to_string());
+    req = req.header("pushpin-route", backend_name.to_string());
 
     let req = match req.body(original_request_body) {
         Ok(req) => req,

--- a/lib/src/session.rs
+++ b/lib/src/session.rs
@@ -22,7 +22,7 @@ use crate::object_store::KvStoreError;
 use crate::wiggle_abi::types::{CacheBusyHandle, CacheHandle};
 
 use {
-    self::downstream::DownstreamResponse,
+    self::downstream::DownstreamResponseState,
     crate::{
         acl::Acl,
         body::Body,
@@ -73,7 +73,7 @@ pub struct Session {
     /// A channel for sending a [`Response`][resp] downstream to the client.
     ///
     /// [resp]: https://docs.rs/http/latest/http/response/struct.Response.html
-    downstream_resp: DownstreamResponse,
+    downstream_resp: DownstreamResponseState,
     /// Handle for receiving a new downstream request.
     downstream_pending_handle: Option<AsyncItemHandle>,
     /// A handle map for items that provide blocking operations. These items are grouped together
@@ -151,7 +151,7 @@ impl Session {
             async_items,
             req_parts,
             resp_parts: PrimaryMap::new(),
-            downstream_resp: DownstreamResponse::new(downstream.sender),
+            downstream_resp: DownstreamResponseState::new(downstream.sender),
             capture_logs: ctx.capture_logs(),
             log_endpoints: PrimaryMap::new(),
             log_endpoints_by_name: HashMap::new(),
@@ -1280,7 +1280,7 @@ impl Session {
             metadata: Some(downstream.metadata),
         });
 
-        self.downstream_resp = DownstreamResponse::new(downstream.sender);
+        self.downstream_resp = DownstreamResponseState::new(downstream.sender);
         self.downstream_req_handle = req_handle;
         self.downstream_req_body_handle = body_handle.into();
 

--- a/lib/src/session.rs
+++ b/lib/src/session.rs
@@ -246,16 +246,8 @@ impl Session {
     ///
     /// # Panics
     ///
-    /// This method must only be called once, *after* a channel has been opened with
-    /// [`Session::set_downstream_response_sender`][set], and *before* the associated
-    /// [oneshot::Receiver][receiver] has been dropped.
-    ///
-    /// This method will panic if:
-    ///   * the downstream response channel was never opened
-    ///   * the associated receiver was dropped prematurely
-    ///
-    /// [set]: struct.Session.html#method.set_downstream_response_sender
-    /// [receiver]: https://docs.rs/tokio/latest/tokio/sync/oneshot/struct.Receiver.html
+    /// This method must only be called once per downstream request, after which attempting
+    /// to send another response will trigger a panic.
     pub fn send_downstream_response(&mut self, resp: Response<Body>) -> Result<(), Error> {
         self.downstream_resp.send(resp)
     }
@@ -266,16 +258,8 @@ impl Session {
     ///
     /// # Panics
     ///
-    /// This method must only be called once, *after* a channel has been opened with
-    /// [`Session::set_downstream_response_sender`][set], and *before* the associated
-    /// [oneshot::Receiver][receiver] has been dropped.
-    ///
-    /// This method will panic if:
-    ///   * the downstream response channel was never opened
-    ///   * the associated receiver was dropped prematurely
-    ///
-    /// [set]: struct.Session.html#method.set_downstream_response_sender
-    /// [receiver]: https://docs.rs/tokio/latest/tokio/sync/oneshot/struct.Receiver.html
+    /// This method must only be called once per downstream request, after which attempting
+    /// to send another response will trigger a panic.
     pub fn redirect_downstream_to_pushpin(
         &mut self,
         redirect_info: PushpinRedirectInfo,

--- a/lib/src/session/downstream.rs
+++ b/lib/src/session/downstream.rs
@@ -14,7 +14,7 @@ use {
 ///
 /// [send]: struct.Session.html#method.send_downstream_response
 /// [set]: struct.Session.html#method.set_downstream_response_sender
-pub(super) enum DownstreamResponse {
+pub enum DownstreamResponseState {
     /// No channel to send the response has been opened yet.
     Closed,
     /// A channel has been opened, but no response has been sent yet.
@@ -23,13 +23,13 @@ pub(super) enum DownstreamResponse {
     Sent,
 }
 
-impl DownstreamResponse {
+impl DownstreamResponseState {
     /// Open a channel to send a [`Response`][resp] downstream, given a [`oneshot::Sender`][sender].
     ///
     /// [resp]: https://docs.rs/http/latest/http/response/struct.Response.html
     /// [sender]: https://docs.rs/tokio/latest/tokio/sync/oneshot/struct.Sender.html
     pub fn new(sender: Sender<Response<Body>>) -> Self {
-        DownstreamResponse::Pending(sender)
+        DownstreamResponseState::Pending(sender)
     }
 
     pub fn is_unsent(&self) -> bool {
@@ -46,7 +46,7 @@ impl DownstreamResponse {
     ///
     /// [resp]: https://docs.rs/http/latest/http/response/struct.Response.html
     pub fn send(&mut self, mut response: Response<Body>) -> Result<(), Error> {
-        use DownstreamResponse::{Closed, Pending, Sent};
+        use DownstreamResponseState::{Closed, Pending, Sent};
 
         filter_outgoing_headers(response.headers_mut());
 
@@ -65,6 +65,6 @@ impl DownstreamResponse {
 
     /// Close the `DownstreamResponse`, potentially without sending any response.
     pub fn close(&mut self) {
-        *self = DownstreamResponse::Closed;
+        *self = DownstreamResponseState::Closed;
     }
 }


### PR DESCRIPTION
This PR adds Viceroy code and hostcall implementations to support the hostcalls `fastly_http_req#redirect_to_grip_proxy` and `fastly_http_req#redirect_to_grip_proxy_v2`.

It adds a new runtime command-line flag, `--local-pushpin-port=<port>` that enables this feature.

## What does this PR do?

This pull request introduces the foundational support within Viceroy for proxying requests to a local Pushpin instance. This enables developers to locally test Fastly Compute services that use real-time features like HTTP streaming or WebSockets-over-HTTP, which are powered by Fanout/Pushpin.

Specifically, this change implements the host-side logic for the following ABI functions: `fastly_http_req#redirect_to_grip_proxy` and `fastly_http_req#redirect_to_grip_proxy_v2`

When a guest module calls one of these functions, Viceroy will now intercept the request and proxy it to a configured Pushpin server instead of handling it directly.

The configuration of Pushpin is performed by a corresponding update to the Fastly CLI, which will set up the appropriate routes and start Pushpin during the `fastly compute serve` command.

## Why is this change important?

Currently, there is no way to locally test Compute features that rely on Fanout. This is a significant gap in the local development workflow, forcing developers to deploy their services to test real-time functionality. By adding this proxying capability to Viceroy, we bridge that gap and create a much more complete and efficient local development experience.

## How is this implemented?

A new `pushpin.rs` Module: A new module is introduced to encapsulate all the proxying logic.

If the guest code calls `redirect_to_grip_proxy` (or `_v2`), the request is replayed to the Pushpin instance, using the name of the backend as the route ID (sets the `Pushpin-route` header value to the backend name). For example, a request to `/api/user` to a backend named `origin` will be sent to Pushpin as `/api/user` with the header `Pushpin-route: origin`. Fastly CLI configures Pushpin with the `accept_pushpin_route=true` setting.

During this forwarding, the original body of the request must be replayed from the beginning. To enable this, I've added a new `body_tee.rs` module, designed to allow forking a stream.

For WebSocket upgrades, the underlying connection is then handed off to a `copy_bidirectional` task to stream data between the client and Pushpin. In order to allow upgrading the original request, code has been added at the beginning of `handle_request` to save an `on_upgrade` future.

## Details

* A new "error" enumeration, `NonHttpResponse`, has been added, which enables the receiver to signal to `handle_request` that the guest wants to return a non-http response, allowing the handler to perform handling specific to the non-http response type.
* A new enumeration `DownstreamResponse` has been added that represents the response itself, which may be an `Http(Response<Body>)` or a `RedirectToPushpin(PushpinRedirectInfo)`. The hostcall for `redirect_to_grip_proxy` (and `_v2`) sends this `RedirectToPushpin` response type, allowing the receiver to signal `NonHttpResponse` to the handler.
    * The existing `DownstreamResponse` enumeration has been renamed to `DownstreamResponseState` to better reflect its name and to mirror other uses within Fastly.
* `handle_request` adds code to handle `NonHttpResponse` response types. If the wrapped response is `RedirectToPushpin`, then if this feature is enabled, `proxy_through_pushpin` is invoked, proxying the request to Pushpin and streaming the result, and upgrading to WebSocket if the response is `101 Switching Protocols`.
* If a backend definition has a path segment, then it is respected by the Pushpin `replace_beg` configuration, but that setup is performed in the CLI, not in Viceroy.
* This has a [companion PR in the Fastly CLI](https://github.com/fastly/cli/pull/1509) which will invoke Pushpin with the appropriate routes before starting Viceroy.