### PR TITLE
fix component error code checking

### DIFF
--- a/src/execute.rs
+++ b/src/execute.rs
@@ -659,7 +659,7 @@ impl ExecuteCtx {
                     Err(e) => {
                         if let Some(exit) = e.downcast_ref::<I32Exit>() {
                             if exit.0 == 0 {
-                                return Ok(());
+                                Ok(())
                             } else {
                                 event!(Level::ERROR, "WebAssembly exited with error: {:?}", e);
                                 Err(ExecutionError::WasmTrap(e))


### PR DESCRIPTION
When exit code is 0, we shouldn't use `return`. Otherwise, the remaining of the function cleanup won't be executed.