### PR TITLE
fix: use original static backend host

### DIFF
--- a/src/upstream.rs
+++ b/src/upstream.rs
@@ -228,7 +228,13 @@ fn canonical_host_header(
                 .authority()
                 .and_then(|auth| HeaderValue::from_str(auth.as_str()).ok())
         })
-        .expect("Could determine a Host header")
+        .or_else(|| {
+            backend
+                .uri
+                .host()
+                .and_then(|h| HeaderValue::from_str(h).ok())
+        })
+        .expect("Could not determine a Host header")
 }
 
 fn canonical_uri(original_uri: &Uri, canonical_host: &str, backend: &Backend) -> Uri {


### PR DESCRIPTION
Prior to this change, using a static backend without explicitly setting a Host header or configuring an override resulted in the expect case being hit.  The configured non-override static backend URI host should be used.

---

I encountered this while working directly against the WIT definitions but this implementation is shared with code paths on the wiggle abi side of things and in a cursory look it seems like it might experience similar issues, though it could be that I missed a key piece in either the SDKs or other ABI code.

This is the code snippet from the experimental python WIT bindings that would hit the failure.  The static backend was configured in viceroy (but with no additional override_host set).

```python
request = http_req.Request.new()
request.set_method("GET")
request.set_uri(path)

# TODO: without this, we hit a panic in viceroy in send
request.insert_header("Host", b"localhost")

body = http_body.new()
response, response_body = http_req.send(request, body, backend_name)
```