### PR TITLE
Fix warnings due to `mismatched_lifetime_syntaxes` lint

### DIFF
--- a/lib/src/cache.rs
+++ b/lib/src/cache.rs
@@ -264,7 +264,7 @@ impl From<Arc<CacheData>> for Found {
 }
 
 impl Found {
-    fn get_body(&self) -> GetBodyBuilder {
+    fn get_body(&self) -> GetBodyBuilder<'_> {
         self.data.as_ref().body()
     }
 

--- a/lib/src/cache/store.rs
+++ b/lib/src/cache/store.rs
@@ -658,7 +658,7 @@ impl<'a> GetBodyBuilder<'a> {
 
 impl CacheData {
     /// Get a Body to read the cached object with.
-    pub(crate) fn body(&self) -> GetBodyBuilder {
+    pub(crate) fn body(&self) -> GetBodyBuilder<'_> {
         GetBodyBuilder {
             cache_data: self,
             from: None,


### PR DESCRIPTION
This new [lint] was added in Rust 1.89. Because we deny warnings in release mode, this currently prevents building Viceroy in release mode on stable Rust.

Resolves #516

[lint]: https://blog.rust-lang.org/2025/08/07/Rust-1.89.0/#mismatched-lifetime-syntaxes-lint