### PR TITLE
Address clippy warnings

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,6 +20,6 @@ jobs:
       run: rustup default ${{ matrix.rust }}
     - run: rustup target add wasm32-wasip1
     - run: rustup target add wasm32-unknown-unknown
-    - name: Install rustfmt
-      run: rustup component add rustfmt
+    - name: Install rustfmt and clippy
+      run: rustup component add rustfmt clippy
     - run: make ci

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,8 +33,8 @@ jobs:
         key: ${{ matrix.platform }}-cargo-v${{ env.CACHE_GENERATION }}-${{ steps.toolchain.outputs.rustc_hash }}-${{ hashFiles('**/Cargo.lock') }}
     - name: Run sccache-cache
       uses: mozilla-actions/sccache-action@v0.0.9
-    - name: Install rustfmt
-      run: rustup component add rustfmt
+    - name: Install rustfmt and clippy
+      run: rustup component add rustfmt clippy
       shell: bash
     - name: Check formatting
       run: cargo fmt --all -- --check

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Add stub implementations for resvpnproxy hostcalls.
 - Add `fake_valid_fastly_keys` config parameter to allow testing `fastly_key_is_valid` hostcall with fake valid keys. ([#599](https://github.com/fastly/Viceroy/pull/599))
+- Use `cargo clippy` to lint code in CI. ([#603](https://github.com/fastly/Viceroy/pull/603))
 
 ## 0.16.5 (2026-03-23)
 

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ format-check:
 
 .PHONY: clippy
 clippy:
-	$(VICEROY_CARGO) clippy --all -- -D warnings
+	$(VICEROY_CARGO) clippy --all-targets --all-features -- -D warnings
 
 .PHONY: test
 test: test-crates trap-test
@@ -37,7 +37,7 @@ trap-test-ci: trap-test
 # The main `ci` target runs everything except `trap-test`.
 .PHONY: ci
 ci: VICEROY_CARGO=cargo --locked
-ci: format-check test-crates
+ci: format-check clippy test-crates
 
 .PHONY: clean
 clean:

--- a/cli/src/opts.rs
+++ b/cli/src/opts.rs
@@ -334,25 +334,25 @@ fn parse_profile_sample_duration(s: &str) -> Result<Duration, Error> {
         return Ok(Duration::from_secs(val));
     }
 
-    if let Some(num) = s.strip_suffix("s") {
-        if let Ok(val) = num.parse() {
-            return Ok(Duration::from_secs(val));
-        }
+    if let Some(num) = s.strip_suffix("s")
+        && let Ok(val) = num.parse()
+    {
+        return Ok(Duration::from_secs(val));
     }
-    if let Some(num) = s.strip_suffix("ms") {
-        if let Ok(val) = num.parse() {
-            return Ok(Duration::from_millis(val));
-        }
+    if let Some(num) = s.strip_suffix("ms")
+        && let Ok(val) = num.parse()
+    {
+        return Ok(Duration::from_millis(val));
     }
-    if let Some(num) = s.strip_suffix("us").or(s.strip_suffix("μs")) {
-        if let Ok(val) = num.parse() {
-            return Ok(Duration::from_micros(val));
-        }
+    if let Some(num) = s.strip_suffix("us").or(s.strip_suffix("μs"))
+        && let Ok(val) = num.parse()
+    {
+        return Ok(Duration::from_micros(val));
     }
-    if let Some(num) = s.strip_suffix("ns") {
-        if let Ok(val) = num.parse() {
-            return Ok(Duration::from_nanos(val));
-        }
+    if let Some(num) = s.strip_suffix("ns")
+        && let Ok(val) = num.parse()
+    {
+        return Ok(Duration::from_nanos(val));
     }
 
     Err(Error::ProfilingStrategy)

--- a/cli/src/subcommands/adapt.rs
+++ b/cli/src/subcommands/adapt.rs
@@ -61,7 +61,7 @@ pub(crate) fn exec(adapt_args: AdaptArgs) -> ExitCode {
         Ok(_) => ExitCode::SUCCESS,
         Err(e) => {
             event!(Level::ERROR, "Failed to write component: {e:?}");
-            return ExitCode::FAILURE;
+            ExitCode::FAILURE
         }
     }
 }

--- a/cli/tests/integration/async_io.rs
+++ b/cli/tests/integration/async_io.rs
@@ -1,3 +1,11 @@
+// On Windows, streaming body backpressure doesn't seem to work as expected, either
+// due to the Hyper client or server too eagerly clearing the chunk buffer. This issue does
+// not appear related to async I/O hostcalls; the behavior is seen within the streaming body
+// implementation in general. For the time being, this test is unix-only.
+//
+// https://github.com/fastly/Viceroy/issues/207 tracks the broader issue.
+#![cfg(target_family = "unix")]
+
 use crate::{
     common::{Test, TestResult},
     viceroy_test,
@@ -9,13 +17,6 @@ use std::sync::{
 };
 use tokio::sync::Barrier;
 
-// On Windows, streaming body backpressure doesn't seem to work as expected, either
-// due to the Hyper client or server too eagerly clearing the chunk buffer. This issue does
-// not appear related to async I/O hostcalls; the behavior is seen within the streaming body
-// implementation in general. For the time being, this test is unix-only.
-//
-// https://github.com/fastly/Viceroy/issues/207 tracks the broader issue.
-#[cfg(target_family = "unix")]
 viceroy_test!(async_io_methods, |is_component| {
     let request_count = Arc::new(AtomicUsize::new(0));
     let req_count_1 = request_count.clone();

--- a/cli/tests/integration/body.rs
+++ b/cli/tests/integration/body.rs
@@ -52,7 +52,7 @@ viceroy_test!(zero_length_raw_chunks_are_transparent, |is_component| {
                             };
                             tokio::task::yield_now().await;
                         }
-                        let _ = write.send_trailers(HeaderMap::default());
+                        let _ = write.send_trailers(HeaderMap::default()).await;
                     });
                     Response::builder()
                         .status(StatusCode::OK)
@@ -103,7 +103,7 @@ viceroy_test!(gzip_breaks_are_ok, |is_component| {
                             };
                             tokio::task::yield_now().await;
                         }
-                        let _ = write.send_trailers(HeaderMap::default());
+                        let _ = write.send_trailers(HeaderMap::default()).await;
                     });
                     Response::builder()
                         .status(StatusCode::OK)

--- a/cli/tests/integration/common.rs
+++ b/cli/tests/integration/common.rs
@@ -347,7 +347,7 @@ impl Test {
 
         let ctx = ExecuteCtx::build(
             &self.module_path,
-            self.profiling_strategy.clone(),
+            self.profiling_strategy,
             HashSet::new(),
             self.guest_profile_config.clone(),
             self.unknown_import_behavior,
@@ -522,6 +522,7 @@ impl Drop for TestServer {
 }
 
 #[derive(Clone)]
+#[allow(clippy::type_complexity)]
 enum TestService {
     Sync(Arc<dyn Fn(Request<Vec<u8>>) -> Response<Vec<u8>> + Send + Sync>),
     Async(Arc<dyn Fn(Request<HyperBody>) -> AsyncResp + Send + Sync>),

--- a/cli/tests/integration/common.rs
+++ b/cli/tests/integration/common.rs
@@ -520,12 +520,15 @@ impl Drop for TestServer {
         }
     }
 }
+type SyncService = dyn Fn(Request<Vec<u8>>) -> Response<Vec<u8>> + Send + Sync;
+
+type AsyncResp = Box<dyn Future<Output = Response<HyperBody>> + Send + Sync>;
+type AsyncService = dyn Fn(Request<HyperBody>) -> AsyncResp + Send + Sync;
 
 #[derive(Clone)]
-#[allow(clippy::type_complexity)]
 enum TestService {
-    Sync(Arc<dyn Fn(Request<Vec<u8>>) -> Response<Vec<u8>> + Send + Sync>),
-    Async(Arc<dyn Fn(Request<HyperBody>) -> AsyncResp + Send + Sync>),
+    Sync(Arc<SyncService>),
+    Async(Arc<AsyncService>),
 }
 
 impl std::fmt::Debug for TestService {
@@ -600,5 +603,3 @@ impl TestService {
         }
     }
 }
-
-type AsyncResp = Box<dyn Future<Output = Response<HyperBody>> + Send + Sync>;

--- a/cli/tests/integration/common/backends.rs
+++ b/cli/tests/integration/common/backends.rs
@@ -272,8 +272,8 @@ impl TestBackendBuilder {
     ///
     /// Panics if:
     ///
-    /// * The `TestBackends` that created this builder no longer exists, or its test servers have
-    /// already been started
+    ///   * The `TestBackends` that created this builder no longer exists, or its test servers have
+    ///     already been started
     ///
     /// * The `path` does not parse as a valid `PathAndQuery`
     ///

--- a/cli/tests/integration/common/backends.rs
+++ b/cli/tests/integration/common/backends.rs
@@ -274,10 +274,8 @@ impl TestBackendBuilder {
     ///
     ///   * The `TestBackends` that created this builder no longer exists, or its test servers have
     ///     already been started
-    ///
-    /// * The `path` does not parse as a valid `PathAndQuery`
-    ///
-    /// * The `override_host` does not parse as a valid `HeaderValue`
+    ///   * The `path` does not parse as a valid `PathAndQuery`
+    ///   * The `override_host` does not parse as a valid `HeaderValue`
     pub async fn build(self) {
         let inner_arc = self.inner.upgrade().expect("TestBackends dropped");
         let path = self.path.parse().expect("invalid backend path");

--- a/cli/tests/integration/reusable_sessions.rs
+++ b/cli/tests/integration/reusable_sessions.rs
@@ -10,7 +10,6 @@ viceroy_test!(check_hostcalls_implemented, |is_component| {
         .via_hyper();
 
     let reqs = (0..5)
-        .into_iter()
         .map(|n| Request::post("/").body(n.to_string()).unwrap())
         .collect();
 
@@ -31,7 +30,6 @@ viceroy_test!(check_crash_causes_5xx, |is_component| {
         .via_hyper();
 
     let reqs = (0..5)
-        .into_iter()
         .map(|n| {
             let body = if n == 4 {
                 "crash!".to_owned()

--- a/src/acl.rs
+++ b/src/acl.rs
@@ -57,10 +57,10 @@ impl Acl {
     /// - and in case of a tie, the last entry wins.
     pub fn lookup(&self, ip: IpAddr) -> Option<&Entry> {
         self.entries.iter().fold(None, |acc, entry| {
-            if let Some(mask) = entry.prefix.is_match(ip) {
-                if acc.is_none_or(|prev_match: &Entry| mask >= prev_match.prefix.mask) {
-                    return Some(entry);
-                }
+            if let Some(mask) = entry.prefix.is_match(ip)
+                && acc.is_none_or(|prev_match: &Entry| mask >= prev_match.prefix.mask)
+            {
+                return Some(entry);
             }
             acc
         })

--- a/src/adapt.rs
+++ b/src/adapt.rs
@@ -87,7 +87,7 @@ pub fn adapt_bytes(bytes: &[u8]) -> anyhow::Result<Vec<u8>> {
 fn mangle_imports(bytes: &[u8]) -> anyhow::Result<wasm_encoder::Module> {
     let mut module = wasm_encoder::Module::new();
 
-    for payload in wasmparser::Parser::new(0).parse_all(&bytes) {
+    for payload in wasmparser::Parser::new(0).parse_all(bytes) {
         let payload = payload?;
         match payload {
             wasmparser::Payload::Version {
@@ -148,22 +148,19 @@ fn mangle_imports(bytes: &[u8]) -> anyhow::Result<wasm_encoder::Module> {
 
 /// Test whether `bytes` holds a wasm binary with an export named `wanted`.
 fn has_export(bytes: &[u8], wanted: &str) -> bool {
-    for payload in wasmparser::Parser::new(0).parse_all(&bytes) {
+    for payload in wasmparser::Parser::new(0).parse_all(bytes) {
         let Ok(payload) = payload else {
             return false;
         };
-        match payload {
-            wasmparser::Payload::ExportSection(section) => {
-                for export in section {
-                    let Ok(export) = export else {
-                        return false;
-                    };
-                    if export.name == wanted {
-                        return true;
-                    }
+        if let wasmparser::Payload::ExportSection(section) = payload {
+            for export in section {
+                let Ok(export) = export else {
+                    return false;
+                };
+                if export.name == wanted {
+                    return true;
                 }
             }
-            _ => {}
         }
     }
 
@@ -173,23 +170,19 @@ fn is_fastly_module(module: &str) -> bool {
     module.starts_with("fastly_") || module == "env" || module == "fastly" || module == "xqd"
 }
 fn has_wit_bindgen_imports(bytes: &[u8]) -> bool {
-    for payload in wasmparser::Parser::new(0).parse_all(&bytes) {
+    for payload in wasmparser::Parser::new(0).parse_all(bytes) {
         let Ok(payload) = payload else {
             return false;
         };
-        match payload {
-            wasmparser::Payload::ImportSection(section) => {
-                for import in section {
-                    let Ok(import) = import else {
-                        return false;
-                    };
-                    if !is_fastly_module(import.module) && import.module != "wasi_snapshot_preview1"
-                    {
-                        return true;
-                    }
+        if let wasmparser::Payload::ImportSection(section) = payload {
+            for import in section {
+                let Ok(import) = import else {
+                    return false;
+                };
+                if !is_fastly_module(import.module) && import.module != "wasi_snapshot_preview1" {
+                    return true;
                 }
             }
-            _ => {}
         }
     }
 

--- a/src/body.rs
+++ b/src/body.rs
@@ -188,6 +188,10 @@ impl Body {
 
         Some(len)
     }
+
+    pub fn is_empty(&self) -> Option<bool> {
+        self.len().map(|len| len == 0)
+    }
 }
 
 impl<T: Into<Chunk>> From<T> for Body {

--- a/src/body_tee.rs
+++ b/src/body_tee.rs
@@ -199,10 +199,10 @@ impl Drop for BodyTeeStream {
         state.consumers[self.id].active = false;
 
         let other_id = 1 - self.id;
-        if state.consumers[other_id].active {
-            if let Some(waker) = state.consumers[other_id].waker.take() {
-                waker.wake();
-            }
+        if state.consumers[other_id].active
+            && let Some(waker) = state.consumers[other_id].waker.take()
+        {
+            waker.wake();
         }
 
         drain_buffer(&mut state);

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -423,7 +423,7 @@ pub enum CacheOverride {
 
 impl CacheOverride {
     pub fn is_pass(&self) -> bool {
-        if let Self::Pass = self { true } else { false }
+        matches!(self, Self::Pass)
     }
 
     /// Convert from the representation suitable for passing across the ABI boundary.

--- a/src/cache/store.rs
+++ b/src/cache/store.rs
@@ -4,7 +4,6 @@ use crate::cache::{Error, variance::VaryRule};
 use bytes::Bytes;
 use std::{
     collections::{HashMap, VecDeque},
-    future::Future,
     sync::{Arc, atomic::AtomicBool},
     time::{Duration, Instant},
 };
@@ -235,8 +234,7 @@ impl CacheKeyObjects {
                 if let Some(fresh) = response_keyed_objects
                     .iter()
                     .filter_map(|(_, cache_value)| cache_value.present.as_ref())
-                    .filter(|cache_data| cache_data.meta.is_fresh())
-                    .next()
+                    .find(|cache_data| cache_data.meta.is_fresh())
                 {
                     data = Some(Arc::clone(fresh));
                     // Return without modifying anything.
@@ -245,15 +243,13 @@ impl CacheKeyObjects {
 
                 // If we have _stale but revalidatable_ entries, we can try to revalidate them
                 // instead.
-                if let Some((variant, revalidatable)) = response_keyed_objects
-                    .iter()
-                    .filter(|(_, cache_value)| {
+                if let Some((variant, revalidatable)) =
+                    response_keyed_objects.iter().find(|(_, cache_value)| {
                         cache_value
                             .present
                             .as_ref()
                             .is_some_and(|data| data.meta.is_usable())
                     })
-                    .next()
                 {
                     let d = revalidatable.present.as_ref().unwrap();
                     data = Some(Arc::clone(d));
@@ -272,7 +268,7 @@ impl CacheKeyObjects {
                     );
 
                     obligated = Some(Obligation {
-                        object: Arc::clone(&self),
+                        object: Arc::clone(self),
                         variant,
                         request_headers: request_headers.clone(),
                         completed: false,
@@ -308,7 +304,7 @@ impl CacheKeyObjects {
                 };
                 key_objects.objects.insert(response_key.clone(), pending);
                 obligated = Some(Obligation {
-                    object: Arc::clone(&self),
+                    object: Arc::clone(self),
                     variant: response_key,
                     request_headers: request_headers.clone(),
                     completed: false,
@@ -318,7 +314,7 @@ impl CacheKeyObjects {
                 // We have modified the table. In theory we don't need to issue a notification,
                 // since any task waiting would be waiting on the *completion* of an obligation
                 // rather than the fulfillment.
-                return false;
+                false
             });
 
             // Now outside of the lock: return what we have.
@@ -357,10 +353,10 @@ impl CacheKeyObjects {
         let result = Arc::clone(&object);
 
         self.0.send_modify(|cache_key_objects| {
-            if let Some(clear_obligation) = clear_obligation {
-                if let Some(v) = cache_key_objects.objects.get_mut(&clear_obligation) {
-                    v.obligated = false;
-                }
+            if let Some(clear_obligation) = clear_obligation
+                && let Some(v) = cache_key_objects.objects.get_mut(&clear_obligation)
+            {
+                v.obligated = false;
             }
 
             // Update the position of the vary rule: this is the most-recent-inserted, so keep it at the front.
@@ -543,11 +539,12 @@ impl Drop for Obligation {
         self.object.0.send_if_modified(|key_objects| {
             if let Some(v) = key_objects.objects.get_mut(&self.variant) {
                 v.obligated = false;
-                return true;
+                true
+            } else {
+                // Something odd happened -- our variant is no longer in the map.
+                // In this case, we didn't change anything, so avoid a spurious wakeup.
+                false
             }
-            // Something odd happened -- our variant is no longer in the map.
-            // In this case, we didn't change anything, so avoid a spurious wakeup.
-            return false;
         });
     }
 }
@@ -589,70 +586,68 @@ impl<'a> GetBodyBuilder<'a> {
     /// Access the body of this cached item.
     ///
     /// In some cases (streaming), the Future may not become ready until the first byte of output is available.
-    pub fn build(self) -> impl Future<Output = Result<Body, crate::Error>> + use<'a> {
-        async move {
-            // Early "return whole body" cases:
-            // "ignore requested range when length is unknown", the old default:
-            let ignore_requested_range =
-                !self.always_use_requested_range && self.cache_data.length().is_none();
-            // No requested range provided:
-            let no_range_provided = self.from.is_none() && self.to.is_none();
-            // Known length and invalid range:
-            let valid_range = match (self.cache_data.length(), self.from, self.to) {
-                (None, _, _) => true,
-                (Some(length), None, Some(to)) if !(1..=length).contains(&to) => false,
-                (Some(length), Some(from), _) if !(0..length).contains(&from) => false,
-                (Some(length), Some(from), Some(to)) if !(from..length).contains(&to) => false,
-                _ => true,
-            };
+    pub async fn build(self) -> Result<Body, crate::Error> {
+        // Early "return whole body" cases:
+        // "ignore requested range when length is unknown", the old default:
+        let ignore_requested_range =
+            !self.always_use_requested_range && self.cache_data.length().is_none();
+        // No requested range provided:
+        let no_range_provided = self.from.is_none() && self.to.is_none();
+        // Known length and invalid range:
+        let valid_range = match (self.cache_data.length(), self.from, self.to) {
+            (None, _, _) => true,
+            (Some(length), None, Some(to)) if !(1..=length).contains(&to) => false,
+            (Some(length), Some(from), _) if !(0..length).contains(&from) => false,
+            (Some(length), Some(from), Some(to)) if !(from..length).contains(&to) => false,
+            _ => true,
+        };
 
-            // In each of these cases, we return the body immediately,
-            // without waiting for any body to exist.
-            if ignore_requested_range || no_range_provided || !valid_range {
+        // In each of these cases, we return the body immediately,
+        // without waiting for any body to exist.
+        if ignore_requested_range || no_range_provided || !valid_range {
+            return self.cache_data.body.read();
+        }
+
+        // At least one of (start, end) is provided.
+
+        let (start, end) = if let (None, Some(end)) = (self.from, self.to) {
+            // We need to convert from "from the end" to "from the start".
+            // To do that, we need a known or expected length.
+            if self.cache_data.length().is_none() {
+                // We don't have an expected length; we have to wait for the end of input.
+                self.cache_data.body.known_length().await?;
+            }
+
+            let length = self
+                .cache_data
+                .length()
+                .expect("unknown length after waiting");
+            if end > length {
+                // Asked for more bytes than are available.
+                // In the case of an invalid range, Compute returns the entire body
+                // (as in HTTP).
                 return self.cache_data.body.read();
             }
+            // Convert to a (start, ...) sequence:
+            (Some(length - end), None)
+        } else {
+            (self.from, self.to)
+        };
 
-            // At least one of (start, end) is provided.
+        let start = start.unwrap_or(0);
 
-            let (start, end) = if let (None, Some(end)) = (self.from, self.to) {
-                // We need to convert from "from the end" to "from the start".
-                // To do that, we need a known or expected length.
-                if self.cache_data.length().is_none() {
-                    // We don't have an expected length; we have to wait for the end of input.
-                    self.cache_data.body.known_length().await?;
-                }
-
-                let length = self
-                    .cache_data
-                    .length()
-                    .expect("unknown length after waiting");
-                if end > length {
-                    // Asked for more bytes than are available.
-                    // In the case of an invalid range, Compute returns the entire body
-                    // (as in HTTP).
-                    return self.cache_data.body.read();
-                }
-                // Convert to a (start, ...) sequence:
-                (Some(length - end), None)
-            } else {
-                (self.from, self.to)
-            };
-
-            let start = start.unwrap_or(0);
-
-            // If the length is not known up-front,
-            // wait for the first byte to exist before returning a body.
-            // Yes, this only applies when the length is unknown.
-            if self.cache_data.length().is_none() {
-                self.cache_data.body.wait_length(start + 1).await?;
-            }
-
-            // Convert from inclusive bounds (GetBodyBuilder) to exclusive (read_range),
-            // and provide the body.
-            self.cache_data
-                .body
-                .read_range(start, end.map(|end| end + 1))
+        // If the length is not known up-front,
+        // wait for the first byte to exist before returning a body.
+        // Yes, this only applies when the length is unknown.
+        if self.cache_data.length().is_none() {
+            self.cache_data.body.wait_length(start + 1).await?;
         }
+
+        // Convert from inclusive bounds (GetBodyBuilder) to exclusive (read_range),
+        // and provide the body.
+        self.cache_data
+            .body
+            .read_range(start, end.map(|end| end + 1))
     }
 }
 
@@ -674,7 +669,7 @@ impl CacheData {
 
     /// Return the length of this object, if the final or expected length is known.
     pub fn length(&self) -> Option<u64> {
-        self.body.length().or_else(|| self.meta.length)
+        self.body.length().or(self.meta.length)
     }
 }
 

--- a/src/collecting_body.rs
+++ b/src/collecting_body.rs
@@ -270,13 +270,13 @@ impl CollectingBody {
                     }
 
                     // Did the body terminate before our "end" offset?
-                    if let Some(end) = end {
-                        if cursor < end {
-                            // Reached the end-of-input without getting the offset we wanted.
-                            // This should be an "unfinished streaming body" error;
-                            // so, return without "finish"ing.
-                            return;
-                        }
+                    if let Some(end) = end
+                        && cursor < end
+                    {
+                        // Reached the end-of-input without getting the offset we wanted.
+                        // This should be an "unfinished streaming body" error;
+                        // so, return without "finish"ing.
+                        return;
                     }
 
                     // We don't wait for the channel to be closed;

--- a/src/component/compute/error.rs
+++ b/src/component/compute/error.rs
@@ -106,7 +106,7 @@ impl From<wiggle::GuestError> for types::Error {
             | InvalidFlagValue { .. }
             | InvalidEnumValue { .. }
             | PtrOutOfBounds { .. }
-            | PtrOverflow { .. }
+            | PtrOverflow
             | InvalidUtf8 { .. }
             | TryFromIntError { .. } => types::Error::InvalidArgument,
             // These errors indicate either a pathological user input or an internal programming
@@ -146,9 +146,7 @@ impl From<KvStoreError> for types::Error {
 
 impl From<ResourceTableError> for types::Error {
     fn from(err: ResourceTableError) -> Self {
-        match err {
-            _ => panic!("{}", err),
-        }
+        panic!("{}", err)
     }
 }
 

--- a/src/component/compute/headers.rs
+++ b/src/component/compute/headers.rs
@@ -129,5 +129,5 @@ pub fn get_values(
     }
 
     let values = headers.get_all(HeaderName::try_from(name)?);
-    Ok(write_values(values.into_iter(), b'\0', max_len, cursor)?)
+    write_values(values.into_iter(), b'\0', max_len, cursor)
 }

--- a/src/component/compute/http_body.rs
+++ b/src/component/compute/http_body.rs
@@ -102,8 +102,7 @@ impl http_body::Host for ComponentCtx {
         // only normal bodies (not streaming bodies) can be read from
         let body = self.session_mut().body_mut(h)?;
 
-        let mut buffer = Vec::new();
-        buffer.resize(chunk_size as usize, 0u8);
+        let mut buffer = vec![0; chunk_size as usize];
         let len = body.read(&mut buffer).await?;
         buffer.truncate(len);
         Ok(buffer)

--- a/src/component/compute/http_downstream.rs
+++ b/src/component/compute/http_downstream.rs
@@ -42,20 +42,20 @@ impl http_downstream::Host for ComponentCtx {
         &mut self,
         h: Resource<http_req::Request>,
     ) -> Option<types::IpAddress> {
-        match self.session().downstream_client_ip(h.into()).ok()? {
-            None => None,
-            Some(ip) => Some(ip.into()),
-        }
+        self.session()
+            .downstream_client_ip(h.into())
+            .ok()?
+            .map(|ip| ip.into())
     }
 
     fn downstream_server_ip_addr(
         &mut self,
         h: Resource<http_req::Request>,
     ) -> Option<types::IpAddress> {
-        match self.session().downstream_server_ip(h.into()).ok()? {
-            None => None,
-            Some(ip) => Some(ip.into()),
-        }
+        self.session()
+            .downstream_server_ip(h.into())
+            .ok()?
+            .map(|ip| ip.into())
     }
 
     fn downstream_client_ddos_detected(

--- a/src/component/compute/http_req.rs
+++ b/src/component/compute/http_req.rs
@@ -400,7 +400,7 @@ impl http_req::HostRequest for ComponentCtx {
         backend: Resource<String>,
     ) -> Result<(), types::Error> {
         let backend = self.wasi_table.get(&backend).unwrap();
-        crate::component::http_req::redirect_to_websocket_proxy(&mut self.session, handle, &backend)
+        crate::component::http_req::redirect_to_websocket_proxy(&mut self.session, handle, backend)
     }
 
     fn set_framing_headers_mode(
@@ -440,7 +440,7 @@ impl http_req::HostRequest for ComponentCtx {
         backend: Resource<String>,
     ) -> Result<(), types::Error> {
         let backend = self.wasi_table.get(&backend).unwrap();
-        crate::component::http_req::redirect_to_grip_proxy(&mut self.session, req_handle, &backend)
+        crate::component::http_req::redirect_to_grip_proxy(&mut self.session, req_handle, backend)
     }
 
     fn drop(&mut self, _request: Resource<http_req::Request>) -> wasmtime::Result<()> {

--- a/src/component/compute/http_resp.rs
+++ b/src/component/compute/http_resp.rs
@@ -2,7 +2,7 @@ use {
     crate::{
         component::{
             bindings::fastly::compute::{http_body, http_resp, http_types, types},
-            compute::headers::{get_names, get_values},
+            compute::headers::get_names,
         },
         error::Error,
         linking::{ComponentCtx, SessionView},
@@ -14,6 +14,11 @@ use {
     hyper::http::response::Response,
     wasmtime::component::Resource,
 };
+
+// This is not used in the test-fatalerror-config configuration, so that configuration produces a
+// complaint if it is unnecessarily used.
+#[cfg(not(feature = "test-fatalerror-config"))]
+use crate::component::compute::headers::get_values;
 
 const MAX_HEADER_NAME_LEN: usize = (1 << 16) - 1;
 

--- a/src/component/compute/kv_store.rs
+++ b/src/component/compute/kv_store.rs
@@ -237,11 +237,9 @@ impl kv_store::HostStore for ComponentCtx {
         let meta = options.metadata;
         let igm = options.if_generation_match;
 
-        let ttl = if let Some(time_to_live_sec) = options.time_to_live_sec {
-            Some(std::time::Duration::from_secs(time_to_live_sec as u64))
-        } else {
-            None
-        };
+        let ttl = options
+            .time_to_live_sec
+            .map(|time_to_live_sec| std::time::Duration::from_secs(time_to_live_sec as u64));
 
         let fut = futures::future::ok(self.session.kv_insert(
             store.clone(),

--- a/src/component/erl.rs
+++ b/src/component/erl.rs
@@ -1,5 +1,6 @@
 use {crate::component::bindings::fastly::compute::types, crate::session::Session};
 
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn check_rate(
     _session: &mut Session,
     _rc: &str,

--- a/src/component/shielding.rs
+++ b/src/component/shielding.rs
@@ -15,7 +15,7 @@ pub(crate) fn backend_for_shield(
 ) -> Result<String, types::Error> {
     let shield_uri = name;
 
-    let Ok(uri) = Uri::from_str(&shield_uri) else {
+    let Ok(uri) = Uri::from_str(shield_uri) else {
         return Err(Error::InvalidArgument.into());
     };
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -209,13 +209,13 @@ impl TryInto<FastlyConfig> for TomlFastlyConfig {
             local_server,
         } = self;
 
-        if let Some(manifest_version) = manifest_version {
-            if manifest_version > MAX_MANIFEST_VERSION {
-                return Err(FastlyConfigError::UnsupportedManifestVersion(
-                    manifest_version,
-                    MAX_MANIFEST_VERSION,
-                ));
-            }
+        if let Some(manifest_version) = manifest_version
+            && manifest_version > MAX_MANIFEST_VERSION
+        {
+            return Err(FastlyConfigError::UnsupportedManifestVersion(
+                manifest_version,
+                MAX_MANIFEST_VERSION,
+            ));
         }
 
         let local_server = local_server

--- a/src/config/device_detection.rs
+++ b/src/config/device_detection.rs
@@ -89,7 +89,7 @@ mod deserialization {
         fn convert_value_to_json(value: Value) -> Option<SerdeValue> {
             match value {
                 Value::String(value) => Some(SerdeValue::String(value)),
-                Value::Integer(value) => Number::try_from(value).ok().map(SerdeValue::Number),
+                Value::Integer(value) => Some(SerdeValue::Number(Number::from(value))),
                 Value::Float(value) => Number::from_f64(value).map(SerdeValue::Number),
                 Value::Boolean(value) => Some(SerdeValue::Bool(value)),
                 Value::Table(value) => {
@@ -252,8 +252,11 @@ impl DeviceDetectionData {
     }
 }
 
-impl ToString for DeviceDetectionData {
-    fn to_string(&self) -> String {
-        serde_json::to_string(&self.data).unwrap_or_else(|_| "".to_string())
+impl std::fmt::Display for DeviceDetectionData {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match serde_json::to_string(&self.data) {
+            Ok(s) => write!(f, "{}", s),
+            Err(_) => Ok(()),
+        }
     }
 }

--- a/src/config/device_detection.rs
+++ b/src/config/device_detection.rs
@@ -9,8 +9,9 @@ pub struct DeviceDetection {
     mapping: DeviceDetectionMapping,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub enum DeviceDetectionMapping {
+    #[default]
     Empty,
     InlineToml {
         user_agents: HashMap<String, DeviceDetectionData>,
@@ -155,12 +156,6 @@ mod deserialization {
         DeviceDetectionMapping::read_json_contents(&file)?;
 
         Ok(DeviceDetectionMapping::Json { file })
-    }
-}
-
-impl Default for DeviceDetectionMapping {
-    fn default() -> Self {
-        Self::Empty
     }
 }
 

--- a/src/config/geolocation.rs
+++ b/src/config/geolocation.rs
@@ -13,8 +13,9 @@ pub struct Geolocation {
     use_default_loopback: bool,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub enum GeolocationMapping {
+    #[default]
     Empty,
     InlineToml {
         addresses: HashMap<IpAddr, GeolocationData>,
@@ -178,12 +179,6 @@ mod deserialization {
         GeolocationMapping::read_json_contents(&file)?;
 
         Ok(GeolocationMapping::Json { file })
-    }
-}
-
-impl Default for GeolocationMapping {
-    fn default() -> Self {
-        Self::Empty
     }
 }
 

--- a/src/config/geolocation.rs
+++ b/src/config/geolocation.rs
@@ -119,7 +119,7 @@ mod deserialization {
         fn convert_value_to_json(value: Value) -> Option<SerdeValue> {
             match value {
                 Value::String(value) => Some(SerdeValue::String(value)),
-                Value::Integer(value) => Number::try_from(value).ok().map(SerdeValue::Number),
+                Value::Integer(value) => Some(SerdeValue::Number(Number::from(value))),
                 Value::Float(value) => Number::from_f64(value).map(SerdeValue::Number),
                 Value::Boolean(value) => Some(SerdeValue::Bool(value)),
                 _ => None,
@@ -302,8 +302,11 @@ impl GeolocationData {
     }
 }
 
-impl ToString for GeolocationData {
-    fn to_string(&self) -> String {
-        serde_json::to_string(&self.data).unwrap_or_else(|_| "".to_string())
+impl std::fmt::Display for GeolocationData {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match serde_json::to_string(&self.data) {
+            Ok(s) => write!(f, "{}", s),
+            Err(_) => Ok(()),
+        }
     }
 }

--- a/src/config/secret_store.rs
+++ b/src/config/secret_store.rs
@@ -45,7 +45,7 @@ impl TryFrom<Table> for SecretStoreConfig {
                         });
                     }
 
-                    let json = read_json_contents(&file_path).map_err(|e| {
+                    let json = read_json_contents(file_path).map_err(|e| {
                         FastlyConfigError::InvalidSecretStoreDefinition {
                             name: store_name.to_string(),
                             err: e,
@@ -134,12 +134,12 @@ impl TryFrom<Table> for SecretStoreConfig {
                                     err: SecretStoreConfigError::FileNotAString(key.to_string()),
                                 }
                             })?;
-                            fs::read(path)
-                                .map_err(|e| FastlyConfigError::InvalidSecretStoreDefinition {
+                            fs::read(path).map_err(|e| {
+                                FastlyConfigError::InvalidSecretStoreDefinition {
                                     name: store_name.to_string(),
                                     err: SecretStoreConfigError::IoError(e),
-                                })?
-                                .into()
+                                }
+                            })?
                         } else if let Some(data) = data {
                             data.as_str()
                                 .ok_or_else(|| FastlyConfigError::InvalidSecretStoreDefinition {

--- a/src/error.rs
+++ b/src/error.rs
@@ -241,7 +241,7 @@ impl Error {
             InvalidFlagValue { .. }
             | InvalidEnumValue { .. }
             | PtrOutOfBounds { .. }
-            | PtrOverflow { .. }
+            | PtrOverflow
             | InvalidUtf8 { .. }
             | TryFromIntError { .. } => FastlyStatus::Inval,
             // These errors indicate either a pathological user input or an internal programming

--- a/src/execute.rs
+++ b/src/execute.rs
@@ -86,11 +86,11 @@ pub struct GuestProfileConfig {
     pub sample_period: Duration,
 }
 
-pub struct NextRequest(Option<(DownstreamRequest, Arc<ExecuteCtx>)>);
+pub struct NextRequest(Option<(Box<DownstreamRequest>, Arc<ExecuteCtx>)>);
 
 impl NextRequest {
     pub fn into_request(mut self) -> Option<DownstreamRequest> {
-        self.0.take().map(|(r, _)| r)
+        self.0.take().map(|(r, _)| *r)
     }
 }
 
@@ -109,7 +109,7 @@ impl Drop for NextRequest {
             return;
         };
 
-        ctx.retry_request(req);
+        ctx.retry_request(*req);
     }
 }
 
@@ -548,7 +548,7 @@ impl ExecuteCtx {
             metadata,
         };
 
-        let mut next_req = NextRequest(Some((downstream, self.clone())));
+        let mut next_req = NextRequest(Some((Box::new(downstream), self.clone())));
         let mut reusable = self.pending_reuse.lock().await;
 
         while let Some(pending) = reusable.pop() {

--- a/src/execute.rs
+++ b/src/execute.rs
@@ -312,7 +312,7 @@ impl ExecuteCtx {
             fake_valid_fastly_keys: FakeValidFastlyKeys::new(),
             epoch_increment_thread,
             epoch_increment_stop,
-            guest_profile_config: guest_profile_config.map(|c| Arc::new(c)),
+            guest_profile_config: guest_profile_config.map(Arc::new),
             cache: Arc::new(Cache::default()),
             pending_reuse: Arc::new(AsyncMutex::new(vec![])),
         };

--- a/src/linking.rs
+++ b/src/linking.rs
@@ -305,7 +305,7 @@ fn make_wasi_ctx(ctx: &ExecuteCtx, session: &Session) -> wasmtime_wasi::WasiCtxB
         // ...which is not the staging environment
         .env("FASTLY_IS_STAGING", "0")
         // request IDs start at 0 and increment, rather than being UUIDs, for ease of testing
-        .env("FASTLY_TRACE_ID", &format!("{:032x}", session.session_id()));
+        .env("FASTLY_TRACE_ID", format!("{:032x}", session.session_id()));
 
     if ctx.log_stdout() {
         wasi_ctx.stdout(LogEndpoint::new(b"stdout", ctx.capture_logs()));

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -115,7 +115,7 @@ impl AsyncWrite for LogEndpoint {
         _cx: &mut Context<'_>,
         buf: &[u8],
     ) -> Poll<Result<usize, std::io::Error>> {
-        self.write_entry(&buf)?;
+        self.write_entry(buf)?;
         Poll::Ready(Ok(buf.len()))
     }
 

--- a/src/object_store.rs
+++ b/src/object_store.rs
@@ -55,11 +55,11 @@ impl ObjectStores {
                 Some(val) => {
                     res = Ok(Some(val.clone()));
                     // manages ttl
-                    if let Some(exp) = val.expiration {
-                        if SystemTime::now() >= exp {
-                            store.remove(&obj_key);
-                            res = Ok(None);
-                        }
+                    if let Some(exp) = val.expiration
+                        && SystemTime::now() >= exp
+                    {
+                        store.remove(&obj_key);
+                        res = Ok(None);
                     }
                 }
                 None => {
@@ -84,6 +84,7 @@ impl ObjectStores {
         Ok(())
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn insert(
         &self,
         obj_store_key: ObjectStoreKey,
@@ -99,12 +100,11 @@ impl ObjectStores {
             .lookup(obj_store_key.clone(), obj_key.clone())
             .map_err(|_| KvStoreError::InternalError)?;
 
-        if let Some(g) = generation {
-            if let Some(val) = &existing {
-                if val.generation != g {
-                    return Err(KvStoreError::PreconditionFailed);
-                }
-            }
+        if let Some(g) = generation
+            && let Some(val) = &existing
+            && val.generation != g
+        {
+            return Err(KvStoreError::PreconditionFailed);
         }
 
         let out_obj = match mode {
@@ -198,10 +198,10 @@ impl ObjectStores {
                 // 404 if the key doesn't exist, otherwise delete
                 Some(val) => {
                     // manages ttl
-                    if let Some(exp) = val.expiration {
-                        if SystemTime::now() >= exp {
-                            res = Ok(false);
-                        }
+                    if let Some(exp) = val.expiration
+                        && SystemTime::now() >= exp
+                    {
+                        res = Ok(false);
                     }
                     store.remove(&obj_key);
                 }
@@ -243,12 +243,11 @@ impl ObjectStores {
                 let ttl_list = store.iter_mut().map(|(k, _)| k.clone()).collect::<Vec<_>>();
                 ttl_list.into_iter().for_each(|k| {
                     let val = store.get(&k);
-                    if let Some(v) = val {
-                        if let Some(exp) = v.expiration {
-                            if SystemTime::now() >= exp {
-                                store.remove(&k);
-                            }
-                        }
+                    if let Some(v) = val
+                        && let Some(exp) = v.expiration
+                        && SystemTime::now() >= exp
+                    {
+                        store.remove(&k);
                     }
                 });
 
@@ -426,7 +425,7 @@ impl From<&KvStoreError> for FastlyStatus {
 ///   * Keys cannot use Unicode characters 0 through 32, 65534 and 65535 as
 ///     single-character key names.  (0x0 through 0x20, 0xFFFE and 0xFFFF)
 fn is_valid_key(key: &str) -> Result<(), KeyValidationError> {
-    let len = key.as_bytes().len();
+    let len = key.len();
     if len < 1 {
         return Err(KeyValidationError::EmptyKey);
     } else if len > 1024 {

--- a/src/service.rs
+++ b/src/service.rs
@@ -121,11 +121,12 @@ impl RequestService {
     }
 }
 
+type ServiceFuture = dyn Future<Output = Result<Response<Body>, Error>> + Send;
+
 impl Service<Request<hyper::Body>> for RequestService {
     type Response = Response<Body>;
     type Error = Error;
-    #[allow(clippy::type_complexity)]
-    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+    type Future = Pin<Box<ServiceFuture>>;
 
     fn poll_ready(&mut self, _cx: &mut task::Context<'_>) -> Poll<Result<(), Self::Error>> {
         Poll::Ready(Ok(()))

--- a/src/session.rs
+++ b/src/session.rs
@@ -1365,7 +1365,7 @@ impl Session {
     /// rely on implementation details that may change over time.
     pub fn get_heap_usage_mib(&self) -> u32 {
         const MEBIBYTE: usize = 1024 * 1024;
-        let mb = self.limiter.memory_allocated.next_multiple_of(MEBIBYTE) / MEBIBYTE;
+        let mb = self.limiter.memory_allocated.div_ceil(MEBIBYTE);
         mb.try_into().unwrap_or(u32::MAX)
     }
 

--- a/src/session.rs
+++ b/src/session.rs
@@ -731,6 +731,7 @@ impl Session {
         self.kv_store_by_name.get(handle)
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn kv_insert(
         &self,
         obj_store_key: ObjectStoreKey,

--- a/src/session/async_item.rs
+++ b/src/session/async_item.rs
@@ -61,6 +61,7 @@ impl PendingKvListTask {
 ///
 /// The `try_recv()` method can be used to make sure that we safely recover
 /// any pending requests that are sent to us without dropping them.
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug)]
 pub enum PendingDownstreamReqTask {
     Complete(Result<Option<NextRequest>, Error>),
@@ -148,6 +149,7 @@ impl PendingCacheTask {
 ///
 /// This enum is needed because we reuse the handle for a body when it is transformed into a streaming
 /// body (writeable only). It is used within the body handle map in `Session`.
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug)]
 pub enum AsyncItem {
     Body(Body),

--- a/src/session/async_item.rs
+++ b/src/session/async_item.rs
@@ -61,7 +61,6 @@ impl PendingKvListTask {
 ///
 /// The `try_recv()` method can be used to make sure that we safely recover
 /// any pending requests that are sent to us without dropping them.
-#[allow(clippy::large_enum_variant)]
 #[derive(Debug)]
 pub enum PendingDownstreamReqTask {
     Complete(Result<Option<NextRequest>, Error>),
@@ -149,7 +148,6 @@ impl PendingCacheTask {
 ///
 /// This enum is needed because we reuse the handle for a body when it is transformed into a streaming
 /// body (writeable only). It is used within the body handle map in `Session`.
-#[allow(clippy::large_enum_variant)]
 #[derive(Debug)]
 pub enum AsyncItem {
     Body(Body),

--- a/src/shielding_site.rs
+++ b/src/shielding_site.rs
@@ -147,22 +147,16 @@ impl ShieldingSites {
     }
 
     pub fn get_encrypted<S: AsRef<str>>(&self, name: S) -> Option<Url> {
-        self.sites
-            .get(name.as_ref())
-            .map(|x| match x {
-                ShieldingSite::Local => None,
-                ShieldingSite::Remote { encrypted, .. } => Some(encrypted.clone()),
-            })
-            .flatten()
+        self.sites.get(name.as_ref()).and_then(|x| match x {
+            ShieldingSite::Local => None,
+            ShieldingSite::Remote { encrypted, .. } => Some(encrypted.clone()),
+        })
     }
 
     pub fn get_unencrypted<S: AsRef<str>>(&self, name: S) -> Option<Url> {
-        self.sites
-            .get(name.as_ref())
-            .map(|x| match x {
-                ShieldingSite::Local => None,
-                ShieldingSite::Remote { unencrypted, .. } => Some(unencrypted.clone()),
-            })
-            .flatten()
+        self.sites.get(name.as_ref()).and_then(|x| match x {
+            ShieldingSite::Local => None,
+            ShieldingSite::Remote { unencrypted, .. } => Some(unencrypted.clone()),
+        })
     }
 }

--- a/src/shift_mem.rs
+++ b/src/shift_mem.rs
@@ -25,7 +25,7 @@ fn shift_func(r#gen: &mut ModuleLocals, func: &mut LocalFunction) {
         let mut instrs = Vec::with_capacity(seq.len());
         for (instr, loc) in seq.instrs.iter() {
             let instr = instr.clone();
-            let loc = loc.clone();
+            let loc = *loc;
             match instr {
                 Instr::Block(Block { seq }) | Instr::Loop(Loop { seq }) => {
                     stack.push(seq);
@@ -212,7 +212,7 @@ pub fn shift_main_module(bytes: &[u8]) -> anyhow::Result<Vec<u8>> {
                 };
             }
             DataKind::Active { .. } => unreachable!(),
-            DataKind::Passive { .. } => {}
+            DataKind::Passive => {}
         }
     }
     // shift memory access

--- a/src/upstream.rs
+++ b/src/upstream.rs
@@ -106,8 +106,8 @@ pub enum Connection {
 impl Connection {
     fn metadata(&self) -> &ConnMetadata {
         match self {
-            Connection::Http(_, md) => &md,
-            Connection::Https(_, md) => &md,
+            Connection::Http(_, md) => md,
+            Connection::Https(_, md) => md,
         }
     }
 }
@@ -395,7 +395,6 @@ pub fn send_request(
 }
 
 /// The type ultimately yielded by a `PendingRequest`.
-
 /// An asynchronous request awaiting a response.
 #[allow(unused)]
 #[derive(Debug)]

--- a/src/wiggle_abi/acl.rs
+++ b/src/wiggle_abi/acl.rs
@@ -17,8 +17,10 @@ impl fastly_acl::FastlyAcl for Session {
     /// Perform an ACL lookup operation using the given ACL handle.
     ///
     /// There are two levels of errors returned by this function:
+    ///
     ///   - Error: These are general hostcall errors, e.g. handle not found.
     ///   - AclError: There are ACL-specific errors, e.g. 'no content'.
+    ///
     /// It's the callers responsibility to check both errors.
     async fn lookup(
         &mut self,

--- a/src/wiggle_abi/backend_impl.rs
+++ b/src/wiggle_abi/backend_impl.rs
@@ -8,7 +8,7 @@ fn lookup_backend_definition<'sess>(
 ) -> Result<&'sess Backend, Error> {
     let name = memory.as_str(backend)?.ok_or(Error::SharedMemory)?;
     session
-        .backend(&name)
+        .backend(name)
         .map(AsRef::as_ref)
         .ok_or(Error::InvalidArgument)
 }
@@ -43,9 +43,9 @@ impl FastlyBackend for Session {
     ) -> Result<super::types::IsDynamic, Error> {
         let name = memory.as_str(backend)?.ok_or(Error::SharedMemory)?;
 
-        if self.dynamic_backend(&name).is_some() {
+        if self.dynamic_backend(name).is_some() {
             Ok(1)
-        } else if self.backend(&name).is_some() {
+        } else if self.backend(name).is_some() {
             Ok(0)
         } else {
             Err(Error::InvalidArgument)

--- a/src/wiggle_abi/cache.rs
+++ b/src/wiggle_abi/cache.rs
@@ -55,7 +55,7 @@ fn load_write_options(
     let vary_rule = if options_mask.contains(CacheWriteOptionsMask::VARY_RULE) {
         let slice = options.vary_rule_ptr.as_array(options.vary_rule_len);
         let vary_rule_bytes = memory.as_slice(slice)?.ok_or(Error::SharedMemory)?;
-        let vary_rule_str = str::from_utf8(vary_rule_bytes).map_err(|e| Error::Utf8Expected(e))?;
+        let vary_rule_str = str::from_utf8(vary_rule_bytes).map_err(Error::Utf8Expected)?;
         vary_rule_str.parse()?
     } else {
         VaryRule::default()
@@ -189,7 +189,7 @@ impl FastlyCache for Session {
         let LookupOptions {
             headers,
             always_use_requested_range,
-        } = load_lookup_options(&self, memory, options_mask, options)?;
+        } = load_lookup_options(self, memory, options_mask, options)?;
         let key = load_cache_key(memory, cache_key)?;
         let cache = Arc::clone(self.cache());
 
@@ -350,7 +350,7 @@ impl FastlyCache for Session {
         let LookupOptions {
             headers,
             always_use_requested_range,
-        } = load_lookup_options(&self, memory, options_mask, options)?;
+        } = load_lookup_options(self, memory, options_mask, options)?;
         let key = load_cache_key(memory, cache_key)?;
         let cache = Arc::clone(self.cache());
 
@@ -465,11 +465,11 @@ impl FastlyCache for Session {
         memory: &mut wiggle::GuestMemory<'_>,
         handle: types::CacheHandle,
     ) -> Result<(), Error> {
-        let entry = self.cache_entry_mut(handle.into()).await?;
+        let entry = self.cache_entry_mut(handle).await?;
         if entry.cancel() {
             Ok(())
         } else {
-            Err(Error::CacheError(crate::cache::Error::CannotWrite).into())
+            Err(Error::CacheError(crate::cache::Error::CannotWrite))
         }
     }
 
@@ -528,7 +528,7 @@ impl FastlyCache for Session {
         user_metadata_out_len: u32,
         nwritten_out: wiggle::GuestPtr<u32>,
     ) -> Result<(), Error> {
-        let entry = self.cache_entry(handle.into()).await?;
+        let entry = self.cache_entry(handle).await?;
 
         let md_bytes = entry
             .found()
@@ -575,7 +575,7 @@ impl FastlyCache for Session {
         options_mask &= !types::CacheGetBodyOptionsMask::TO;
 
         if !options_mask.is_empty() {
-            return Err(Error::NotAvailable("unknown cache get_body option").into());
+            return Err(Error::NotAvailable("unknown cache get_body option"));
         }
 
         // We wind up re-borrowing `found` and `self.session` several times here, to avoid
@@ -586,7 +586,7 @@ impl FastlyCache for Session {
         // We have an exclusive borrow &mut self.session for the lifetime of this call,
         // so even though we're re-borrowing/repeating lookups, we know we won't run into TOCTOU.
 
-        let entry = self.cache_entry(handle.into()).await?;
+        let entry = self.cache_entry(handle).await?;
 
         // Preemptively (optimistically) start a read. Don't worry, the Drop impl for Body will
         // clean up the copying task.
@@ -608,13 +608,13 @@ impl FastlyCache for Session {
         let body_handle = self.insert_body(body);
         // Finalize by committing the handle as "the last read".
         // We have to borrow `found` again, this time as mutable.
-        self.cache_entry_mut(handle.into())
+        self.cache_entry_mut(handle)
             .await?
             .found_mut()
             .unwrap()
-            .last_body_handle = Some(body_handle.into());
+            .last_body_handle = Some(body_handle);
 
-        Ok(body_handle.into())
+        Ok(body_handle)
     }
 
     async fn get_length(
@@ -623,7 +623,7 @@ impl FastlyCache for Session {
         handle: types::CacheHandle,
     ) -> Result<types::CacheObjectLength, Error> {
         let found = self
-            .cache_entry(handle.into())
+            .cache_entry(handle)
             .await?
             .found()
             .ok_or(Error::CacheError(crate::cache::Error::Missing))?;

--- a/src/wiggle_abi/device_detection_impl.rs
+++ b/src/wiggle_abi/device_detection_impl.rs
@@ -35,7 +35,7 @@ impl FastlyDeviceDetection for Session {
             let user_agent_slice = memory
                 .as_slice(user_agent.as_bytes())?
                 .ok_or(Error::SharedMemory)?;
-            let user_agent_str = std::str::from_utf8(&user_agent_slice)?;
+            let user_agent_str = std::str::from_utf8(user_agent_slice)?;
 
             self.device_detection_lookup(user_agent_str)
                 .ok_or_else(|| {

--- a/src/wiggle_abi/entity.rs
+++ b/src/wiggle_abi/entity.rs
@@ -28,7 +28,7 @@ macro_rules! wiggle_entity {
         impl cranelift_entity::EntityRef for $entity {
             /// Create a new entity reference from a small integer.
             fn new(index: usize) -> Self {
-                debug_assert!(index < (std::u32::MAX as usize));
+                debug_assert!(index < (u32::MAX as usize));
                 (index as u32).into()
             }
             /// Get the index that was used to create this entity reference.

--- a/src/wiggle_abi/http_downstream.rs
+++ b/src/wiggle_abi/http_downstream.rs
@@ -303,7 +303,7 @@ impl FastlyHttpDownstream for Session {
         match u32::try_from(region_len) {
             Ok(region_len) if region_len <= region_max_len => {
                 memory.copy_from_slice(region.as_bytes(), region_out.as_array(region_len))?;
-                memory.write(nwritten_out, region_len.try_into().unwrap_or(0))?;
+                memory.write(nwritten_out, region_len)?;
 
                 Ok(())
             }

--- a/src/wiggle_abi/kv_store_impl.rs
+++ b/src/wiggle_abi/kv_store_impl.rs
@@ -31,8 +31,8 @@ impl FastlyKvStore for Session {
         name: GuestPtr<str>,
     ) -> Result<KvStoreHandle, Error> {
         let name = memory.as_str(name)?.ok_or(Error::SharedMemory)?;
-        if self.kv_store().store_exists(&name)? {
-            Ok(self.kv_store_handle(&name))
+        if self.kv_store().store_exists(name)? {
+            Ok(self.kv_store_handle(name))
         } else {
             Err(Error::ObjectStoreError(
                 ObjectStoreError::UnknownObjectStore(name.to_owned()),
@@ -382,7 +382,7 @@ impl FastlyKvStore for Session {
 
         match resp {
             Ok(value) => {
-                let body_handle = self.insert_body(value.into()).into();
+                let body_handle = self.insert_body(value.into());
 
                 memory.write(body_handle_out, body_handle)?;
 

--- a/src/wiggle_abi/log_impl.rs
+++ b/src/wiggle_abi/log_impl.rs
@@ -30,11 +30,11 @@ impl FastlyLog for Session {
     ) -> Result<EndpointHandle, Error> {
         let name = memory.as_slice(name)?.ok_or(Error::SharedMemory)?;
 
-        if is_reserved_endpoint(&name) {
+        if is_reserved_endpoint(name) {
             return Err(Error::InvalidArgument);
         }
 
-        Ok(self.log_endpoint_handle(&name))
+        Ok(self.log_endpoint_handle(name))
     }
 
     fn write(
@@ -48,7 +48,7 @@ impl FastlyLog for Session {
 
         // The log API is infallible, so if we get an error, warn about it
         // rather than bubbling it up through the log API.
-        match endpoint.write_entry(&msg) {
+        match endpoint.write_entry(msg) {
             Ok(()) => {}
             Err(err) => tracing::error!("Error writing log message: {:?}", err),
         }

--- a/src/wiggle_abi/req_impl.rs
+++ b/src/wiggle_abi/req_impl.rs
@@ -71,7 +71,7 @@ impl FastlyHttpReq for Session {
     ) -> Result<(), Error> {
         let sk = if sk.len() > 0 {
             let sk = memory.as_slice(sk)?.ok_or(Error::SharedMemory)?;
-            let sk = HeaderValue::from_bytes(&sk).map_err(|_| Error::InvalidArgument)?;
+            let sk = HeaderValue::from_bytes(sk).map_err(|_| Error::InvalidArgument)?;
             Some(sk)
         } else {
             None
@@ -461,7 +461,7 @@ impl FastlyHttpReq for Session {
                 let byte_slice = memory
                     .as_slice(config.ca_cert.as_array(config.ca_cert_len))?
                     .ok_or(Error::SharedMemory)?;
-                let mut byte_cursor = std::io::Cursor::new(&byte_slice[..]);
+                let mut byte_cursor = std::io::Cursor::new(byte_slice);
                 rustls_pemfile::certs(&mut byte_cursor)?
                     .drain(..)
                     .map(rustls::Certificate)
@@ -483,7 +483,7 @@ impl FastlyHttpReq for Session {
                 .as_slice(config.cert_hostname.as_array(config.cert_hostname_len))?
                 .ok_or(Error::SharedMemory)?;
 
-            Some(std::str::from_utf8(&byte_slice)?.to_owned())
+            Some(std::str::from_utf8(byte_slice)?.to_owned())
         } else {
             None
         };
@@ -497,7 +497,7 @@ impl FastlyHttpReq for Session {
                 let byte_slice = memory
                     .as_slice(config.sni_hostname.as_array(config.sni_hostname_len))?
                     .ok_or(Error::SharedMemory)?;
-                let sni_hostname = std::str::from_utf8(&byte_slice)?;
+                let sni_hostname = std::str::from_utf8(byte_slice)?;
                 if let Some(cert_host) = &cert_host {
                     if cert_host != sni_hostname {
                         // because we're using rustls, we cannot support distinct SNI and cert hostnames
@@ -545,7 +545,7 @@ impl FastlyHttpReq for Session {
                 SecretLookup::Injected { plaintext } => plaintext,
             };
 
-            Some(ClientCertInfo::new(&cert_slice, key)?)
+            Some(ClientCertInfo::new(cert_slice, key)?)
         } else {
             None
         };
@@ -807,7 +807,7 @@ impl FastlyHttpReq for Session {
     ) -> Result<(), Error> {
         let req = self.request_parts_mut(req_handle)?;
 
-        let version = hyper::Version::try_from(version)?;
+        let version = hyper::Version::from(version);
         req.version = version;
         Ok(())
     }
@@ -822,7 +822,7 @@ impl FastlyHttpReq for Session {
         let backend_bytes_slice = memory
             .as_slice(backend_bytes.as_bytes())?
             .ok_or(Error::SharedMemory)?;
-        let backend_name = std::str::from_utf8(&backend_bytes_slice)?;
+        let backend_name = std::str::from_utf8(backend_bytes_slice)?;
 
         // prepare the request
         let req_parts = self.take_request_parts(req_handle)?;
@@ -872,7 +872,7 @@ impl FastlyHttpReq for Session {
         let backend_bytes_slice = memory
             .as_slice(backend_bytes.as_bytes())?
             .ok_or(Error::SharedMemory)?;
-        let backend_name = std::str::from_utf8(&backend_bytes_slice)?;
+        let backend_name = std::str::from_utf8(backend_bytes_slice)?;
 
         // prepare the request
         let req_parts = self.take_request_parts(req_handle)?;
@@ -1181,7 +1181,7 @@ fn read_guest_ip(
     bytes: &GuestPtr<u8>,
     len: u32,
 ) -> Result<Option<IpAddr>, Error> {
-    let bytes = memory.as_slice(bytes.as_array(len as u32))?;
+    let bytes = memory.as_slice(bytes.as_array(len))?;
 
     match len {
         0 => Ok(None),

--- a/src/wiggle_abi/resp_impl.rs
+++ b/src/wiggle_abi/resp_impl.rs
@@ -145,7 +145,7 @@ impl FastlyHttpResp for Session {
     ) -> Result<(), Error> {
         let resp = self.response_parts_mut(resp_handle)?;
 
-        let version = hyper::Version::try_from(version)?;
+        let version = hyper::Version::from(version);
         resp.version = version;
         Ok(())
     }

--- a/src/wiggle_abi/secret_store_impl.rs
+++ b/src/wiggle_abi/secret_store_impl.rs
@@ -50,7 +50,7 @@ impl FastlySecretStore for Session {
         name: GuestPtr<str>,
     ) -> Result<SecretStoreHandle, Error> {
         let name = memory.as_str(name)?.ok_or(Error::SharedMemory)?;
-        self.secret_store_handle(&name)
+        self.secret_store_handle(name)
             .ok_or(Error::SecretStoreError(
                 SecretStoreError::UnknownSecretStore(name.to_string()),
             ))
@@ -68,7 +68,7 @@ impl FastlySecretStore for Session {
                     SecretStoreError::InvalidSecretStoreHandle(secret_store_handle),
                 ))?;
         let secret_name = memory.as_str(secret_name)?.ok_or(Error::SharedMemory)?;
-        self.secret_handle(store_name.as_str(), &secret_name)
+        self.secret_handle(store_name.as_str(), secret_name)
             .ok_or(Error::SecretStoreError(SecretStoreError::UnknownSecret(
                 secret_name.to_string(),
             )))


### PR DESCRIPTION
For as long as I can remember, `cargo clippy` has produced a huge amount of warnings in this project. This pull request resolves as many of those warnings as possible, with a few exceptions:

- Large size difference between enum variants
- Functions with too many arguments
- Complex type definition

I felt these were out of scope for a large sweeping change like this so I've annotated them to be ignored by clippy.

As a result, clippy output is now clean, and it can be added to the CI workflow to ensure new changes are checked for best practices.