### PR TITLE
Reapply changes to support rich integration tests for fastly compute

### DIFF
--- a/cli/tests/integration/common.rs
+++ b/cli/tests/integration/common.rs
@@ -418,8 +418,8 @@ impl Test {
                     .await
                     .map(|result| {
                         match result {
-                            (resp, None) => resp,
-                            (_, Some(err)) => {
+                            (resp, None, _) => resp,
+                            (_, Some(err), _) => {
                                 // Splat the string representation of the runtime error into a synthetic
                                 // 500. This is a bit of a hack, but good enough to check for expected error
                                 // strings.

--- a/cli/tests/integration/common/backends.rs
+++ b/cli/tests/integration/common/backends.rs
@@ -76,6 +76,7 @@ impl TestBackends {
                 grpc: false,
                 client_cert: None,
                 ca_certs: vec![],
+                handler: None,
             };
             backends.insert(name.to_string(), Arc::new(backend_config));
         }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -557,6 +557,37 @@ impl std::str::FromStr for SurrogateKey {
     }
 }
 
+/// A thin public wrapper around `Cache` that provides a convenient API for integration testing.
+#[derive(Clone)]
+pub struct InMemoryCache(pub(crate) Arc<Cache>);
+
+impl Default for InMemoryCache {
+    fn default() -> Self {
+        Self(Arc::new(Cache::default()))
+    }
+}
+
+impl InMemoryCache {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Purge cache entries matching the given surrogate key strings.
+    pub fn purge(&self, surrogates: Vec<String>) {
+        for s in surrogates {
+            if let Ok(key) = s.parse::<SurrogateKey>() {
+                self.0.purge(key, false);
+            }
+        }
+    }
+}
+
+impl std::fmt::Display for InMemoryCache {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "InMemoryCache")
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::rc::Rc;

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -285,6 +285,7 @@ impl Found {
 // Explain some about how this works:
 // - Request collapsing
 // - Stale-while-revalidate
+#[derive(Debug)]
 pub struct Cache {
     inner: moka::future::Cache<CacheKey, Arc<CacheKeyObjects>>,
 }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -370,6 +370,17 @@ impl Cache {
             .map(|(_, entry)| entry.purge(&key, soft_purge))
             .sum()
     }
+
+    /// Purge/soft-purge all cache entries corresponding to the given surrogate key.
+    /// Returns the number of entries (variants) purged.
+    ///
+    /// Note: this does not block concurrent reads _or inserts_; an insertion can race with the
+    /// purge.
+    pub fn purge_all(&self, keys: Vec<SurrogateKey>, soft_purge: bool) -> usize {
+        keys.into_iter()
+            .map(|key| self.purge(key, soft_purge))
+            .sum()
+    }
 }
 
 /// Options that can be applied to a write, e.g. insert or transaction_insert.

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -1,5 +1,5 @@
 use core::str;
-use std::{collections::HashSet, sync::Arc, time::Duration};
+use std::{collections::HashSet, fmt, sync::Arc, time::Duration};
 
 use bytes::Bytes;
 #[cfg(test)]
@@ -126,6 +126,20 @@ impl TryFrom<&str> for CacheKey {
 
     fn try_from(value: &str) -> Result<Self, Self::Error> {
         value.as_bytes().try_into()
+    }
+}
+
+impl fmt::Display for CacheKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match str::from_utf8(&self.0) {
+            Ok(s) => write!(f, "{s}"),
+            Err(_) => {
+                for byte in &self.0 {
+                    write!(f, "{byte:02x}")?;
+                }
+                Ok(())
+            }
+        }
     }
 }
 
@@ -381,6 +395,17 @@ impl Cache {
         keys.into_iter()
             .map(|key| self.purge(key, soft_purge))
             .sum()
+    }
+}
+
+impl fmt::Display for Cache {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(f, "Cache {{")?;
+        for (key, objects) in self.inner.iter() {
+            writeln!(f, "  key: {key}")?;
+            write!(f, "{:4}", &*objects)?;
+        }
+        write!(f, "}}")
     }
 }
 

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -557,37 +557,6 @@ impl std::str::FromStr for SurrogateKey {
     }
 }
 
