### PR TITLE
Update to the latest version of the witx files.

### DIFF
--- a/lib/compute-at-edge-abi/compute-at-edge.witx
+++ b/lib/compute-at-edge-abi/compute-at-edge.witx
@@ -872,9 +872,8 @@
 
     ;;; Hostcall for getting the destination IP used for this request.
     ;;;
-    ;;; The buffer for the IP address must be 16 bytes. This will return
-    ;;; the number of bytes written to the buffer: 4 for IPv4 addresses,
-    ;;; and 16 for IPv6.
+    ;;; The buffer for the IP address must be 16 bytes. `addr_octets_out`
+    ;;; will be set to 4 for IPv4 addresses, and 16 for IPv6.
     (@interface func (export "get_addr_dest_ip")
         (param $h $response_handle)
         ;; must be a 16-byte array
@@ -997,12 +996,12 @@
     (@interface func (export "lookup_async")
         (param $store $object_store_handle)
         (param $key string)
-        (param $pending_body_handle_out (@witx pointer $pending_kv_lookup_handle))
+        (param $pending_handle_out (@witx pointer $pending_kv_lookup_handle))
         (result $err (expected (error $fastly_status)))
     )
 
     (@interface func (export "pending_lookup_wait")
-        (param $pending_body_handle $pending_kv_lookup_handle)
+        (param $pending_objstr_handle $pending_kv_lookup_handle)
         (param $body_handle_out (@witx pointer $body_handle))
         (result $err (expected (error $fastly_status)))
     )
@@ -1035,8 +1034,22 @@
     )
 
     (@interface func (export "pending_delete_wait")
-        (param $pending_handle $pending_kv_delete_handle)
+        (param $pending_objstr_handle $pending_kv_delete_handle)
         (result $err (expected (error $fastly_status)))
+    )
+)
+
+(module $fastly_image_optimizer
+    (@interface func (export "transform_image_optimizer_request")
+        (param $origin_image_request $request_handle)
+        (param $origin_image_request_body $body_handle)
+        (param $origin_image_request_backend string)
+        (param $io_transform_config_mask $image_optimizer_transform_config_options)
+        (param $io_transform_configuration (@witx pointer $image_optimizer_transform_config))
+        (param $io_error_detail (@witx pointer $image_optimizer_error_detail))
+        (result $err (expected
+                (tuple $response_handle $body_handle)
+                (error $fastly_status)))
     )
 )
 
@@ -1346,19 +1359,5 @@
         (param $body_handle_out (@witx pointer $body_handle))
         (param $acl_error_out (@witx pointer $acl_error))
         (result $err (expected (error $fastly_status)))
-    )
-)
-
-(module $fastly_image_optimizer
-    (@interface func (export "transform_image_optimizer_request")
-        (param $origin_image_request $request_handle)
-        (param $origin_image_request_body $body_handle)
-        (param $origin_image_request_backend string)
-        (param $io_transform_config_mask $image_optimizer_transform_config_options)
-        (param $io_transform_configuration (@witx pointer $image_optimizer_transform_config))
-        (param $io_error_detail (@witx pointer $image_optimizer_error_detail))
-        (result $err (expected
-                (tuple $response_handle $body_handle)
-                (error $fastly_status)))
     )
 )

--- a/lib/compute-at-edge-abi/http-cache.witx
+++ b/lib/compute-at-edge-abi/http-cache.witx
@@ -30,10 +30,12 @@
 ;;; `prepare_response_for_storage`.
 (typename $http_storage_action
     (enum (@witx tag u32)
-        ;; Insert the response into cache (`transaction_insert*`).
+        ;; Insert the response into cache (for `transaction-insert` and
+        ;; `transaction-insert-and-stream-back`).
         $insert
 
-        ;; Update the stale response in cache (`transaction_update*`).
+        ;; Update the stale response in cache (for `transaction-update` and
+        ;; `transaction-update-and-return-fresh`).
         $update
 
         ;; Do not store this response.
@@ -55,6 +57,9 @@
         ;; properties.
         (field $override_key_ptr (@witx pointer (@witx char8)))
         (field $override_key_len (@witx usize))
+        ;; Name of the backend the request will eventually be sent to.
+        (field $backend_name_ptr (@witx pointer (@witx char8)))
+        (field $backend_name_len (@witx usize))
     )
 )
 
