### PR TITLE
Remove deprecated `macos-13` runners from CI matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
   test:
     strategy:
       matrix:
-        platform: [ubuntu-22.04, ubuntu-24.04, windows-2022, macos-13, macos-14, macos-15]
+        platform: [ubuntu-22.04, ubuntu-24.04, windows-2022, macos-14, macos-15]
     runs-on: ${{ matrix.platform }}
     env:
       SCCACHE_GHA_ENABLED: "true"
@@ -52,7 +52,7 @@ jobs:
   trap-test:
     strategy:
       matrix:
-        platform: [ubuntu-22.04, ubuntu-24.04, windows-2022, macos-13, macos-14, macos-15]
+        platform: [ubuntu-22.04, ubuntu-24.04, windows-2022, macos-14, macos-15]
     runs-on: ${{ matrix.platform }}
     env:
       SCCACHE_GHA_ENABLED: "true"


### PR DESCRIPTION
Per https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/