### PR TITLE
Fix implementation of `downstream_compliance_region` hostcall

### DIFF
--- a/lib/src/wiggle_abi/http_downstream.rs
+++ b/lib/src/wiggle_abi/http_downstream.rs
@@ -290,7 +290,7 @@ impl FastlyHttpDownstream for Session {
 
         match u32::try_from(region_len) {
             Ok(region_len) if region_len <= region_max_len => {
-                memory.copy_from_slice(region, region_out.as_array(region_max_len))?;
+                memory.copy_from_slice(region, region_out.as_array(region_len))?;
                 memory.write(nwritten_out, region_len.try_into().unwrap_or(0))?;
 
                 Ok(())


### PR DESCRIPTION
This fixes a bug in Viceroy's implementation of the `fastly_http_downstream::downstream_compliance_region` hostcall, which used the `region_max_len` value with `GuestMemory::copy_from_slice`, a method that expects the input and output slices to precisely match in length. It now uses `region_len` as it should.