@@ -63,6 +68,7 @@
     (flags (@witx repr u32)
         $reserved
         $override_key
+        $backend_name
     )
 )
 
@@ -161,10 +167,7 @@
         (result $err (expected (error $fastly_status)))
     )
 
-    ;;; Perform a cache lookup based on the given request without participating in request
-    ;;; collapsing.
-    ;;;
-    ;;; The request is not consumed.
+    ;;; DEPRECATED: use transaction_lookup
     (@interface func (export "lookup")
         (param $req_handle $request_handle)
         (param $options_mask $http_cache_lookup_options_mask)
@@ -343,8 +346,8 @@
         (result $err (expected (tuple $http_storage_action $response_handle) (error $fastly_status)))
     )
 
-    ;;; Retrieve a stored response from the cache, returning the `$none` error if there was no found
-    ;;; response.
+    ;;; Retrieve a stored response from the cache, returning the `$none` error if there was no
+    ;;; response found.
     ;;;
     ;;; If `transform_for_client` is set, the response will be adjusted according to the looked-up
     ;;; request. For example, a response retrieved for a range request may be transformed into a
@@ -364,36 +367,36 @@
         (result $err (expected $cache_lookup_state (error $fastly_status)))
     )
 
-    ;;; Get the length of the found response, returning the `$none` error if there was no found
-    ;;; response or no length was provided.
+    ;;; Get the length of the found response, returning the `$none` error if there was no response
+    ;;; found or no length was provided.
     (@interface func (export "get_length")
         (param $handle $http_cache_handle)
         (result $err (expected $cache_object_length (error $fastly_status)))
     )
 
     ;;; Get the configured max age of the found response in nanoseconds, returning the `$none` error
-    ;;; if there was no found response.
+    ;;; if there was no response found.
     (@interface func (export "get_max_age_ns")
         (param $handle $http_cache_handle)
         (result $err (expected $cache_duration_ns (error $fastly_status)))
     )
 
     ;;; Get the configured stale-while-revalidate period of the found response in nanoseconds,
-    ;;; returning the `$none` error if there was no found response.
+    ;;; returning the `$none` error if there was no response found.
     (@interface func (export "get_stale_while_revalidate_ns")
         (param $handle $http_cache_handle)
         (result $err (expected $cache_duration_ns (error $fastly_status)))
     )
 
     ;;; Get the age of the found response in nanoseconds, returning the `$none` error if there was
-    ;;; no found response.
+    ;;; no response found.
     (@interface func (export "get_age_ns")
         (param $handle $http_cache_handle)
         (result $err (expected $cache_duration_ns (error $fastly_status)))
     )
 
     ;;; Get the number of cache hits for the found response, returning the `$none` error if there
-    ;;; was no found response.
+    ;;; was no response found.
     ;;;
     ;;; Note that this figure only reflects hits for a stored response in a particular cache server
     ;;; or cluster, not the entire Fastly network.
@@ -403,7 +406,7 @@
     )
 
     ;;; Get whether a found response is marked as containing sensitive data, returning the `$none`
-    ;;; error if there was no found response.
+    ;;; error if there was no response found.
     (@interface func (export "get_sensitive_data")
         (param $handle $http_cache_handle)
         (result $err (expected $is_sensitive (error $fastly_status)))
@@ -425,8 +428,8 @@
         (result $err (expected (error $fastly_status)))
     )
 
-    ;;; Get the vary rule of the found response, returning the `$none` error if there was no found
-    ;;; response.
+    ;;; Get the vary rule of the found response, returning the `$none` error if there was no
+    ;;; response found.
     ;;;
     ;;; The output is a list of header names separated by spaces.
     ;;;

