### PR TITLE
Add `health` config parameter for backends to mock backend health status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Add stub implementations for resvpnproxy hostcalls.
 - Add `fake_valid_fastly_keys` config parameter to allow testing `fastly_key_is_valid` hostcall with fake valid keys. ([#599](https://github.com/fastly/Viceroy/pull/599))
+- Add `health` config parameter for backends to mock backend health status in testing. ([#605](https://github.com/fastly/Viceroy/pulls/606))
 
 ## 0.16.5 (2026-03-23)
 

--- a/cli/tests/integration/common/backends.rs
+++ b/cli/tests/integration/common/backends.rs
@@ -76,6 +76,7 @@ impl TestBackends {
                 grpc: false,
                 client_cert: None,
                 ca_certs: vec![],
+                health: viceroy_lib::config::BackendHealth::Unknown,
             };
             backends.insert(name.to_string(), Arc::new(backend_config));
         }

--- a/src/component/backend.rs
+++ b/src/component/backend.rs
@@ -144,6 +144,7 @@ pub(crate) async fn register_dynamic_backend(
         grpc,
         client_cert,
         ca_certs,
+        health: crate::config::BackendHealth::Unknown,
     };
 
     if !session.add_backend(name, new_backend) {
@@ -163,9 +164,12 @@ pub(crate) fn is_healthy(
     session: &mut Session,
     backend: &str,
 ) -> Result<backend::BackendHealth, types::Error> {
-    // just doing this to get a different error if the backend doesn't exist
-    let _ = session.backend(backend).ok_or(Error::InvalidArgument)?;
-    Ok(backend::BackendHealth::Unknown)
+    let backend = session.backend(backend).ok_or(Error::InvalidArgument)?;
+    match &backend.health {
+        crate::config::BackendHealth::Unknown => Ok(backend::BackendHealth::Unknown),
+        crate::config::BackendHealth::Healthy => Ok(backend::BackendHealth::Healthy),
+        crate::config::BackendHealth::Unhealthy => Ok(backend::BackendHealth::Unhealthy),
+    }
 }
 
 pub(crate) fn is_dynamic(session: &mut Session, backend: &str) -> Result<bool, types::Error> {

--- a/src/component/shielding.rs
+++ b/src/component/shielding.rs
@@ -28,6 +28,7 @@ pub(crate) fn backend_for_shield(
         grpc: false,
         client_cert: None,
         ca_certs: Vec::new(),
+        health: crate::config::BackendHealth::Unknown,
     };
 
     if !session.add_backend(&new_name, new_backend) {

--- a/src/config.rs
+++ b/src/config.rs
@@ -39,7 +39,7 @@ pub use crate::acl::Acls;
 /// Types and deserializers for backend configuration settings.
 mod backends;
 
-pub use self::backends::{Backend, ClientCertError, ClientCertInfo};
+pub use self::backends::{Backend, BackendHealth, ClientCertError, ClientCertInfo};
 
 pub type Backends = HashMap<String, Arc<Backend>>;
 

--- a/src/config/backends.rs
+++ b/src/config/backends.rs
@@ -7,6 +7,18 @@ use {
 
 pub use self::client_cert_info::{ClientCertError, ClientCertInfo};
 
+/// Backend health status for testing purposes.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub enum BackendHealth {
+    /// Health status is unknown (default).
+    #[default]
+    Unknown,
+    /// Backend is healthy.
+    Healthy,
+    /// Backend is unhealthy.
+    Unhealthy,
+}
+
 /// A single backend definition.
 #[derive(Clone, Debug)]
 pub struct Backend {
@@ -17,6 +29,7 @@ pub struct Backend {
     pub grpc: bool,
     pub client_cert: Option<ClientCertInfo>,
     pub ca_certs: Vec<rustls::Certificate>,
+    pub health: BackendHealth,
 }
 
 /// A map of [`Backend`] definitions, keyed by their name.
@@ -149,6 +162,25 @@ mod deserialization {
                 .transpose()?
                 .unwrap_or(false);
 
+            let health = toml
+                .remove("health")
+                .map(|health| match health {
+                    Value::String(health) => {
+                        let health_lower = health.to_lowercase();
+                        match health_lower.as_str() {
+                            "unknown" => Ok(super::BackendHealth::Unknown),
+                            "healthy" => Ok(super::BackendHealth::Healthy),
+                            "unhealthy" => Ok(super::BackendHealth::Unhealthy),
+                            _ => Err(BackendConfigError::InvalidHealthEntry(health)),
+                        }
+                    }
+                    _ => Err(BackendConfigError::InvalidHealthEntry(
+                        "not a string".to_string(),
+                    )),
+                })
+                .transpose()?
+                .unwrap_or_default();
+
             check_for_unrecognized_keys(&toml)?;
 
             Ok(Self {
@@ -159,6 +191,7 @@ mod deserialization {
                 client_cert,
                 grpc,
                 ca_certs,
+                health,
             })
         }
     }

--- a/src/config/unit_tests.rs
+++ b/src/config/unit_tests.rs
@@ -344,6 +344,76 @@ mod backend_config_tests {
             res => panic!("unexpected result: {:?}", res),
         }
     }
+
+    /// Check that backend health field accepts valid values.
+    #[test]
+    fn backend_configs_can_provide_health_status() {
+        let config_with_health = r#"
+            [backends]
+            [backends.healthy_backend]
+            url = "http://a.com"
+            health = "healthy"
+
+            [backends.unhealthy_backend]
+            url = "http://b.com"
+            health = "unhealthy"
+
+            [backends.unknown_backend]
+            url = "http://c.com"
+            health = "unknown"
+
+            [backends.default_backend]
+            url = "http://d.com"
+        "#;
+        let config = read_local_server_config(config_with_health)
+            .expect("can read backend config with health status");
+
+        let healthy = config.backends.0.get("healthy_backend").unwrap();
+        assert_eq!(healthy.health, crate::config::BackendHealth::Healthy);
+
+        let unhealthy = config.backends.0.get("unhealthy_backend").unwrap();
+        assert_eq!(unhealthy.health, crate::config::BackendHealth::Unhealthy);
+
+        let unknown = config.backends.0.get("unknown_backend").unwrap();
+        assert_eq!(unknown.health, crate::config::BackendHealth::Unknown);
+
+        let default = config.backends.0.get("default_backend").unwrap();
+        assert_eq!(default.health, crate::config::BackendHealth::Unknown);
+    }
+
+    /// Check that health field must have valid value.
+    #[test]
+    fn backend_configs_health_must_be_valid() {
+        use BackendConfigError::InvalidHealthEntry;
+        static BAD_HEALTH_FIELD: &str = r#"
+            [backends]
+            "shark" = { url = "http://a.com", health = "sick" }
+        "#;
+        match read_local_server_config(BAD_HEALTH_FIELD) {
+            Err(InvalidBackendDefinition {
+                err: InvalidHealthEntry(value),
+                ..
+            }) if value == "sick" => {}
+            res => panic!("unexpected result: {:?}", res),
+        }
+    }
+
+    /// Check that health field must be a string.
+    #[test]
+    fn backend_configs_health_must_be_string() {
+        use BackendConfigError::InvalidHealthEntry;
+        static BAD_HEALTH_FIELD: &str = r#"
+            [backends]
+            "shark" = { url = "http://a.com", health = true }
+        "#;
+        match read_local_server_config(BAD_HEALTH_FIELD) {
+            Err(InvalidBackendDefinition {
+                err: InvalidHealthEntry(_),
+                ..
+            }) => {}
+            res => panic!("unexpected result: {:?}", res),
+        }
+    }
 }
 
 /// Unit tests for dictionaries/config_stores in the `local_server` section of a `fastly.toml` package manifest.

--- a/src/error.rs
+++ b/src/error.rs
@@ -486,6 +486,11 @@ pub enum BackendConfigError {
     #[error("'grpc' field was not a boolean")]
     InvalidGrpcEntry,
 
+    #[error(
+        "'health' field has invalid value '{0}' (expected 'unknown', 'healthy', or 'unhealthy')"
+    )]
+    InvalidHealthEntry(String),
+
     #[error("invalid url: {0}")]
     InvalidUrl(#[from] http::uri::InvalidUri),
 

--- a/src/wiggle_abi/backend_impl.rs
+++ b/src/wiggle_abi/backend_impl.rs
@@ -31,9 +31,12 @@ impl FastlyBackend for Session {
         memory: &mut wiggle::GuestMemory<'_>,
         backend: wiggle::GuestPtr<str>,
     ) -> Result<super::types::BackendHealth, Error> {
-        // just doing this to get a different error if the backend doesn't exist
-        let _ = lookup_backend_definition(self, memory, backend)?;
-        Ok(super::types::BackendHealth::Unknown)
+        let backend = lookup_backend_definition(self, memory, backend)?;
+        match &backend.health {
+            crate::config::BackendHealth::Unknown => Ok(super::types::BackendHealth::Unknown),
+            crate::config::BackendHealth::Healthy => Ok(super::types::BackendHealth::Healthy),
+            crate::config::BackendHealth::Unhealthy => Ok(super::types::BackendHealth::Unhealthy),
+        }
     }
 
     fn is_dynamic(

--- a/src/wiggle_abi/req_impl.rs
+++ b/src/wiggle_abi/req_impl.rs
@@ -564,6 +564,7 @@ impl FastlyHttpReq for Session {
             grpc,
             client_cert,
             ca_certs,
+            health: crate::config::BackendHealth::Unknown,
         };
 
         if !self.add_backend(&name, new_backend) {

--- a/src/wiggle_abi/shielding.rs
+++ b/src/wiggle_abi/shielding.rs
@@ -95,6 +95,7 @@ impl fastly_shielding::FastlyShielding for Session {
             grpc: false,
             client_cert: None,
             ca_certs: Vec::new(),
+            health: crate::config::BackendHealth::Unknown,
         };
 
         if !self.add_backend(&new_name, new_backend) {


### PR DESCRIPTION
This pull request adds a `health` parameter to the backend config, allowing for testing of services that rely on health check data for routing logic. Closes #605.

```yaml
[backends]
[backends.healthy_backend]
url = "http://a.com"
health = "healthy"

[backends.unhealthy_backend]
url = "http://b.com"
health = "unhealthy"
```