### PR TITLE
Allow components to have multiple memories.

### DIFF
--- a/src/linking.rs
+++ b/src/linking.rs
@@ -21,17 +21,17 @@ pub struct Limiter {
 
 impl Default for Limiter {
     fn default() -> Self {
-        Limiter::new(1, 1)
+        Limiter::new(1, 1, 1)
     }
 }
 
 impl Limiter {
-    fn new(max_instances: usize, max_tables: usize) -> Self {
+    fn new(max_instances: usize, max_memories: usize, max_tables: usize) -> Self {
         Limiter {
             memory_allocated: 0,
             internal: StoreLimitsBuilder::new()
                 .instances(max_instances)
-                .memories(1)
+                .memories(max_memories)
                 .memory_size(128 * 1024 * 1024)
                 .table_elements(98765)
                 .tables(max_tables)
@@ -159,7 +159,7 @@ impl ComponentCtx {
             wasi_random: wasmtime_wasi::random::WasiRandomCtx::default(),
             session,
             guest_profiler: guest_profiler.map(Box::new),
-            limiter: Limiter::new(100, 100),
+            limiter: Limiter::new(100, 100, 100)
         };
         let mut store = Store::new(ctx.engine(), wasm_ctx);
         store.set_epoch_deadline(1);


### PR DESCRIPTION
Viceroy currently uses arbitrary values for the number of instances and tables allowed in components. Use a similarly arbitrary number of memories as well.