--- a/lib/compute-at-edge-abi/typenames.witx
+++ b/lib/compute-at-edge-abi/typenames.witx
@@ -93,11 +93,11 @@
 (typename $dictionary_handle (handle))
 ;;; (DEPRECATED) A handle to an Object Store.
 (typename $object_store_handle (handle))
-;;; (DEPRECATED) A handle to a pending KV lookup request.
+;;; (DEPRECATED) A handle to a pending KV lookup.
 (typename $pending_kv_lookup_handle (handle))
-;;; (DEPRECATED) A handle to a pending KV insert request.
+;;; (DEPRECATED) A handle to a pending KV insert.
 (typename $pending_kv_insert_handle (handle))
-;;; (DEPRECATED) A handle to a pending KV delete request.
+;;; (DEPRECATED) A handle to a pending KV delete.
 (typename $pending_kv_delete_handle (handle))
 ;;; (DEPRECATED) A handle to a pending KV list.
 (typename $pending_kv_list_handle (handle))
@@ -120,9 +120,9 @@
 ;;; A handle to a request promise.
 (typename $request_promise_handle (handle))
 ;;; A handle to an object supporting generic async operations.
-;;; Can be a `body_handle`, a `pending_request_handle`,
+;;; Can be a `body_handle`, `pending_request_handle`,
 ;;; `cache_handle`, `cache_busy_handle`, `cache_replace_handle` (see cache.witx),
-;;; a `request_promise_handle`, or other handles.
+;;; `request_promise_handle`, or other handles.
 ;;;
 ;;; Each async item has an associated I/O action:
 ;;;
@@ -193,6 +193,103 @@
        $tls_1_1
        $tls_1_2
        $tls_1_3))
+
+(typename $kv_lookup_config_options
+    (flags (@witx repr u32)
+       $reserved
+       ))
+
+(typename $kv_lookup_config
+  (record
+    (field $reserved u32)
+    ))
+
+(typename $kv_delete_config_options
+    (flags (@witx repr u32)
+       $reserved
+       ))
+
+(typename $kv_delete_config
+  (record
+    (field $reserved u32)
+    ))
+
+(typename $kv_insert_config_options
+    (flags (@witx repr u32)
+       $reserved
+       $background_fetch
+       ;; reserved_2 was previously if_generation_match (u32)
+       $reserved_2
+       $metadata
+       $time_to_live_sec
+       $if_generation_match
+       ))
+
+(typename $kv_insert_mode
+    (enum (@witx tag u32)
+       $overwrite
+       $add
+       $append
+       $prepend))
+
+(typename $kv_insert_config
+  (record
+    (field $mode $kv_insert_mode)
+    (field $unused u32)
+    (field $metadata (@witx pointer (@witx char8)))
+    (field $metadata_len u32)
+    (field $time_to_live_sec u32)
+    (field $if_generation_match u64)
+    ))
+
+(typename $kv_list_config_options
+    (flags (@witx repr u32)
+       $reserved
+       $cursor
+       $limit
+       $prefix
+       ))
+
+(typename $kv_list_mode
+    (enum (@witx tag u32)
+       $strong
+       $eventual))
+
+(typename $kv_list_config
+  (record
+    (field $mode $kv_list_mode)
+    (field $cursor (@witx pointer (@witx char8)))
+    (field $cursor_len u32)
+    (field $limit u32)
+    (field $prefix (@witx pointer (@witx char8)))
+    (field $prefix_len u32)
+    ))
+
+(typename $kv_error
+    (enum (@witx tag u32)
+        ;;; The $kv_error has not been set.
+        $uninitialized
+        ;;; There was no error.
+        $ok
+        ;;; KV store cannot or will not process the request due to something that is perceived to be a client error
+        ;;; This will map to the api's 400 codes
+        $bad_request
+        ;;; KV store cannot find the requested resource
+        ;;; This will map to the api's 404 codes
+        $not_found
+        ;;; KV store cannot fulfill the request, as defined by the client's prerequisites (ie. if-generation-match)
+        ;;; This will map to the api's 412 codes
+        $precondition_failed
+        ;;; The size limit for a KV store key was exceeded.
+        ;;; This will map to the api's 413 codes
+        $payload_too_large
+        ;;; The system encountered an unexpected internal error.
+        ;;; This will map to all remaining http error codes
+        $internal_error
+        ;;; Too many requests have been made to the KV store.
+        ;;; This will map to the api's 429 codes
+        $too_many_requests
+        ))
 
 (typename $backend_config_options
     (flags (@witx repr u32)
@@ -406,103 +503,6 @@
         (field $workspace_len u32)
     )
 )
