### PR TITLE
Address Clippy lint on variant size by boxing in NextRequest

### DIFF
--- a/cli/tests/integration/common.rs
+++ b/cli/tests/integration/common.rs
@@ -520,12 +520,15 @@ impl Drop for TestServer {
         }
     }
 }
+type SyncService = dyn Fn(Request<Vec<u8>>) -> Response<Vec<u8>> + Send + Sync;
+
+type AsyncResp = Box<dyn Future<Output = Response<HyperBody>> + Send + Sync>;
+type AsyncService = dyn Fn(Request<HyperBody>) -> AsyncResp + Send + Sync;
 
 #[derive(Clone)]
-#[allow(clippy::type_complexity)]
 enum TestService {
-    Sync(Arc<dyn Fn(Request<Vec<u8>>) -> Response<Vec<u8>> + Send + Sync>),
-    Async(Arc<dyn Fn(Request<HyperBody>) -> AsyncResp + Send + Sync>),
+    Sync(Arc<SyncService>),
+    Async(Arc<AsyncService>),
 }
 
 impl std::fmt::Debug for TestService {
@@ -600,5 +603,3 @@ impl TestService {
         }
     }
 }
-
-type AsyncResp = Box<dyn Future<Output = Response<HyperBody>> + Send + Sync>;

--- a/src/component/compute/http_resp.rs
+++ b/src/component/compute/http_resp.rs
@@ -2,7 +2,7 @@ use {
     crate::{
         component::{
             bindings::fastly::compute::{http_body, http_resp, http_types, types},
-            compute::headers::{get_names, get_values},
+            compute::headers::get_names,
         },
         error::Error,
         linking::{ComponentCtx, SessionView},
@@ -14,6 +14,11 @@ use {
     hyper::http::response::Response,
     wasmtime::component::Resource,
 };
+
+// This is not used in the test-fatalerror-config configuration, so that configuration produces a
+// complaint if it is unnecessarily used.
+#[cfg(not(feature = "test-fatalerror-config"))]
+use crate::component::compute::headers::get_values;
 
 const MAX_HEADER_NAME_LEN: usize = (1 << 16) - 1;
 

--- a/src/execute.rs
+++ b/src/execute.rs
@@ -86,11 +86,11 @@ pub struct GuestProfileConfig {
     pub sample_period: Duration,
 }
 
-pub struct NextRequest(Option<(DownstreamRequest, Arc<ExecuteCtx>)>);
+pub struct NextRequest(Option<(Box<DownstreamRequest>, Arc<ExecuteCtx>)>);
 
 impl NextRequest {
     pub fn into_request(mut self) -> Option<DownstreamRequest> {
-        self.0.take().map(|(r, _)| r)
+        self.0.take().map(|(r, _)| *r)
     }
 }
 
@@ -109,7 +109,7 @@ impl Drop for NextRequest {
             return;
         };
 
-        ctx.retry_request(req);
+        ctx.retry_request(*req);
     }
 }
 
@@ -548,7 +548,7 @@ impl ExecuteCtx {
             metadata,
         };
 
-        let mut next_req = NextRequest(Some((downstream, self.clone())));
+        let mut next_req = NextRequest(Some((Box::new(downstream), self.clone())));
         let mut reusable = self.pending_reuse.lock().await;
 
         while let Some(pending) = reusable.pop() {

--- a/src/service.rs
+++ b/src/service.rs
@@ -121,11 +121,12 @@ impl RequestService {
     }
 }
 
+type ServiceFuture = dyn Future<Output = Result<Response<Body>, Error>> + Send;
+
 impl Service<Request<hyper::Body>> for RequestService {
     type Response = Response<Body>;
     type Error = Error;
-    #[allow(clippy::type_complexity)]
-    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+    type Future = Pin<Box<ServiceFuture>>;
 
     fn poll_ready(&mut self, _cx: &mut task::Context<'_>) -> Poll<Result<(), Self::Error>> {
         Poll::Ready(Ok(()))

--- a/src/session/async_item.rs
+++ b/src/session/async_item.rs
@@ -61,7 +61,6 @@ impl PendingKvListTask {
 ///
 /// The `try_recv()` method can be used to make sure that we safely recover
 /// any pending requests that are sent to us without dropping them.
-#[allow(clippy::large_enum_variant)]
 #[derive(Debug)]
 pub enum PendingDownstreamReqTask {
     Complete(Result<Option<NextRequest>, Error>),
@@ -149,7 +148,6 @@ impl PendingCacheTask {
 ///
 /// This enum is needed because we reuse the handle for a body when it is transformed into a streaming
 /// body (writeable only). It is used within the body handle map in `Session`.
-#[allow(clippy::large_enum_variant)]
 #[derive(Debug)]
 pub enum AsyncItem {
     Body(Body),


### PR DESCRIPTION
Instead of `allow`ing the variance in #603, fix it.