-/// A thin public wrapper around `Cache` that provides a convenient API for integration testing.
-#[derive(Clone)]
-pub struct InMemoryCache(pub(crate) Arc<Cache>);
-
-impl Default for InMemoryCache {
-    fn default() -> Self {
-        Self(Arc::new(Cache::default()))
-    }
-}
-
-impl InMemoryCache {
-    pub fn new() -> Self {
-        Self::default()
-    }
-
-    /// Purge cache entries matching the given surrogate key strings.
-    pub fn purge(&self, surrogates: Vec<String>) {
-        for s in surrogates {
-            if let Ok(key) = s.parse::<SurrogateKey>() {
-                self.0.purge(key, false);
-            }
-        }
-    }
-}
-
-impl std::fmt::Display for InMemoryCache {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "InMemoryCache")
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use std::rc::Rc;

--- a/src/cache/store.rs
+++ b/src/cache/store.rs
@@ -4,6 +4,7 @@ use crate::cache::{variance::VaryRule, Error};
 use bytes::Bytes;
 use std::{
     collections::{HashMap, VecDeque},
+    fmt,
     future::Future,
     sync::{atomic::AtomicBool, Arc},
     time::{Duration, Instant},
@@ -120,6 +121,44 @@ impl ObjectMeta {
             surrogate_keys,
             soft_purge: AtomicBool::new(false),
         }
+    }
+}
+
+impl fmt::Display for ObjectMeta {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let indent = f.width().unwrap_or(0);
+        let i = " ".repeat(indent);
+
+        writeln!(f, "{i}ObjectMeta:")?;
+        writeln!(f, "{i}  age: {:?}", self.age())?;
+        writeln!(f, "{i}  max_age: {:?}", self.max_age)?;
+        writeln!(f, "{i}  stale_while_revalidate: {:?}", self.stale_while_revalidate)?;
+        writeln!(f, "{i}  fresh: {}", self.is_fresh())?;
+        writeln!(f, "{i}  usable: {}", self.is_usable())?;
+        writeln!(f, "{i}  vary_rule: {}", self.vary_rule)?;
+        writeln!(f, "{i}  surrogate_keys: {}", self.surrogate_keys)?;
+        writeln!(f, "{i}  length: {:?}", self.length)?;
+        writeln!(
+            f,
+            "{i}  soft_purge: {}",
+            self.soft_purge.load(std::sync::atomic::Ordering::SeqCst)
+        )?;
+
+        // Show request headers
+        writeln!(f, "{i}  request_headers:")?;
+        for (name, value) in self.request_headers.iter() {
+            writeln!(f, "{i}    {}: {}", name, value.to_str().unwrap_or("<binary>"))?;
+        }
+
+        // Show user_metadata as UTF-8 if possible
+        if !self.user_metadata.is_empty() {
+            match std::str::from_utf8(&self.user_metadata) {
+                Ok(s) => writeln!(f, "{i}  user_metadata: {s}")?,
+                Err(_) => writeln!(f, "{i}  user_metadata: ({} bytes)", self.user_metadata.len())?,
+            }
+        }
+
+        Ok(())
     }
 }
 
