### PR TITLE
Add rudimentary support for 103 responses

### DIFF
--- a/cli/tests/integration/early_hints.rs
+++ b/cli/tests/integration/early_hints.rs
@@ -1,0 +1,15 @@
+// A test to ensure that early hints (103 responses) don't cause errors in Viceroy.
+
+use crate::{
+    common::{Test, TestResult},
+    viceroy_test,
+};
+
+viceroy_test!(early_hints, |is_component| {
+    let resp = Test::using_fixture("env-vars.wasm")
+        .adapt_component(is_component)
+        .against_empty()
+        .await?;
+    assert!(resp.status().is_success());
+    Ok(())
+});

--- a/cli/tests/integration/main.rs
+++ b/cli/tests/integration/main.rs
@@ -9,6 +9,7 @@ mod config_store_lookup;
 mod device_detection_lookup;
 mod dictionary_lookup;
 mod downstream_req;
+mod early_hints;
 mod edge_rate_limiting;
 mod env_vars;
 mod geolocation_lookup;

--- a/test-fixtures/src/bin/early-hints.rs
+++ b/test-fixtures/src/bin/early-hints.rs
@@ -1,0 +1,22 @@
+//! A guest program to test that config-store lookups work properly.
+
+use std::{thread, time::Duration};
+
+use fastly::http::StatusCode;
+use fastly::{Error, Request, Response};
+
+#[fastly::main]
+fn main(_req: Request) -> Result<Response, Error> {
+    let hint = Response::from_status(103)
+        .with_header("Link", "</style1>; rel=preload; as=style")
+        .with_header("Link", "</script1.js>; rel=preload; as=scrypt");
+    hint.send_to_client();
+    thread::sleep(Duration::from_secs(1));
+    let hint2 = Response::from_status(103)
+        .with_header("Link", "</style2>; rel=preload; as=style")
+        .with_header("Link", "</script2.js>; rel=preload; as=scrypt");
+    hint2.send_to_client();
+    thread::sleep(Duration::from_secs(1));
+
+    Ok(Response::from_status(StatusCode::OK).with_body("Here's the real HTTP body!"))
+}


### PR DESCRIPTION
This adds minimal support for 103 responses.

Currently, the version of hyper we use does not support 103s, which prior to now would cause hyper to return an error.

This change will catch, log, and drop 103s so that they are displayed in the output, but will not be sent down to hyper, and thus to the client. The end result is that guests can test their 103 support, and see that the 103s were generated and transmitted out of the guest. But they will be elided from the response stream sent back to the client. The client *will* receive the final response.

This allows users to continue to use Viceroy in their testing pipeline to ensure that the stack is working. They will be able to assert the status of the final response, but not the existence of the 103 frames. This ensures that Viceroy is not outright broken when presented with 103s, but it does not yet provide full 103 support.

Adding full 103 support would require adding support to hyper (and h2, on which hyper depends), but that's not as straightforward as we would like. This is also complicated by the fact that we're pinned to hyper 0.14, while hyper main is 1.6 (as of this writing).