-
-(typename $kv_lookup_config_options
-    (flags (@witx repr u32)
-       $reserved
-       ))
-
-(typename $kv_lookup_config
-  (record
-    (field $reserved u32)
-    ))
-
-(typename $kv_delete_config_options
-    (flags (@witx repr u32)
-       $reserved
-       ))
-
-(typename $kv_delete_config
-  (record
-    (field $reserved u32)
-    ))
-
-(typename $kv_insert_config_options
-    (flags (@witx repr u32)
-       $reserved
-       $background_fetch
-       ;; reserved_2 was previously if_generation_match (u32)
-       $reserved_2
-       $metadata
-       $time_to_live_sec
-       $if_generation_match
-       ))
-
-(typename $kv_insert_mode
-    (enum (@witx tag u32)
-       $overwrite
-       $add
-       $append
-       $prepend))
-
-(typename $kv_insert_config
-  (record
-    (field $mode $kv_insert_mode)
-    (field $unused u32)
-    (field $metadata (@witx pointer (@witx char8)))
-    (field $metadata_len u32)
-    (field $time_to_live_sec u32)
-    (field $if_generation_match u64)
-    ))
-
-(typename $kv_list_config_options
-    (flags (@witx repr u32)
-       $reserved
-       $cursor
-       $limit
-       $prefix
-       ))
-
-(typename $kv_list_mode
-    (enum (@witx tag u32)
-       $strong
-       $eventual))
-
-(typename $kv_list_config
-  (record
-    (field $mode $kv_list_mode)
-    (field $cursor (@witx pointer (@witx char8)))
-    (field $cursor_len u32)
-    (field $limit u32)
-    (field $prefix (@witx pointer (@witx char8)))
-    (field $prefix_len u32)
-    ))
-
-(typename $kv_error
-    (enum (@witx tag u32)
-        ;;; The $kv_error has not been set.
-        $uninitialized
-        ;;; There was no error.
-        $ok
-        ;;; KV store cannot or will not process the request due to something that is perceived to be a client error
-        ;;; This will map to the api's 400 codes
-        $bad_request
-        ;;; KV store cannot find the requested resource
-        ;;; This will map to the api's 404 codes
-        $not_found
-        ;;; KV store cannot fulfill the request, as definied by the client's prerequisites (ie. if-generation-match)
-        ;;; This will map to the api's 412 codes
-        $precondition_failed
-        ;;; The size limit for a KV store key was exceeded.
-        ;;; This will map to the api's 413 codes
-        $payload_too_large
-        ;;; The system encountered an unexpected internal error.
-        ;;; This will map to all remaining http error codes
-        $internal_error
-        ;;; Too many requests have been made to the KV store.
-        ;;; This will map to the api's 429 codes
-        $too_many_requests
-        ))
 
 (typename $acl_error
     (enum (@witx tag u32)


### PR DESCRIPTION
To prepare for more regularly keeping Viceroy's interfaces up to date, this updates to the latest version of the witx interfaces.

Other than the addition of the backend_name field to the HTTP cache lookup options struct, this just contains comment updates and some minor code movement.