@@ -479,6 +518,57 @@ struct CacheValue {
 
     /// Whether there is an outstanding Obligation to freshen this entry.
     obligated: bool,
+}
+
+impl fmt::Display for CacheKeyObjects {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let indent = f.width().unwrap_or(0);
+        let inner = self.0.borrow();
+        fmt::Display::fmt(&IndentWrapper(&*inner, indent), f)
+    }
+}
+
+/// Helper to pass indent through Display since CacheKeyObjectsInner is private.
+struct IndentWrapper<'a>(&'a CacheKeyObjectsInner, usize);
+
+impl fmt::Display for IndentWrapper<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let inner = self.0;
+        let indent = self.1;
+        let i = " ".repeat(indent);
+
+        // Vary rules
+        writeln!(f, "{i}vary_rules:")?;
+        for rule in inner.vary_rules.iter() {
+            writeln!(f, "{i}  - {rule}")?;
+        }
+
+        // Objects (variants)
+        writeln!(f, "{i}variants:")?;
+        for (variant, value) in inner.objects.iter() {
+            writeln!(f, "{i}  {variant}:")?;
+            if let Some(data) = &value.present {
+                write!(f, "{:indent$}", data, indent = indent + 4)?;
+            } else {
+                writeln!(f, "{i}    (empty)")?;
+            }
+            writeln!(f, "{i}    obligated: {}", value.obligated)?;
+        }
+
+        Ok(())
+    }
+}
+
+impl fmt::Display for CacheData {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let indent = f.width().unwrap_or(0);
+        write!(f, "{:indent$}", self.meta, indent = indent)?;
+        let i = " ".repeat(indent);
+        if let Some(len) = self.length() {
+            writeln!(f, "{i}body_length: {len}")?;
+        }
+        Ok(())
+    }
 }
 
 /// An obligation to fetch & update the cache.

--- a/src/cache/variance.rs
+++ b/src/cache/variance.rs
@@ -9,7 +9,7 @@
 //! The core cache API provides the bones of this.
 //!
 
-use std::{collections::HashSet, str::FromStr};
+use std::{collections::HashSet, fmt, str::FromStr};
 
 use bytes::{Bytes, BytesMut};
 pub use http::HeaderName;
