### PR TITLE
Add options for experimenting with wasm gc and exceptions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Add `health` config parameter for backends to mock backend health status in testing. ([#605](https://github.com/fastly/Viceroy/pulls/606))
 - Use `cargo clippy` to lint code in CI. ([#603](https://github.com/fastly/Viceroy/pull/603))
 - Rename `Error::InvalidAlpnRepsonse` to correct a typo ([#612](https://github.com/fastly/Viceroy/pull/612))
+- Add options for experimenting with wasm gc and exceptions. ([#601](https://github.com/fastly/Viceroy/pull/601))
 
 ## 0.16.5 (2026-03-23)
 

--- a/cli/src/execute_ctx.rs
+++ b/cli/src/execute_ctx.rs
@@ -77,6 +77,7 @@ pub(crate) async fn create_execution_context(
         guest_profile_config,
         args.unknown_import_behavior(),
         args.adapt(),
+        args.wasm_features(),
     )?
     .with_log_stderr(args.log_stderr())
     .with_log_stdout(args.log_stdout())

--- a/cli/src/opts.rs
+++ b/cli/src/opts.rs
@@ -13,6 +13,7 @@ use {
         path::{Path, PathBuf},
     },
     viceroy_lib::{Error, ProfilingStrategy, config::ExperimentalModule},
+    wasmtime::WasmFeatures,
 };
 
 // Command-line arguments for the Viceroy CLI.
@@ -124,6 +125,15 @@ pub struct SharedArgs {
     /// components before running them.
     #[arg(long = "adapt")]
     adapt: bool,
+    /// Enable the Wasm Exception Handling feature.
+    #[arg(long)]
+    wasm_exceptions: bool,
+    /// Enable the Wasm GC feature.
+    #[arg(long)]
+    wasm_gc: bool,
+    /// Enable component-model GC integration.
+    #[arg(long)]
+    wasm_cm_gc: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -231,6 +241,20 @@ impl SharedArgs {
 
     pub fn adapt(&self) -> bool {
         self.adapt
+    }
+
+    pub fn wasm_features(&self) -> WasmFeatures {
+        let mut wasm_features = WasmFeatures::default();
+        if self.wasm_exceptions {
+            wasm_features.insert(WasmFeatures::EXCEPTIONS);
+        }
+        if self.wasm_gc {
+            wasm_features.insert(WasmFeatures::GC);
+        }
+        if self.wasm_cm_gc {
+            wasm_features.insert(WasmFeatures::CM_GC);
+        }
+        wasm_features
     }
 }
 

--- a/cli/tests/integration/common.rs
+++ b/cli/tests/integration/common.rs
@@ -21,6 +21,7 @@ use viceroy_lib::{
         ObjectStores, SecretStores, ShieldingSites,
     },
 };
+use wasmtime::WasmFeatures;
 
 pub use self::backends::TestBackends;
 
@@ -352,6 +353,7 @@ impl Test {
             self.guest_profile_config.clone(),
             self.unknown_import_behavior,
             self.adapt_component,
+            WasmFeatures::default(),
         )?
         .with_acls(self.acls.clone())
         .with_backends(self.backends.backend_configs().await)

--- a/cli/tests/trap-test/src/main.rs
+++ b/cli/tests/trap-test/src/main.rs
@@ -1,7 +1,7 @@
 use std::collections::HashSet;
 use {
     hyper::{Body, Request, StatusCode},
-    viceroy_lib::{ExecuteCtx, ProfilingStrategy},
+    viceroy_lib::{ExecuteCtx, ProfilingStrategy, WasmFeatures},
 };
 
 /// A shorthand for the path to our test fixtures' build artifacts for Rust tests.
@@ -22,6 +22,7 @@ async fn fatal_error_traps_impl(adapt_core_wasm: bool) -> TestResult {
         None,
         viceroy_lib::config::UnknownImportBehavior::LinkError,
         adapt_core_wasm,
+        WasmFeatures::default(),
     )?;
     let req = Request::get("http://127.0.0.1:7676/").body(Body::from(""))?;
     let local = "127.0.0.1:80".parse().unwrap();

--- a/src/execute.rs
+++ b/src/execute.rs
@@ -54,6 +54,8 @@ use {
     wasmtime_wasi::I32Exit,
 };
 
+pub use wasmtime::WasmFeatures;
+
 pub const DEFAULT_EPOCH_INTERRUPTION_PERIOD: Duration = Duration::from_micros(50);
 
 const NEXT_REQ_PENDING_MAX: usize = 5;
@@ -175,6 +177,7 @@ impl ExecuteCtx {
         guest_profile_config: Option<GuestProfileConfig>,
         unknown_import_behavior: UnknownImportBehavior,
         adapt_components: bool,
+        wasm_features: WasmFeatures,
     ) -> Result<ExecuteCtxBuilder, Error> {
         let input = fs::read(&module_path)?;
 
@@ -202,7 +205,7 @@ impl ExecuteCtx {
             (is_wat, is_component, input)
         };
 
-        let config = &configure_wasmtime(is_component, profiling_strategy);
+        let config = &configure_wasmtime(wasm_features, profiling_strategy);
         let engine = Engine::new(config)?;
         let instance_pre = if is_component {
             warn!(
@@ -328,6 +331,7 @@ impl ExecuteCtx {
         guest_profile_config: Option<GuestProfileConfig>,
         unknown_import_behavior: UnknownImportBehavior,
         adapt_components: bool,
+        wasm_features: WasmFeatures,
     ) -> Result<Arc<Self>, Error> {
         ExecuteCtx::build(
             module_path,
@@ -336,6 +340,7 @@ impl ExecuteCtx {
             guest_profile_config,
             unknown_import_behavior,
             adapt_components,
+            wasm_features,
         )?
         .finish()
     }
@@ -417,12 +422,22 @@ impl ExecuteCtx {
     ///
     /// ```no_run
     /// # use std::collections::HashSet;
+    /// # use wasmtime::WasmFeatures;
     /// use hyper::{Body, http::Request};
     /// # use viceroy_lib::{Error, ExecuteCtx, ProfilingStrategy, ViceroyService};
     /// # async fn f() -> Result<(), Error> {
     /// # let req = Request::new(Body::from(""));
     /// let adapt_core_wasm = false;
-    /// let ctx = ExecuteCtx::new("path/to/a/file.wasm", ProfilingStrategy::None, HashSet::new(), None, Default::default(), adapt_core_wasm)?;
+    /// let wasm_features = WasmFeatures::default();
+    /// let ctx = ExecuteCtx::new(
+    ///     "path/to/a/file.wasm",
+    ///     ProfilingStrategy::None,
+    ///     HashSet::new(),
+    ///     None,
+    ///     Default::default(),
+    ///     adapt_core_wasm,
+    ///     wasm_features
+    /// )?;
     /// let local = "127.0.0.1:80".parse().unwrap();
     /// let remote = "127.0.0.1:0".parse().unwrap();
     /// let resp = ctx.handle_request(req, local, remote).await?;
@@ -1078,7 +1093,7 @@ impl Drop for ExecuteCtx {
 }
 
 fn configure_wasmtime(
-    allow_components: bool,
+    wasm_features: WasmFeatures,
     profiling_strategy: ProfilingStrategy,
 ) -> wasmtime::Config {
     use wasmtime::{Config, InstanceAllocationStrategy, WasmBacktraceDetails};
@@ -1092,9 +1107,7 @@ fn configure_wasmtime(
 
     config.allocation_strategy(InstanceAllocationStrategy::OnDemand);
 
-    if allow_components {
-        config.wasm_component_model(true);
-    }
+    config.wasm_features(wasm_features, true);
 
     // Wasm permits the "relaxed" instructions to be nondeterministic
     // between runs, but requires them to be deterministic within runs.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,6 +42,6 @@ mod upstream;
 pub mod wiggle_abi;
 
 pub use {
-    error::Error, execute::ExecuteCtx, execute::GuestProfileConfig, service::ViceroyService,
-    upstream::BackendConnector, wasmtime::ProfilingStrategy,
+    error::Error, execute::ExecuteCtx, execute::GuestProfileConfig, execute::WasmFeatures,
+    service::ViceroyService, upstream::BackendConnector, wasmtime::ProfilingStrategy,
 };

--- a/src/service.rs
+++ b/src/service.rs
@@ -42,10 +42,20 @@ impl ViceroyService {
     ///
     /// ```no_run
     /// # use std::collections::HashSet;
+    /// # use wasmtime::WasmFeatures;
     /// use viceroy_lib::{Error, ExecuteCtx, ProfilingStrategy, ViceroyService};
     /// # fn f() -> Result<(), Error> {
     /// let adapt_core_wasm = false;
-    /// let ctx = ExecuteCtx::new("path/to/a/file.wasm", ProfilingStrategy::None, HashSet::new(), None, Default::default(), adapt_core_wasm)?;
+    /// let wasm_features = WasmFeatures::default();
+    /// let ctx = ExecuteCtx::new(
+    ///     "path/to/a/file.wasm",
+    ///     ProfilingStrategy::None,
+    ///     HashSet::new(),
+    ///     None,
+    ///     Default::default(),
+    ///     adapt_core_wasm,
+    ///     wasm_features
+    /// )?;
     /// let svc = ViceroyService::new(ctx);
     /// # Ok(())
     /// # }


### PR DESCRIPTION
Add an argument to `viceroy_lib::ExecuteCtx::build` for enabling additional Wasm language features, and add command-line arguments to the viceroy CLI for enabling gc and exceptions.