### PR TITLE
Restore explicit Rust target install in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,10 @@ jobs:
         with:
           submodules: true
 
+      - name: Install Rust
+        run: rustup target add ${{ matrix.rust_arch }}-${{ matrix.rust_abi }}
+        shell: bash
+
       - name: Install C cross-compilation toolchain
         if: ${{ matrix.name == 'linux' && matrix.arch != 'amd64' }}
         run: |


### PR DESCRIPTION
Changes in #604 caused the release of v0.17.0 to fail. After this is merged, we need to tag this commit as v0.17.0 to trigger another release attempt.