### PR TITLE
fix: don't throw error when exit code is 0

### DIFF
--- a/src/execute.rs
+++ b/src/execute.rs
@@ -662,6 +662,11 @@ impl ExecuteCtx {
                     }
 
                     Err(e) => {
+                        if let Some(exit) = e.downcast_ref::<wasmtime_wasi::I32Exit>() {
+                            if exit.0 == 0 {
+                                return Ok(());
+                            }
+                        }
                         event!(Level::ERROR, "WebAssembly trapped: {:?}", e);
                         Err(ExecutionError::WasmTrap(e))
                     }


### PR DESCRIPTION
With WASIp2, `exit` always returns `Err` (see [code](https://github.com/bytecodealliance/wasmtime/blob/main/crates/wasi/src/p2/host/exit.rs#L11)). We need to silence the error when the exit code is 0. This is the same treatment as in [xqd](https://github.com/fastly/ExecuteD/blob/main/src/guest/component.rs#L215).