### PR TITLE
Enable tracing in the WIT bindings.

### DIFF
--- a/lib/src/component/mod.rs
+++ b/lib/src/component/mod.rs
@@ -6,6 +6,7 @@ use {
 component::bindgen!({
     path: "wit",
     world: "fastly:api/compute",
+    tracing: true,
     async: true,
     with: {
         "fastly:api/uap/user-agent": uap::UserAgent,


### PR DESCRIPTION
This makes it possible to enable tracing for WIT function calls.