### PR TITLE
fix: spelling typos in comments and error messages

### DIFF
--- a/src/cache/store.rs
+++ b/src/cache/store.rs
@@ -179,7 +179,7 @@ impl CacheKeyObjects {
                 for cache_value in response_values {
                     if let Some(data) = &cache_value.present {
                         if data.meta.is_fresh() {
-                            // We have fresh data; no need to generate an obligaton.
+                            // We have fresh data; no need to generate an obligation.
                             return (Some(Arc::clone(data)), None);
                         }
                         if data.meta.is_usable() && cache_value.obligated {
@@ -215,7 +215,7 @@ impl CacheKeyObjects {
             // being fulfilled.
             self.0.send_if_modified(|key_objects| {
                 // Now under the write lock.
-                // We might have a stale result, or someone else might have an obligaton;
+                // We might have a stale result, or someone else might have an obligation;
                 // pick the best we can.
                 let response_keys: Vec<_> = key_objects
                     .vary_rules

--- a/src/config.rs
+++ b/src/config.rs
@@ -178,7 +178,7 @@ impl FromStr for FastlyConfig {
 /// a [`FastlyConfig`][conf].
 ///
 /// [conf]: struct.FastlyConfig.html
-/// [fromt-str]: https://docs.rs/toml/latest/toml/de/fn.from_str.html
+/// [from-str]: https://docs.rs/toml/latest/toml/de/fn.from_str.html
 #[derive(Deserialize)]
 struct TomlFastlyConfig {
     manifest_version: Option<u32>,

--- a/src/error.rs
+++ b/src/error.rs
@@ -587,7 +587,7 @@ pub enum DictionaryConfigError {
 /// Errors that may occur while validating device detection configurations.
 #[derive(Debug, thiserror::Error)]
 pub enum DeviceDetectionConfigError {
-    /// An I/O error that occured while reading the file.
+    /// An I/O error that occurred while reading the file.
     #[error(transparent)]
     IoError(std::io::Error),
 
@@ -643,7 +643,7 @@ pub enum DeviceDetectionConfigError {
 /// Errors that may occur while validating geolocation configurations.
 #[derive(Debug, thiserror::Error)]
 pub enum GeolocationConfigError {
-    /// An I/O error that occured while reading the file.
+    /// An I/O error that occurred while reading the file.
     #[error(transparent)]
     IoError(std::io::Error),
 
@@ -702,7 +702,7 @@ pub enum GeolocationConfigError {
 /// Errors that may occur while validating object store configurations.
 #[derive(Debug, thiserror::Error)]
 pub enum ObjectStoreConfigError {
-    /// An I/O error that occured while reading the file.
+    /// An I/O error that occurred while reading the file.
     #[error(transparent)]
     IoError(std::io::Error),
     #[error("The `file` and `data` keys for the object `{0}` are set. Only one can be used.")]
@@ -754,7 +754,7 @@ pub enum ObjectStoreConfigError {
 /// Errors that may occur while validating secret store configurations.
 #[derive(Debug, thiserror::Error)]
 pub enum SecretStoreConfigError {
-    /// An I/O error that occured while reading the file.
+    /// An I/O error that occurred while reading the file.
     #[error(transparent)]
     IoError(std::io::Error),
 
@@ -800,7 +800,7 @@ pub enum SecretStoreConfigError {
 #[derive(Debug, thiserror::Error)]
 pub enum ShieldingSiteConfigError {
     #[error(
-        "Illegal TOML value for shielding site; must be either the string 'local' or a table containin an encrypted and unencrypted URL."
+        "Illegal TOML value for shielding site; must be either the string 'local' or a table containing an encrypted and unencrypted URL."
     )]
     IllegalSiteValue,
 

--- a/src/object_store.rs
+++ b/src/object_store.rs
@@ -364,7 +364,7 @@ pub enum KvStoreError {
     )]
     BadRequest,
     #[error(
-        "KV store cannot fulfill the request, as definied by the client's prerequisites (ie. if-generation-match)"
+        "KV store cannot fulfill the request, as defined by the client's prerequisites (ie. if-generation-match)"
     )]
     PreconditionFailed,
     #[error("The size limit for a KV store key was exceeded")]

--- a/src/streaming_body.rs
+++ b/src/streaming_body.rs
@@ -35,7 +35,7 @@ pub struct StreamingBody {
 /// these cases, `hyper` will dutifully frame each chunk as it reads them from the `Body`. If the
 /// `Body` suddenly returns `Ok(None)`, it will apply the proper `0\r\n\r\n` termination to the
 /// message. The finish message ensures that this will only happen when the Wasm program
-/// affirmitavely marks the body as finished.
+/// affirmatively marks the body as finished.
 #[derive(Debug)]
 pub enum StreamingBodyItem {
     Chunk(Chunk),

--- a/wasm_abi/adapter/src/fastly/core.rs
+++ b/wasm_abi/adapter/src/fastly/core.rs
@@ -83,7 +83,7 @@ pub enum FramingHeadersMode {
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 #[repr(u32)]
 pub enum HttpKeepaliveMode {
-    /// This is the default behavor.
+    /// This is the default behavior.
     Automatic = 0,
 
     /// Send `Connection: close` in HTTP/1 and a GOAWAY frame in HTTP/2 and HTTP/3.  This prompts
@@ -2502,7 +2502,7 @@ pub mod fastly_http_req {
         resp_body_handle_out: *mut BodyHandle,
     ) -> FastlyStatus {
         // `http-req.select-request` traps if there are no handles or too many handles; this
-        // check preservs the witx `pending-req-select` behavior.
+        // check preserves the witx `pending-req-select` behavior.
         if pending_req_handles_len == 0
             || pending_req_handles_len >= fastly_shared::MAX_PENDING_REQS as usize
         {
@@ -2532,7 +2532,7 @@ pub mod fastly_http_req {
         resp_body_handle_out: *mut BodyHandle,
     ) -> FastlyStatus {
         // `http-req.select-request` traps if there are no handles or too many handles; this
-        // check preservs the witx `pending-req-select` behavior.
+        // check preserves the witx `pending-req-select` behavior.
         if pending_req_handles_len == 0
             || pending_req_handles_len >= fastly_shared::MAX_PENDING_REQS as usize
         {
@@ -3581,7 +3581,7 @@ pub mod fastly_kv_store {
     #[repr(C)]
     pub struct LookupConfig {
         // reserved is just a placeholder,
-        // can be removed when somethin real is added
+        // can be removed when something real is added
         reserved: u32,
     }
 
@@ -3594,7 +3594,7 @@ pub mod fastly_kv_store {
     #[repr(C)]
     pub struct DeleteConfig {
         // reserved is just a placeholder,
-        // can be removed when somethin real is added
+        // can be removed when something real is added
         reserved: u32,
     }
 

--- a/wasm_abi/adapter/src/lib.rs
+++ b/wasm_abi/adapter/src/lib.rs
@@ -1136,7 +1136,7 @@ pub unsafe extern "C" fn poll_oneoff(
                 .trapping_unwrap()
     );
     // Store the pollable handles at the beginning, and the bool results at the
-    // end, so that we don't clobber the bool results when writting the events.
+    // end, so that we don't clobber the bool results when writing the events.
     let pollables = main_ptr!(out as *mut c_void as *mut Pollable);
     let results = main_ptr!(out.add(nsubscriptions).cast::<u32>().sub(nsubscriptions));
 
@@ -1524,7 +1524,7 @@ pub(crate) struct State {
     ///
     /// `cache_busy_handle_wait` consumes its handle, however because the
     /// SDK's `CacheBusyHandle::wait` doesn't consume `self`, it does a
-    /// seperate drop and calls `close_busy`. To avoid this use of a dangling
+    /// separate drop and calls `close_busy`. To avoid this use of a dangling
     /// handle, `cache_busy_handle_wait` records the handle it consumed so that
     /// `close_busy` can check if it's closing a handle that has just been
     /// consumed.
@@ -1535,7 +1535,7 @@ pub(crate) struct State {
     ///
     /// `replace_insert` consumes its handle, however because the
     /// SDK's `CacheReplaceHandle::replace_insert` doesn't consume `self`, it does a
-    /// seperate drop and calls `close`. To avoid this use of a dangling
+    /// separate drop and calls `close`. To avoid this use of a dangling
     /// handle, `replace_insert` records the handle it consumed so that
     /// `close` can check if it's closing a handle that has just been
     /// consumed.


### PR DESCRIPTION
Fixes #608

## What changed

Corrects the spelling errors surfaced by jsoref's check-spelling run (linked from the issue). Every change is inside a doc comment, inline comment, or error-message string literal — no public API names, enum variants, or identifiers are touched.

| Typo | Correction | File |
|---|---|---|
| `affirmitavely` | `affirmatively` | `src/streaming_body.rs` |
| `behavor` | `behavior` | `wasm_abi/adapter/src/fastly/core.rs` |
| `containin` | `containing` | `src/error.rs` |
| `definied` | `defined` | `src/object_store.rs` |
| `fromt-str` | `from-str` | `src/config.rs` (also fixes a broken rustdoc intra-doc link: the usage at line 177 writes `[from-str]` but the label definition was misspelled `[fromt-str]:`) |
| `obligaton` | `obligation` | `src/cache/store.rs` (comments only; the existing `obligaton_when_stale` / `obligaton2` identifiers are left alone to keep this a pure text fix) |
| `occured` | `occurred` | `src/error.rs` (×4) |
| `preservs` | `preserves` | `wasm_abi/adapter/src/fastly/core.rs` |
| `seperate` | `separate` | `wasm_abi/adapter/src/lib.rs` (×2) |
| `somethin` | `something` | `wasm_abi/adapter/src/fastly/core.rs` (×2) |
| `writting` | `writing` | `wasm_abi/adapter/src/lib.rs` |

**Left alone**:

- `suport` in `CHANGELOG.md` line 95 — historical record.
- The public `InvalidAlpnRepsonse` enum variant in `src/error.rs` — renaming it would be a breaking change to the error API, and the issue is scoped to comment/string typos.
- The issue-listed words that don't appear in the repository (`Compontent`, `exitting`, `Repsonse` / `resposne` outside the untouched variant, `uniqe`, `wheee`) — nothing to fix there.

Total: 7 files, 18 insertions / 18 deletions, all substitutions are 1:1 length-neutral in the surrounding context.
