### PR TITLE
Retroactively add changelog entry for 103 responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.16.0 (2025-11-10)
 
+- Add rudimentary support for 103 responses ([#550](https://github.com/fastly/Viceroy/pull/550))
 - Add support for manual HTTP framing headers ([#551](https://github.com/fastly/Viceroy/pull/551))
 - Core cache: Only return `FOUND` if the object is not expired ([#552](https://github.com/fastly/Viceroy/pull/552))
 


### PR DESCRIPTION
#550 did not add a changelog entry, and v0.16.0 was released without it in the changelog. This PR updates the changelog for historical purposes.