@@ -82,6 +82,26 @@ pub struct Variant {
     /// sequence. However, since header values may contain arbitrary bytes, this is a Bytes rather
     /// than a String.
     signature: Bytes,
+}
+
+impl fmt::Display for VaryRule {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.headers.is_empty() {
+            write!(f, "VaryRule([])")
+        } else {
+            let headers: Vec<&str> = self.headers.iter().map(|h| h.as_str()).collect();
+            write!(f, "VaryRule([{}])", headers.join(", "))
+        }
+    }
+}
+
+impl fmt::Display for Variant {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match std::str::from_utf8(&self.signature) {
+            Ok(s) => write!(f, "Variant({s})"),
+            Err(_) => write!(f, "Variant({:?})", self.signature),
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/component/backend.rs
+++ b/src/component/backend.rs
@@ -144,6 +144,7 @@ pub(crate) async fn register_dynamic_backend(
         grpc,
         client_cert,
         ca_certs,
+        handler: None,
     };
 
     if !session.add_backend(name, new_backend) {

--- a/src/component/shielding.rs
+++ b/src/component/shielding.rs
@@ -28,6 +28,7 @@ pub(crate) fn backend_for_shield(
         grpc: false,
         client_cert: None,
         ca_certs: Vec::new(),
+        handler: None,
     };
 
     if !session.add_backend(&new_name, new_backend) {

--- a/src/config.rs
+++ b/src/config.rs
@@ -32,7 +32,10 @@ pub use crate::acl::Acls;
 /// Types and deserializers for backend configuration settings.
 mod backends;
 
-pub use self::backends::{Backend, ClientCertError, ClientCertInfo};
+pub use self::backends::{
+    Backend, ClientCertError, ClientCertInfo, DynamicBackendRegistrationInterceptor, Handler,
+    InMemoryBackendHandler,
+};
 
 pub type Backends = HashMap<String, Arc<Backend>>;
 

--- a/src/execute.rs
+++ b/src/execute.rs
@@ -390,6 +390,57 @@ impl ExecuteCtx {
         .finish()
     }
 
+    /// Create a new builder that reuses the compiled wasm module from this context.
+    ///
+    /// This is much cheaper than calling `build()` again, as it skips wasm compilation.
+    /// All configuration (backends, dictionaries, object stores, etc.) starts at defaults
+    /// and must be set on the returned builder.
+    pub fn to_builder(&self) -> Result<ExecuteCtxBuilder, Error> {
+        let epoch_increment_stop = Arc::new(AtomicBool::new(false));
+        let engine_clone = self.engine.clone();
+        let epoch_increment_stop_clone = epoch_increment_stop.clone();
+        let sample_period = self
+            .guest_profile_config
+            .as_ref()
+            .map(|c| c.sample_period)
+            .unwrap_or(DEFAULT_EPOCH_INTERRUPTION_PERIOD);
+        let epoch_increment_thread = Some(thread::spawn(move || {
+            while !epoch_increment_stop_clone.load(Ordering::Relaxed) {
+                thread::sleep(sample_period);
+                engine_clone.increment_epoch();
+            }
+        }));
+
+        Ok(ExecuteCtxBuilder {
+            inner: Self {
+                engine: self.engine.clone(),
+                instance_pre: self.instance_pre.clone(),
+                acls: Acls::new(),
+                backends: Backends::default(),
+                device_detection: DeviceDetection::default(),
+                geolocation: Geolocation::default(),
+                tls_config: TlsConfig::new()?,
+                dictionaries: Dictionaries::default(),
+                config_path: None,
+                capture_logs: Arc::new(Mutex::new(std::io::stdout())),
+                log_stdout: false,
+                log_stderr: false,
+                local_pushpin_proxy_port: None,
+                next_req_id: Arc::new(AtomicU64::new(0)),
+                object_store: ObjectStores::new(),
+                secret_stores: SecretStores::new(),
+                shielding_sites: ShieldingSites::new(),
+                epoch_increment_thread,
+                epoch_increment_stop,
+                guest_profile_config: self.guest_profile_config.clone(),
+                cache: InMemoryCache::default(),
+                pending_reuse: Arc::new(AsyncMutex::new(vec![])),
+                endpoints_monitor: EndpointsMonitor::default(),
+                dynamic_backend_interceptor: None,
+            },
+        })
+    }
+
     /// Get the engine for this execution context.
     pub fn engine(&self) -> &Engine {
         &self.engine

--- a/src/execute.rs
+++ b/src/execute.rs
@@ -6,7 +6,7 @@ use {
         adapt,
         body::Body,
         body_tee::tee,
-        cache::{Cache, InMemoryCache},
+        cache::Cache,
         component as compute,
         config::{
             Backends, DeviceDetection, Dictionaries, ExperimentalModule, Geolocation,
@@ -203,7 +203,7 @@ pub struct ExecuteCtx {
     /// The shielding sites for this execution.
     shielding_sites: ShieldingSites,
     /// The cache for this service.
-    cache: InMemoryCache,
+    cache: Arc<Cache>,
     /// Senders waiting for new requests for reusable sessions.
     pending_reuse: Arc<AsyncMutex<Vec<Sender<NextRequest>>>>,
     epoch_increment_thread: Option<JoinHandle<()>>,
@@ -361,7 +361,7 @@ impl ExecuteCtx {
             epoch_increment_thread,
             epoch_increment_stop,
             guest_profile_config: guest_profile_config.map(|c| Arc::new(c)),
-            cache: InMemoryCache::default(),
+            cache: Arc::new(Cache::default()),
             pending_reuse: Arc::new(AsyncMutex::new(vec![])),
             endpoints_monitor: EndpointsMonitor::default(),
             dynamic_backend_interceptor: None,
@@ -388,57 +388,6 @@ impl ExecuteCtx {
             adapt_components,
         )?
         .finish()
-    }
-
-    /// Create a new builder that reuses the compiled wasm module from this context.
-    ///
-    /// This is much cheaper than calling `build()` again, as it skips wasm compilation.
-    /// All configuration (backends, dictionaries, object stores, etc.) starts at defaults
-    /// and must be set on the returned builder.
-    pub fn to_builder(&self) -> Result<ExecuteCtxBuilder, Error> {
-        let epoch_increment_stop = Arc::new(AtomicBool::new(false));
-        let engine_clone = self.engine.clone();
-        let epoch_increment_stop_clone = epoch_increment_stop.clone();
-        let sample_period = self
-            .guest_profile_config
-            .as_ref()
-            .map(|c| c.sample_period)
-            .unwrap_or(DEFAULT_EPOCH_INTERRUPTION_PERIOD);
-        let epoch_increment_thread = Some(thread::spawn(move || {
-            while !epoch_increment_stop_clone.load(Ordering::Relaxed) {
-                thread::sleep(sample_period);
-                engine_clone.increment_epoch();
-            }
-        }));
-
-        Ok(ExecuteCtxBuilder {
-            inner: Self {
-                engine: self.engine.clone(),
-                instance_pre: self.instance_pre.clone(),
-                acls: Acls::new(),
-                backends: Backends::default(),
-                device_detection: DeviceDetection::default(),
-                geolocation: Geolocation::default(),
-                tls_config: TlsConfig::new()?,
-                dictionaries: Dictionaries::default(),
-                config_path: None,
-                capture_logs: Arc::new(Mutex::new(std::io::stdout())),
-                log_stdout: false,
-                log_stderr: false,
-                local_pushpin_proxy_port: None,
-                next_req_id: Arc::new(AtomicU64::new(0)),
-                object_store: ObjectStores::new(),
-                secret_stores: SecretStores::new(),
-                shielding_sites: ShieldingSites::new(),
-                epoch_increment_thread,
-                epoch_increment_stop,
-                guest_profile_config: self.guest_profile_config.clone(),
-                cache: InMemoryCache::default(),
-                pending_reuse: Arc::new(AsyncMutex::new(vec![])),
-                endpoints_monitor: EndpointsMonitor::default(),
-                dynamic_backend_interceptor: None,
-            },
-        })
     }
 
     /// Get the engine for this execution context.
@@ -692,7 +641,13 @@ impl ExecuteCtx {
         ));
 
         if let Some(response) = Self::maybe_receive_response(receiver).await {
-            return (response.0, response.1, Some(GuestHandle { handle: guest_handle }));
+            return (
+                response.0,
+                response.1,
+                Some(GuestHandle {
+                    handle: guest_handle,
+                }),
+            );
         }
 
         match guest_handle
@@ -983,24 +938,21 @@ impl ExecuteCtx {
                 shielding_sites: self.shielding_sites.clone(),
                 guest_profile_config: self.guest_profile_config.clone(),
                 // Fresh per-test state:
-                cache: InMemoryCache::new(),
+                cache: Arc::new(Cache::default()),
                 next_req_id: Arc::new(AtomicU64::new(0)),
                 pending_reuse: Arc::new(AsyncMutex::new(vec![])),
                 // Don't own the epoch thread (parent owns it)
                 epoch_increment_thread: None,
                 epoch_increment_stop: self.epoch_increment_stop.clone(),
-                // New fields default:
+                // New interceptor.
                 dynamic_backend_interceptor: None,
+                // New endpoints monitor.
                 endpoints_monitor: EndpointsMonitor::default(),
             },
         }
     }
 
     pub fn cache(&self) -> &Arc<Cache> {
-        &self.cache.0
-    }
-
-    pub fn in_memory_cache(&self) -> &InMemoryCache {
         &self.cache
     }
 
@@ -1120,7 +1072,7 @@ impl ExecuteCtxBuilder {
     }
 
     /// Set the cache for this execution context.
-    pub fn with_cache(mut self, cache: InMemoryCache) -> Self {
+    pub fn with_cache(mut self, cache: Arc<Cache>) -> Self {
         self.inner.cache = cache;
         self
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,6 +42,16 @@ mod upstream;
 pub mod wiggle_abi;
 
 pub use {
-    error::Error, execute::ExecuteCtx, execute::GuestProfileConfig, service::ViceroyService,
-    upstream::BackendConnector, wasmtime::ProfilingStrategy,
+    cache::InMemoryCache,
+    error::Error,
+    execute::{
+        run_to_completion, EndpointListener, EndpointsMonitor, ExecuteCtx, ExecuteCtxBuilder,
+        GuestHandle, GuestProfileConfig,
+    },
+    service::ViceroyService,
+    upstream::BackendConnector,
+    wasmtime::ProfilingStrategy,
 };
+pub use async_trait;
+pub use http;
+pub use hyper;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,8 +41,11 @@ mod streaming_body;
 mod upstream;
 pub mod wiggle_abi;
 
+pub use async_trait;
+pub use http;
+pub use hyper;
 pub use {
-    cache::InMemoryCache,
+    cache::Cache,
     error::Error,
     execute::{
         run_to_completion, EndpointListener, EndpointsMonitor, ExecuteCtx, ExecuteCtxBuilder,
@@ -53,6 +56,3 @@ pub use {
     upstream::BackendConnector,
     wasmtime::ProfilingStrategy,
 };
-pub use async_trait;
-pub use http;
-pub use hyper;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,6 +48,7 @@ pub use {
         run_to_completion, EndpointListener, EndpointsMonitor, ExecuteCtx, ExecuteCtxBuilder,
         GuestHandle, GuestProfileConfig,
     },
+    object_store::{ObjectKey, ObjectStoreKey},
     service::ViceroyService,
     upstream::BackendConnector,
     wasmtime::ProfilingStrategy,

--- a/src/session.rs
+++ b/src/session.rs
@@ -585,15 +585,10 @@ impl Session {
         }
         let mut endpoint = LogEndpoint::new(name, self.capture_logs.clone());
         // Check if the endpoints monitor has a registered sender for this name
-        if let Some(sender) = self
-            .ctx
-            .endpoints_monitor()
-            .endpoints
-            .blocking_read()
-            .get(name)
-            .cloned()
-        {
-            endpoint = endpoint.with_channel(sender);
+        if let Ok(endpoints) = self.ctx.endpoints_monitor().endpoints.try_read() {
+            if let Some(sender) = endpoints.get(name).cloned() {
+                endpoint = endpoint.with_channel(sender);
+            }
         }
         let handle = self.log_endpoints.push(endpoint);
         self.log_endpoints_by_name.insert(name.to_owned(), handle);

--- a/src/wiggle_abi/req_impl.rs
+++ b/src/wiggle_abi/req_impl.rs
@@ -564,6 +564,7 @@ impl FastlyHttpReq for Session {
             grpc,
             client_cert,
             ca_certs,
+            handler: None,
         };
 
         if !self.add_backend(&name, new_backend) {

--- a/src/wiggle_abi/shielding.rs
+++ b/src/wiggle_abi/shielding.rs
@@ -95,6 +95,7 @@ impl fastly_shielding::FastlyShielding for Session {
             grpc: false,
             client_cert: None,
             ca_certs: Vec::new(),
+            handler: None,
         };
 
         if !self.add_backend(&new_name, new_backend) {


### PR DESCRIPTION
This PR extends Viceroy's public API to support richer integration testing by introducing several new capabilities or extending existing ones:
- In-memory backend handlers (`InMemoryBackendHandler` trait + `Handler` wrapper): Backends can now be configured with custom async handlers that intercept requests and return responses without making real HTTP calls, enabling fully in-process integration tests.
- Similarly, there's now a dynamic backend registration interceptor (yes, incredible name... `DynamicBackendRegistrationInterceptor` trait): Allows test harnesses to hook into dynamic backend registration and modify or augment backends as they are registered at runtime (e.g., to attach in-memory handlers).
- Add Display trait to `Cache` and related structs to allow pretty printing. This is useful for debugging potentially incorrect cache state that the application produces.
- Extend `Cache` with `purge_all` convenience method.
- `GuestHandle` + `run_to_completion()`: The `handle_request` and `spawn_guest` call chains now return a `GuestHandle` so callers can await full guest completion (including async logging, cache writes, etc.) after receiving the HTTP response.
- Logging endpoint monitoring (`EndpointsMonitor` / `EndpointListener`): Provides a channel-based mechanism to register listeners on named logging endpoints, allowing tests to capture and assert on log output from the guest.
- `ExecuteCtx::fork()`: Allows creating a lightweight fork of an execution context that shares the compiled WASM engine/module but has fresh per-test state (cache, request IDs, pending reuse), making it efficient to run many tests against the same compiled guest.
- Re-exported dependencies: async_trait, http, and hyper are now re-exported from the crate root so downstream consumers don't need to depend on matching versions.
