### PR TITLE
Rename 'session' to 'sandbox'.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- Rename 'session' to 'sandbox' since that is the preferred term in public documentation.
+
 ## 0.17.0 (2026-04-27)
 
 - Add stub implementations for resvpnproxy hostcalls. ([#596](https://github.com/fastly/Viceroy/pull/596))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased
 
-- Rename 'session' to 'sandbox' since that is the preferred term in public documentation.
+- Rename 'session' to 'sandbox' since that is the preferred term in public documentation. ([#617](https://github.com/fastly/Viceroy/pull/617))
 
 ## 0.17.0 (2026-04-27)
 

--- a/cli/tests/integration/main.rs
+++ b/cli/tests/integration/main.rs
@@ -24,7 +24,7 @@ mod memory;
 mod profiling;
 mod request;
 mod response;
-mod reusable_sessions;
+mod reusable_sandboxes;
 mod secret_store;
 mod sending_response;
 mod shielding;

--- a/cli/tests/integration/reusable_sandboxes.rs
+++ b/cli/tests/integration/reusable_sandboxes.rs
@@ -5,7 +5,7 @@ use crate::viceroy_test;
 use hyper::{Request, StatusCode};
 
 viceroy_test!(check_hostcalls_implemented, |is_component| {
-    let test = Test::using_fixture("reusable-sessions.wasm")
+    let test = Test::using_fixture("reusable-sandboxes.wasm")
         .adapt_component(is_component)
         .via_hyper();
 
@@ -25,7 +25,7 @@ viceroy_test!(check_hostcalls_implemented, |is_component| {
 });
 
 viceroy_test!(check_crash_causes_5xx, |is_component| {
-    let test = Test::using_fixture("reusable-sessions.wasm")
+    let test = Test::using_fixture("reusable-sandboxes.wasm")
         .adapt_component(is_component)
         .via_hyper();
 

--- a/src/async_io.rs
+++ b/src/async_io.rs
@@ -1,7 +1,7 @@
 use {
     crate::{
         error::Error,
-        session::Session,
+        sandbox::Sandbox,
         wiggle_abi::{fastly_async_io::FastlyAsyncIo, types::AsyncItemHandle},
     },
     futures::{FutureExt, TryFutureExt},
@@ -10,7 +10,7 @@ use {
     wiggle::{GuestMemory, GuestPtr},
 };
 
-impl FastlyAsyncIo for Session {
+impl FastlyAsyncIo for Sandbox {
     async fn select(
         &mut self,
         memory: &mut GuestMemory<'_>,

--- a/src/collecting_body.rs
+++ b/src/collecting_body.rs
@@ -21,7 +21,7 @@ use crate::{
 /// - Streaming in a body, from an `insert`/`replace`-style request, implemented via StreamingBody
 /// - Storage of that body in the cache
 /// - Streaming out of the body, from a `lookup`/`TransactionInsertBuilder:execute_and_stream_back`
-///   request, from the same or a different session
+///   request, from the same or a different sandbox
 ///
 /// CollectingBody provides a place for this to happen. It accepts a `Body` as a source of data,
 /// e.g. one from a `StreamingBody` or an origin response; stores the data for future retrieval;

--- a/src/component/adapter/http_req.rs
+++ b/src/component/adapter/http_req.rs
@@ -4,7 +4,7 @@ use {
         fastly::compute::http_downstream::Host as HttpDownstream,
         fastly::compute::{http_req, types},
     },
-    crate::linking::{ComponentCtx, SessionView},
+    crate::linking::{ComponentCtx, SandboxView},
     wasmtime::component::Resource,
 };
 
@@ -15,7 +15,7 @@ trait DsView {
 }
 impl DsView for ComponentCtx {
     fn ds_req_handle(&self) -> Resource<http_req::Request> {
-        self.session().downstream_request().into()
+        self.sandbox().downstream_request().into()
     }
 }
 

--- a/src/component/backend.rs
+++ b/src/component/backend.rs
@@ -2,8 +2,8 @@ use {
     crate::component::bindings::fastly::compute::{backend, http_types, types},
     crate::config::{Backend, ClientCertInfo},
     crate::error::Error,
+    crate::sandbox::Sandbox,
     crate::secret_store::SecretLookup,
-    crate::session::Session,
     crate::wiggle_abi::SecretStoreError,
     http::HeaderValue,
     http::Uri,
@@ -12,7 +12,7 @@ use {
 };
 
 pub(crate) async fn register_dynamic_backend(
-    session: &mut Session,
+    sandbox: &mut Sandbox,
     table: &mut ResourceTable,
     prefix: String,
     target: String,
@@ -98,7 +98,7 @@ pub(crate) async fn register_dynamic_backend(
     };
 
     let client_cert = if let Some((client_cert, client_key)) = options.client_cert {
-        let key_lookup = session
+        let key_lookup = sandbox
             .secret_lookup(client_key)
             .ok_or(Error::SecretStoreError(
                 SecretStoreError::InvalidSecretHandle(client_key),
@@ -107,7 +107,7 @@ pub(crate) async fn register_dynamic_backend(
             SecretLookup::Standard {
                 store_name,
                 secret_name,
-            } => session
+            } => sandbox
                 .secret_stores()
                 .get_store(store_name)
                 .ok_or(Error::SecretStoreError(
@@ -147,7 +147,7 @@ pub(crate) async fn register_dynamic_backend(
         health: crate::config::BackendHealth::Unknown,
     };
 
-    if !session.add_backend(name, new_backend) {
+    if !sandbox.add_backend(name, new_backend) {
         return Err(Error::BackendNameRegistryError(name.to_string()).into());
     }
 
@@ -156,15 +156,15 @@ pub(crate) async fn register_dynamic_backend(
     Ok(res)
 }
 
-pub(crate) fn exists(session: &mut Session, backend: &str) -> bool {
-    session.backend(backend).is_some()
+pub(crate) fn exists(sandbox: &mut Sandbox, backend: &str) -> bool {
+    sandbox.backend(backend).is_some()
 }
 
 pub(crate) fn is_healthy(
-    session: &mut Session,
+    sandbox: &mut Sandbox,
     backend: &str,
 ) -> Result<backend::BackendHealth, types::Error> {
-    let backend = session.backend(backend).ok_or(Error::InvalidArgument)?;
+    let backend = sandbox.backend(backend).ok_or(Error::InvalidArgument)?;
     match &backend.health {
         crate::config::BackendHealth::Unknown => Ok(backend::BackendHealth::Unknown),
         crate::config::BackendHealth::Healthy => Ok(backend::BackendHealth::Healthy),
@@ -172,10 +172,10 @@ pub(crate) fn is_healthy(
     }
 }
 
-pub(crate) fn is_dynamic(session: &mut Session, backend: &str) -> Result<bool, types::Error> {
-    if session.dynamic_backend(backend).is_some() {
+pub(crate) fn is_dynamic(sandbox: &mut Sandbox, backend: &str) -> Result<bool, types::Error> {
+    if sandbox.dynamic_backend(backend).is_some() {
         Ok(true)
-    } else if session.backend(backend).is_some() {
+    } else if sandbox.backend(backend).is_some() {
         Ok(false)
     } else {
         Err(Error::InvalidArgument.into())
@@ -183,12 +183,12 @@ pub(crate) fn is_dynamic(session: &mut Session, backend: &str) -> Result<bool, t
 }
 
 pub(crate) fn get_host(
-    session: &mut Session,
+    sandbox: &mut Sandbox,
     backend: &str,
     _max_len: u64,
 ) -> Result<String, types::Error> {
     // just doing this to get a different error if the backend doesn't exist
-    let _ = session.backend(backend).ok_or(Error::InvalidArgument)?;
+    let _ = sandbox.backend(backend).ok_or(Error::InvalidArgument)?;
     Err(Error::Unsupported {
         msg: "`get-host` is not actually supported in Viceroy",
     }
@@ -196,11 +196,11 @@ pub(crate) fn get_host(
 }
 
 pub(crate) fn get_override_host(
-    session: &mut Session,
+    sandbox: &mut Sandbox,
     backend: &str,
     max_len: u64,
 ) -> Result<Option<Vec<u8>>, types::Error> {
-    let backend = session.backend(backend).ok_or(Error::InvalidArgument)?;
+    let backend = sandbox.backend(backend).ok_or(Error::InvalidArgument)?;
     if let Some(host) = backend.override_host.as_ref() {
         let host = host.to_str()?;
 
@@ -218,8 +218,8 @@ pub(crate) fn get_override_host(
     }
 }
 
-pub(crate) fn get_port(session: &mut Session, backend: &str) -> Result<u16, types::Error> {
-    let backend = session.backend(backend).ok_or(Error::InvalidArgument)?;
+pub(crate) fn get_port(sandbox: &mut Sandbox, backend: &str) -> Result<u16, types::Error> {
+    let backend = sandbox.backend(backend).ok_or(Error::InvalidArgument)?;
     match backend.uri.port_u16() {
         Some(port) => Ok(port),
         None => {
@@ -233,11 +233,11 @@ pub(crate) fn get_port(session: &mut Session, backend: &str) -> Result<u16, type
 }
 
 pub(crate) fn get_connect_timeout_ms(
-    session: &mut Session,
+    sandbox: &mut Sandbox,
     backend: &str,
 ) -> Result<u32, types::Error> {
     // just doing this to get a different error if the backend doesn't exist
-    let _ = session.backend(backend).ok_or(Error::InvalidArgument)?;
+    let _ = sandbox.backend(backend).ok_or(Error::InvalidArgument)?;
     Err(Error::Unsupported {
         msg: "connection timing is not actually supported in Viceroy",
     }
@@ -245,11 +245,11 @@ pub(crate) fn get_connect_timeout_ms(
 }
 
 pub(crate) fn get_first_byte_timeout_ms(
-    session: &mut Session,
+    sandbox: &mut Sandbox,
     backend: &str,
 ) -> Result<u32, types::Error> {
     // just doing this to get a different error if the backend doesn't exist
-    let _ = session.backend(backend).ok_or(Error::InvalidArgument)?;
+    let _ = sandbox.backend(backend).ok_or(Error::InvalidArgument)?;
     Err(Error::Unsupported {
         msg: "connection timing is not actually supported in Viceroy",
     }
@@ -257,28 +257,28 @@ pub(crate) fn get_first_byte_timeout_ms(
 }
 
 pub(crate) fn get_between_bytes_timeout_ms(
-    session: &mut Session,
+    sandbox: &mut Sandbox,
     backend: &str,
 ) -> Result<u32, types::Error> {
     // just doing this to get a different error if the backend doesn't exist
-    let _ = session.backend(backend).ok_or(Error::InvalidArgument)?;
+    let _ = sandbox.backend(backend).ok_or(Error::InvalidArgument)?;
     Err(Error::Unsupported {
         msg: "connection timing is not actually supported in Viceroy",
     }
     .into())
 }
 
-pub(crate) fn is_tls(session: &mut Session, backend: &str) -> Result<bool, types::Error> {
-    let backend = session.backend(backend).ok_or(Error::InvalidArgument)?;
+pub(crate) fn is_tls(sandbox: &mut Sandbox, backend: &str) -> Result<bool, types::Error> {
+    let backend = sandbox.backend(backend).ok_or(Error::InvalidArgument)?;
     Ok(backend.uri.scheme() == Some(&http::uri::Scheme::HTTPS))
 }
 
 pub(crate) fn get_tls_min_version(
-    session: &mut Session,
+    sandbox: &mut Sandbox,
     backend: &str,
 ) -> Result<Option<http_types::TlsVersion>, types::Error> {
     // just doing this to get a different error if the backend doesn't exist
-    let _ = session.backend(backend).ok_or(Error::InvalidArgument)?;
+    let _ = sandbox.backend(backend).ok_or(Error::InvalidArgument)?;
     // health checks are not enabled in Viceroy :(
     Err(Error::Unsupported {
         msg: "tls version flags are not supported in Viceroy",
@@ -287,11 +287,11 @@ pub(crate) fn get_tls_min_version(
 }
 
 pub(crate) fn get_tls_max_version(
-    session: &mut Session,
+    sandbox: &mut Sandbox,
     backend: &str,
 ) -> Result<Option<http_types::TlsVersion>, types::Error> {
     // just doing this to get a different error if the backend doesn't exist
-    let _ = session.backend(backend).ok_or(Error::InvalidArgument)?;
+    let _ = sandbox.backend(backend).ok_or(Error::InvalidArgument)?;
     // health checks are not enabled in Viceroy :(
     Err(Error::Unsupported {
         msg: "tls version flags are not supported in Viceroy",
@@ -300,7 +300,7 @@ pub(crate) fn get_tls_max_version(
 }
 
 pub(crate) fn get_http_keepalive_time(
-    _session: &mut Session,
+    _sandbox: &mut Sandbox,
     _backend: &str,
 ) -> Result<backend::TimeoutMs, types::Error> {
     Err(Error::Unsupported {
@@ -310,7 +310,7 @@ pub(crate) fn get_http_keepalive_time(
 }
 
 pub(crate) fn get_tcp_keepalive_enable(
-    _session: &mut Session,
+    _sandbox: &mut Sandbox,
     _backend: &str,
 ) -> Result<bool, types::Error> {
     Err(Error::Unsupported {
@@ -320,7 +320,7 @@ pub(crate) fn get_tcp_keepalive_enable(
 }
 
 pub(crate) fn get_tcp_keepalive_interval(
-    _session: &mut Session,
+    _sandbox: &mut Sandbox,
     _backend: &str,
 ) -> Result<backend::TimeoutSecs, types::Error> {
     Err(Error::Unsupported {
@@ -330,7 +330,7 @@ pub(crate) fn get_tcp_keepalive_interval(
 }
 
 pub(crate) fn get_tcp_keepalive_probes(
-    _session: &mut Session,
+    _sandbox: &mut Sandbox,
     _backend: &str,
 ) -> Result<backend::ProbeCount, types::Error> {
     Err(Error::Unsupported {
@@ -340,7 +340,7 @@ pub(crate) fn get_tcp_keepalive_probes(
 }
 
 pub(crate) fn get_tcp_keepalive_time(
-    _session: &mut Session,
+    _sandbox: &mut Sandbox,
     _backend: &str,
 ) -> Result<backend::TimeoutSecs, types::Error> {
     Err(Error::Unsupported {

--- a/src/component/compute/acl.rs
+++ b/src/component/compute/acl.rs
@@ -1,5 +1,5 @@
 use crate::component::bindings::fastly::compute::{acl, http_body, types};
-use crate::linking::{ComponentCtx, SessionView};
+use crate::linking::{ComponentCtx, SandboxView};
 use std::net::IpAddr;
 use wasmtime::component::Resource;
 
@@ -8,7 +8,7 @@ impl acl::Host for ComponentCtx {}
 impl acl::HostAcl for ComponentCtx {
     fn open(&mut self, acl_name: String) -> Result<Resource<acl::Acl>, types::OpenError> {
         let handle = self
-            .session_mut()
+            .sandbox_mut()
             .acl_handle_by_name(&acl_name)
             .ok_or(types::OpenError::NotFound)?;
         Ok(handle.into())
@@ -19,7 +19,7 @@ impl acl::HostAcl for ComponentCtx {
         acl_handle: Resource<acl::Acl>,
         ip_addr: acl::IpAddress,
     ) -> Result<Option<Resource<http_body::Body>>, acl::AclError> {
-        let acl = self.session().acl_by_handle(acl_handle.into()).unwrap();
+        let acl = self.sandbox().acl_by_handle(acl_handle.into()).unwrap();
 
         let ip: IpAddr = ip_addr.into();
 
@@ -27,7 +27,7 @@ impl acl::HostAcl for ComponentCtx {
             Some(entry) => {
                 let body =
                     serde_json::to_vec_pretty(&entry).map_err(|_| acl::AclError::GenericError)?;
-                let body_handle = self.session_mut().insert_body(body.into());
+                let body_handle = self.sandbox_mut().insert_body(body.into());
                 Ok(Some(body_handle.into()))
             }
             None => Ok(None),

--- a/src/component/compute/async_io.rs
+++ b/src/component/compute/async_io.rs
@@ -1,7 +1,7 @@
 use {
     crate::component::bindings::fastly::compute::async_io,
     crate::{
-        linking::{ComponentCtx, SessionView},
+        linking::{ComponentCtx, SandboxView},
         wiggle_abi,
     },
     anyhow::bail,
@@ -16,7 +16,7 @@ impl async_io::Host for ComponentCtx {
             bail!("`select` without a timeout must have at least one handle");
         }
 
-        let select_fut = self.session_mut().select_impl(
+        let select_fut = self.sandbox_mut().select_impl(
             hs.into_iter()
                 .map(|i| wiggle_abi::types::AsyncItemHandle::from(i).into()),
         );
@@ -30,8 +30,8 @@ impl async_io::Host for ComponentCtx {
         hs: Vec<Resource<async_io::Pollable>>,
         timeout_ms: u32,
     ) -> Option<u32> {
-        let select_fut = self.session_mut().select_impl(hs.into_iter().map(|i| {
-            crate::session::AsyncItemHandle::from(wiggle_abi::types::AsyncItemHandle::from(i))
+        let select_fut = self.sandbox_mut().select_impl(hs.into_iter().map(|i| {
+            crate::sandbox::AsyncItemHandle::from(wiggle_abi::types::AsyncItemHandle::from(i))
         }));
 
         tokio::time::timeout(Duration::from_millis(timeout_ms as u64), select_fut)
@@ -43,12 +43,12 @@ impl async_io::Host for ComponentCtx {
 
 impl async_io::HostPollable for ComponentCtx {
     fn new_ready(&mut self) -> Resource<async_io::Pollable> {
-        wiggle_abi::types::AsyncItemHandle::from(self.session_mut().new_ready()).into()
+        wiggle_abi::types::AsyncItemHandle::from(self.sandbox_mut().new_ready()).into()
     }
 
     fn is_ready(&mut self, handle: Resource<async_io::Pollable>) -> bool {
         let handle = wiggle_abi::types::AsyncItemHandle::from(handle);
-        self.session_mut()
+        self.sandbox_mut()
             .async_item_mut(handle.into())
             .unwrap()
             .await_ready()
@@ -60,9 +60,9 @@ impl async_io::HostPollable for ComponentCtx {
         let handle = wiggle_abi::types::AsyncItemHandle::from(handle).into();
 
         // Use `.take_async_item` instead of manipulating
-        // `self.session_mut().async_items` directly, so that any extra state
+        // `self.sandbox_mut().async_items` directly, so that any extra state
         // associated with the item is also cleared.
-        let _ = self.session_mut().take_async_item(handle).unwrap();
+        let _ = self.sandbox_mut().take_async_item(handle).unwrap();
 
         Ok(())
     }

--- a/src/component/compute/backend.rs
+++ b/src/component/compute/backend.rs
@@ -17,7 +17,7 @@ impl backend::Host for ComponentCtx {
         options: Resource<backend::DynamicBackendOptions>,
     ) -> Result<Resource<String>, types::Error> {
         crate::component::backend::register_dynamic_backend(
-            &mut self.session,
+            &mut self.sandbox,
             &mut self.wasi_table,
             prefix,
             target,
@@ -29,7 +29,7 @@ impl backend::Host for ComponentCtx {
 
 impl backend::HostBackend for ComponentCtx {
     fn open(&mut self, name: String) -> Result<Resource<String>, backend::OpenError> {
-        if !crate::component::backend::exists(&mut self.session, &name) {
+        if !crate::component::backend::exists(&mut self.sandbox, &name) {
             return Err(backend::OpenError::NotFound);
         }
 
@@ -47,17 +47,17 @@ impl backend::HostBackend for ComponentCtx {
         name: Resource<String>,
     ) -> Result<backend::BackendHealth, types::Error> {
         let name = self.wasi_table.get(&name).unwrap();
-        crate::component::backend::is_healthy(&mut self.session, name)
+        crate::component::backend::is_healthy(&mut self.sandbox, name)
     }
 
     fn is_dynamic(&mut self, name: Resource<String>) -> Result<bool, types::Error> {
         let name = self.wasi_table.get(&name).unwrap();
-        crate::component::backend::is_dynamic(&mut self.session, name)
+        crate::component::backend::is_dynamic(&mut self.sandbox, name)
     }
 
     fn get_host(&mut self, name: Resource<String>, max_len: u64) -> Result<String, types::Error> {
         let name = self.wasi_table.get(&name).unwrap();
-        crate::component::backend::get_host(&mut self.session, name, max_len)
+        crate::component::backend::get_host(&mut self.sandbox, name, max_len)
     }
 
     fn get_override_host(
@@ -66,17 +66,17 @@ impl backend::HostBackend for ComponentCtx {
         max_len: u64,
     ) -> Result<Option<Vec<u8>>, types::Error> {
         let name = self.wasi_table.get(&name).unwrap();
-        crate::component::backend::get_override_host(&mut self.session, name, max_len)
+        crate::component::backend::get_override_host(&mut self.sandbox, name, max_len)
     }
 
     fn get_port(&mut self, backend: Resource<String>) -> Result<u16, types::Error> {
         let backend = self.wasi_table.get(&backend).unwrap();
-        crate::component::backend::get_port(&mut self.session, backend)
+        crate::component::backend::get_port(&mut self.sandbox, backend)
     }
 
     fn get_connect_timeout_ms(&mut self, backend: Resource<String>) -> Result<u32, types::Error> {
         let backend = self.wasi_table.get(&backend).unwrap();
-        crate::component::backend::get_connect_timeout_ms(&mut self.session, backend)
+        crate::component::backend::get_connect_timeout_ms(&mut self.sandbox, backend)
     }
 
     fn get_first_byte_timeout_ms(
@@ -84,7 +84,7 @@ impl backend::HostBackend for ComponentCtx {
         backend: Resource<String>,
     ) -> Result<u32, types::Error> {
         let backend = self.wasi_table.get(&backend).unwrap();
-        crate::component::backend::get_first_byte_timeout_ms(&mut self.session, backend)
+        crate::component::backend::get_first_byte_timeout_ms(&mut self.sandbox, backend)
     }
 
     fn get_between_bytes_timeout_ms(
@@ -92,7 +92,7 @@ impl backend::HostBackend for ComponentCtx {
         backend: Resource<String>,
     ) -> Result<u32, types::Error> {
         let backend = self.wasi_table.get(&backend).unwrap();
-        crate::component::backend::get_between_bytes_timeout_ms(&mut self.session, backend)
+        crate::component::backend::get_between_bytes_timeout_ms(&mut self.sandbox, backend)
     }
 
     fn get_http_keepalive_time(
@@ -100,7 +100,7 @@ impl backend::HostBackend for ComponentCtx {
         backend: Resource<String>,
     ) -> Result<backend::TimeoutMs, types::Error> {
         let backend = self.wasi_table.get(&backend).unwrap();
-        crate::component::backend::get_http_keepalive_time(&mut self.session, backend)
+        crate::component::backend::get_http_keepalive_time(&mut self.sandbox, backend)
     }
 
     fn get_tcp_keepalive_enable(
@@ -108,7 +108,7 @@ impl backend::HostBackend for ComponentCtx {
         backend: Resource<String>,
     ) -> Result<bool, types::Error> {
         let backend = self.wasi_table.get(&backend).unwrap();
-        crate::component::backend::get_tcp_keepalive_enable(&mut self.session, backend)
+        crate::component::backend::get_tcp_keepalive_enable(&mut self.sandbox, backend)
     }
 
     fn get_tcp_keepalive_interval(
@@ -116,7 +116,7 @@ impl backend::HostBackend for ComponentCtx {
         backend: Resource<String>,
     ) -> Result<backend::TimeoutSecs, types::Error> {
         let backend = self.wasi_table.get(&backend).unwrap();
-        crate::component::backend::get_tcp_keepalive_interval(&mut self.session, backend)
+        crate::component::backend::get_tcp_keepalive_interval(&mut self.sandbox, backend)
     }
 
     fn get_tcp_keepalive_probes(
@@ -124,7 +124,7 @@ impl backend::HostBackend for ComponentCtx {
         backend: Resource<String>,
     ) -> Result<backend::ProbeCount, types::Error> {
         let backend = self.wasi_table.get(&backend).unwrap();
-        crate::component::backend::get_tcp_keepalive_probes(&mut self.session, backend)
+        crate::component::backend::get_tcp_keepalive_probes(&mut self.sandbox, backend)
     }
 
     fn get_tcp_keepalive_time(
@@ -132,12 +132,12 @@ impl backend::HostBackend for ComponentCtx {
         backend: Resource<String>,
     ) -> Result<backend::TimeoutSecs, types::Error> {
         let backend = self.wasi_table.get(&backend).unwrap();
-        crate::component::backend::get_tcp_keepalive_time(&mut self.session, backend)
+        crate::component::backend::get_tcp_keepalive_time(&mut self.sandbox, backend)
     }
 
     fn is_tls(&mut self, backend: Resource<String>) -> Result<bool, types::Error> {
         let backend = self.wasi_table.get(&backend).unwrap();
-        crate::component::backend::is_tls(&mut self.session, backend)
+        crate::component::backend::is_tls(&mut self.sandbox, backend)
     }
 
     fn get_tls_min_version(
@@ -145,7 +145,7 @@ impl backend::HostBackend for ComponentCtx {
         backend: Resource<String>,
     ) -> Result<Option<http_types::TlsVersion>, types::Error> {
         let backend = self.wasi_table.get(&backend).unwrap();
-        crate::component::backend::get_tls_min_version(&mut self.session, backend)
+        crate::component::backend::get_tls_min_version(&mut self.sandbox, backend)
     }
 
     fn get_tls_max_version(
@@ -153,7 +153,7 @@ impl backend::HostBackend for ComponentCtx {
         backend: Resource<String>,
     ) -> Result<Option<http_types::TlsVersion>, types::Error> {
         let backend = self.wasi_table.get(&backend).unwrap();
-        crate::component::backend::get_tls_max_version(&mut self.session, backend)
+        crate::component::backend::get_tls_max_version(&mut self.sandbox, backend)
     }
 
     fn drop(&mut self, backend: Resource<String>) -> wasmtime::Result<()> {

--- a/src/component/compute/cache.rs
+++ b/src/component/compute/cache.rs
@@ -4,8 +4,8 @@ use {
         body::Body,
         cache::{self, CacheKey, SurrogateKeySet, VaryRule, WriteOptions},
         error::Error,
-        linking::{ComponentCtx, SessionView},
-        session::{PeekableTask, PendingCacheTask, Session},
+        linking::{ComponentCtx, SandboxView},
+        sandbox::{PeekableTask, PendingCacheTask, Sandbox},
         wiggle_abi::types::{CacheBusyHandle, CacheHandle},
     },
     bytes::Bytes,
@@ -96,12 +96,12 @@ struct LookupOptions {
 }
 
 fn load_lookup_options(
-    session: &Session,
+    sandbox: &Sandbox,
     options: api::LookupOptions,
 ) -> Result<LookupOptions, Error> {
     let headers = if let Some(request_headers) = options.request_headers {
         let handle = request_headers;
-        let parts = session.request_parts(handle.into())?;
+        let parts = sandbox.request_parts(handle.into())?;
         parts.headers.clone()
     } else {
         HeaderMap::default()
@@ -122,18 +122,18 @@ impl api::Host for ComponentCtx {
         mut options: api::WriteOptions,
     ) -> Result<Resource<api::Body>, types::Error> {
         let key: CacheKey = get_key(key)?;
-        let cache = Arc::clone(self.session().cache());
+        let cache = Arc::clone(self.sandbox().cache());
 
         let request_headers = if let Some(handle) = options.request_headers.take() {
-            let parts = self.session().request_parts(handle.into())?;
+            let parts = self.sandbox().request_parts(handle.into())?;
             parts.headers.clone()
         } else {
             HeaderMap::default()
         };
         let options = load_write_options(&options)?;
 
-        let handle = self.session_mut().insert_body(Body::empty());
-        let read_body = self.session_mut().begin_streaming(handle)?;
+        let handle = self.sandbox_mut().insert_body(Body::empty());
+        let read_body = self.sandbox_mut().begin_streaming(handle)?;
         cache
             .insert(&key, request_headers, options, read_body)
             .await;
@@ -157,12 +157,12 @@ impl api::Host for ComponentCtx {
     ) -> Result<Resource<api::Entry>, types::Error> {
         let handle = CacheBusyHandle::from(handle).into();
         // Swap out for a distinct handle, so we don't hit a repeated `close`+`close_busy`:
-        let entry = self.session_mut().cache_entry_mut(handle).await?;
+        let entry = self.sandbox_mut().cache_entry_mut(handle).await?;
         let mut other_entry = entry.stub();
         std::mem::swap(entry, &mut other_entry);
         let task = PeekableTask::spawn(Box::pin(async move { Ok(other_entry) })).await;
         let h: CacheHandle = self
-            .session_mut()
+            .sandbox_mut()
             .insert_cache_op(PendingCacheTask::new(task))
             .into();
         Ok(h.into())
@@ -174,13 +174,13 @@ impl api::Host for ComponentCtx {
     ) -> Result<(), types::Error> {
         let handle = CacheBusyHandle::from(handle).into();
         // Don't wait for the transaction to complete; drop the future to cancel.
-        let _ = self.session_mut().take_cache_entry(handle)?;
+        let _ = self.sandbox_mut().take_cache_entry(handle)?;
         Ok(())
     }
 
     async fn close_entry(&mut self, handle: Resource<api::Entry>) -> Result<(), types::Error> {
         let _ = self
-            .session_mut()
+            .sandbox_mut()
             .take_cache_entry(handle.into())?
             .task()
             .recv()
@@ -308,10 +308,10 @@ impl api::HostEntry for ComponentCtx {
         let LookupOptions {
             headers,
             always_use_requested_range,
-        } = load_lookup_options(self.session(), options)?;
+        } = load_lookup_options(self.sandbox(), options)?;
 
         let key: CacheKey = get_key(key)?;
-        let cache = Arc::clone(self.session().cache());
+        let cache = Arc::clone(self.sandbox().cache());
 
         let task = PeekableTask::spawn(Box::pin(async move {
             Ok(cache
@@ -321,7 +321,7 @@ impl api::HostEntry for ComponentCtx {
         }))
         .await;
         let task = PendingCacheTask::new(task);
-        let handle: CacheHandle = self.session_mut().insert_cache_op(task).into();
+        let handle: CacheHandle = self.sandbox_mut().insert_cache_op(task).into();
         Ok(handle.into())
     }
 
@@ -335,20 +335,20 @@ impl api::HostEntry for ComponentCtx {
         let from = options.from;
         let to = options.to;
 
-        // We wind up re-borrowing `found` and `self.session` several times here, to avoid
+        // We wind up re-borrowing `found` and `self.sandbox` several times here, to avoid
         // borrowing the both of them at once.
         // (It possible that inserting a body would change the address of Found, by re-shuffling
         // the AsyncItems table; we have to live by borrowck's rules.)
         //
-        // We have an exclusive borrow self.session_mut() for the lifetime of this call,
+        // We have an exclusive borrow self.sandbox_mut() for the lifetime of this call,
         // so even though we're re-borrowing/repeating lookups, we know we won't run into TOCTOU.
 
-        let entry = self.session_mut().cache_entry(handle).await?;
+        let entry = self.sandbox_mut().cache_entry(handle).await?;
 
         // Preemptively (optimistically) start a read. Don't worry, the Drop impl for Body will
         // clean up the copying task.
-        // We have to do this to allow `found`'s lifetime to end before self.session().body, which
-        // has to re-borrow self.self.session().
+        // We have to do this to allow `found`'s lifetime to end before self.sandbox().body, which
+        // has to re-borrow self.self.sandbox().
         let body = entry.body(from, to).await?;
         let found = entry
             .found()
@@ -356,16 +356,16 @@ impl api::HostEntry for ComponentCtx {
 
         if let Some(prev_handle) = found.last_body_handle {
             // Check if they're still reading the previous handle.
-            if self.session().body(prev_handle).is_ok() {
+            if self.sandbox().body(prev_handle).is_ok() {
                 return Err(Error::CacheError(cache::Error::HandleBodyUsed).into());
             }
         };
 
-        let body_handle = self.session_mut().insert_body(body);
+        let body_handle = self.sandbox_mut().insert_body(body);
 
         // Finalize by committing the handle as "the last read".
         // We have to borrow `found` again, this time as mutable.
-        self.session_mut()
+        self.sandbox_mut()
             .cache_entry_mut(handle)
             .await?
             .found_mut()
@@ -392,10 +392,10 @@ impl api::HostEntry for ComponentCtx {
         let LookupOptions {
             headers,
             always_use_requested_range,
-        } = load_lookup_options(self.session(), options)?;
+        } = load_lookup_options(self.sandbox(), options)?;
 
         let key: CacheKey = get_key(key)?;
-        let cache = Arc::clone(self.session().cache());
+        let cache = Arc::clone(self.sandbox().cache());
 
         // Look up once, joining the transaction only if obligated:
         let e = cache
@@ -418,7 +418,7 @@ impl api::HostEntry for ComponentCtx {
         };
 
         let task = PendingCacheTask::new(task);
-        let handle: CacheBusyHandle = self.session_mut().insert_cache_op(task).into();
+        let handle: CacheBusyHandle = self.sandbox_mut().insert_cache_op(task).into();
         Ok(handle.into())
     }
 
@@ -431,7 +431,7 @@ impl api::HostEntry for ComponentCtx {
             .transaction_insert_and_stream_back(handle, options)
             .await?;
         // Ignore the "stream back" handle
-        let _ = self.session_mut().take_cache_entry(cache_handle.into())?;
+        let _ = self.sandbox_mut().take_cache_entry(cache_handle.into())?;
         Ok(body)
     }
 
@@ -446,18 +446,18 @@ impl api::HostEntry for ComponentCtx {
         }
         let options = load_write_options(&options)?;
 
-        // Optimistically start a body, so we don't have to reborrow self.session_mut()
-        let body_handle = self.session_mut().insert_body(Body::empty());
-        let read_body = self.session_mut().begin_streaming(body_handle)?;
+        // Optimistically start a body, so we don't have to reborrow self.sandbox_mut()
+        let body_handle = self.sandbox_mut().insert_body(Body::empty());
+        let read_body = self.sandbox_mut().begin_streaming(body_handle)?;
 
         let e = self
-            .session_mut()
+            .sandbox_mut()
             .cache_entry_mut(handle.into())
             .await?
             .insert(options, read_body)?;
         // Return a new handle for the read end.
         let handle: CacheHandle = self
-            .session_mut()
+            .sandbox_mut()
             .insert_cache_op(PendingCacheTask::new(PeekableTask::complete(e)))
             .into();
 
@@ -475,7 +475,7 @@ impl api::HostEntry for ComponentCtx {
         }
         let options = load_write_options(&options)?;
 
-        let entry = self.session_mut().cache_entry_mut(handle.into()).await?;
+        let entry = self.sandbox_mut().cache_entry_mut(handle.into()).await?;
         // The path here is:
         // InvalidCacheHandle -> FastlyStatus::BADF -> (ABI boundary) ->
         // CacheError::InvalidOperation
@@ -487,7 +487,7 @@ impl api::HostEntry for ComponentCtx {
         &mut self,
         handle: Resource<api::Entry>,
     ) -> Result<(), types::Error> {
-        let entry = self.session_mut().cache_entry_mut(handle.into()).await?;
+        let entry = self.sandbox_mut().cache_entry_mut(handle.into()).await?;
         if entry.cancel() {
             Ok(())
         } else {
@@ -499,7 +499,7 @@ impl api::HostEntry for ComponentCtx {
         &mut self,
         handle: Resource<api::Entry>,
     ) -> Result<api::LookupState, types::Error> {
-        let entry = self.session_mut().cache_entry_mut(handle.into()).await?;
+        let entry = self.sandbox_mut().cache_entry_mut(handle.into()).await?;
 
         let mut state = api::LookupState::empty();
         if let Some(found) = entry.found() {
@@ -527,7 +527,7 @@ impl api::HostEntry for ComponentCtx {
         handle: Resource<api::Entry>,
         max_len: u64,
     ) -> Result<Option<Vec<u8>>, types::Error> {
-        let entry = self.session_mut().cache_entry(handle.into()).await?;
+        let entry = self.sandbox_mut().cache_entry(handle.into()).await?;
 
         let md_bytes = entry
             .found()
@@ -544,7 +544,7 @@ impl api::HostEntry for ComponentCtx {
         &mut self,
         handle: Resource<api::Entry>,
     ) -> Result<Option<u64>, types::Error> {
-        let Some(found) = self.session_mut().cache_entry(handle.into()).await?.found() else {
+        let Some(found) = self.sandbox_mut().cache_entry(handle.into()).await?.found() else {
             return Ok(None);
         };
         Ok(found.length())
@@ -554,7 +554,7 @@ impl api::HostEntry for ComponentCtx {
         &mut self,
         handle: Resource<api::Entry>,
     ) -> Result<Option<u64>, types::Error> {
-        let entry = self.session_mut().cache_entry_mut(handle.into()).await?;
+        let entry = self.sandbox_mut().cache_entry_mut(handle.into()).await?;
         if let Some(found) = entry.found() {
             Ok(Some(found.meta().max_age().as_nanos().try_into().unwrap()))
         } else {
@@ -576,7 +576,7 @@ impl api::HostEntry for ComponentCtx {
         &mut self,
         handle: Resource<api::Entry>,
     ) -> Result<Option<u64>, types::Error> {
-        let entry = self.session_mut().cache_entry_mut(handle.into()).await?;
+        let entry = self.sandbox_mut().cache_entry_mut(handle.into()).await?;
         if let Some(found) = entry.found() {
             Ok(Some(found.meta().age().as_nanos().try_into().unwrap()))
         } else {

--- a/src/component/compute/compute_runtime.rs
+++ b/src/component/compute/compute_runtime.rs
@@ -4,15 +4,15 @@ use std::sync::atomic::Ordering;
 
 impl compute_runtime::Host for ComponentCtx {
     fn get_vcpu_ms(&mut self) -> u64 {
-        self.session().active_cpu_time_us.load(Ordering::SeqCst) / 1000
+        self.sandbox().active_cpu_time_us.load(Ordering::SeqCst) / 1000
     }
 
     fn get_heap_mib(&mut self) -> compute_runtime::MemoryMib {
-        self.session().get_heap_usage_mib()
+        self.sandbox().get_heap_usage_mib()
     }
 
     fn get_sandbox_id(&mut self) -> String {
-        format!("{:032x}", self.session().session_id())
+        format!("{:032x}", self.sandbox().sandbox_id())
     }
 
     fn get_hostname(&mut self) -> String {

--- a/src/component/compute/config_store.rs
+++ b/src/component/compute/config_store.rs
@@ -1,13 +1,13 @@
 use {
     crate::component::bindings::fastly::compute::{config_store, types},
-    crate::linking::{ComponentCtx, SessionView},
+    crate::linking::{ComponentCtx, SandboxView},
     crate::wiggle_abi::types::{ConfigStoreHandle, DictionaryHandle},
     wasmtime::component::Resource,
 };
 
 impl config_store::HostStore for ComponentCtx {
     fn open(&mut self, name: String) -> Result<Resource<config_store::Store>, types::OpenError> {
-        let handle = self.session_mut().dictionary_handle(name.as_str())?;
+        let handle = self.sandbox_mut().dictionary_handle(name.as_str())?;
         let handle = ConfigStoreHandle::from(u32::from(handle));
         Ok(handle.into())
     }
@@ -19,7 +19,7 @@ impl config_store::HostStore for ComponentCtx {
         max_len: u64,
     ) -> Result<Option<String>, types::Error> {
         let handle = DictionaryHandle::from(store.rep());
-        let dict = &self.session().dictionary(handle)?.contents;
+        let dict = &self.sandbox().dictionary(handle)?.contents;
 
         let item = if let Some(item) = dict.get(&name) {
             item

--- a/src/component/compute/device_detection.rs
+++ b/src/component/compute/device_detection.rs
@@ -5,7 +5,7 @@ use {
 
 impl device_detection::Host for ComponentCtx {
     fn lookup(&mut self, user_agent: String, max_len: u64) -> Result<Option<String>, types::Error> {
-        if let Some(result) = self.session().device_detection_lookup(&user_agent) {
+        if let Some(result) = self.sandbox().device_detection_lookup(&user_agent) {
             if result.len() > max_len as usize {
                 return Err(types::Error::BufferLen(
                     u64::try_from(result.len()).unwrap_or(0),

--- a/src/component/compute/dictionary.rs
+++ b/src/component/compute/dictionary.rs
@@ -1,12 +1,12 @@
 use {
     crate::component::bindings::fastly::compute::{dictionary, types},
-    crate::linking::{ComponentCtx, SessionView},
+    crate::linking::{ComponentCtx, SandboxView},
     wasmtime::component::Resource,
 };
 
 impl dictionary::HostDictionary for ComponentCtx {
     fn open(&mut self, name: String) -> Result<Resource<dictionary::Dictionary>, types::OpenError> {
-        let handle = self.session_mut().dictionary_handle(name.as_str())?;
+        let handle = self.sandbox_mut().dictionary_handle(name.as_str())?;
         Ok(handle.into())
     }
 
@@ -16,7 +16,7 @@ impl dictionary::HostDictionary for ComponentCtx {
         key: String,
         max_len: u64,
     ) -> Result<Option<String>, types::Error> {
-        let dict = &self.session().dictionary(h.into())?.contents;
+        let dict = &self.sandbox().dictionary(h.into())?.contents;
 
         let item = if let Some(item) = dict.get(&key) {
             item

--- a/src/component/compute/erl.rs
+++ b/src/component/compute/erl.rs
@@ -31,7 +31,7 @@ impl erl::HostRateCounter for ComponentCtx {
         let rc = self.wasi_table.get(&rc).unwrap();
         let pb = self.wasi_table.get(&pb).unwrap();
         crate::component::erl::check_rate(
-            &mut self.session,
+            &mut self.sandbox,
             rc,
             entry,
             delta,
@@ -49,7 +49,7 @@ impl erl::HostRateCounter for ComponentCtx {
         delta: u32,
     ) -> Result<(), types::Error> {
         let rc = self.wasi_table.get(&rc).unwrap();
-        crate::component::erl::ratecounter_increment(&mut self.session, rc, entry, delta)
+        crate::component::erl::ratecounter_increment(&mut self.sandbox, rc, entry, delta)
     }
 
     fn lookup_rate(
@@ -59,7 +59,7 @@ impl erl::HostRateCounter for ComponentCtx {
         window: u32,
     ) -> Result<u32, types::Error> {
         let rc = self.wasi_table.get(&rc).unwrap();
-        crate::component::erl::ratecounter_lookup_rate(&mut self.session, rc, entry, window)
+        crate::component::erl::ratecounter_lookup_rate(&mut self.sandbox, rc, entry, window)
     }
 
     fn lookup_count(
@@ -69,7 +69,7 @@ impl erl::HostRateCounter for ComponentCtx {
         duration: u32,
     ) -> Result<u32, types::Error> {
         let rc = self.wasi_table.get(&rc).unwrap();
-        crate::component::erl::ratecounter_lookup_count(&mut self.session, rc, entry, duration)
+        crate::component::erl::ratecounter_lookup_count(&mut self.sandbox, rc, entry, duration)
     }
 
     fn drop(&mut self, ratecounter: Resource<String>) -> wasmtime::Result<()> {
@@ -91,12 +91,12 @@ impl erl::HostPenaltyBox for ComponentCtx {
 
     fn add(&mut self, pb: Resource<String>, entry: String, ttl: u32) -> Result<(), types::Error> {
         let pb = self.wasi_table.get(&pb).unwrap();
-        crate::component::erl::penaltybox_add(&mut self.session, pb, entry, ttl)
+        crate::component::erl::penaltybox_add(&mut self.sandbox, pb, entry, ttl)
     }
 
     fn has(&mut self, pb: Resource<String>, entry: String) -> Result<bool, types::Error> {
         let pb = self.wasi_table.get(&pb).unwrap();
-        crate::component::erl::penaltybox_has(&mut self.session, pb, entry)
+        crate::component::erl::penaltybox_has(&mut self.sandbox, pb, entry)
     }
 
     fn drop(&mut self, penaltybox: Resource<String>) -> wasmtime::Result<()> {

--- a/src/component/compute/geo.rs
+++ b/src/component/compute/geo.rs
@@ -9,7 +9,7 @@ impl geo::Host for ComponentCtx {
         let ip_addr: IpAddr = addr.into();
 
         let json = self
-            .session()
+            .sandbox()
             .geolocation_lookup(&ip_addr)
             .ok_or(geo::Error::GenericError)?;
 

--- a/src/component/compute/http_body.rs
+++ b/src/component/compute/http_body.rs
@@ -6,7 +6,7 @@ use {
     crate::{
         body::Body,
         error::Error,
-        linking::{ComponentCtx, SessionView},
+        linking::{ComponentCtx, SandboxView},
     },
     http::header::{HeaderName, HeaderValue},
     wasmtime::component::Resource,
@@ -18,7 +18,7 @@ pub const MAX_HEADER_NAME_LEN: usize = (1 << 16) - 1;
 
 impl http_body::Host for ComponentCtx {
     fn new(&mut self) -> Result<Resource<http_body::Body>, types::Error> {
-        Ok(self.session_mut().insert_body(Body::empty()).into())
+        Ok(self.sandbox_mut().insert_body(Body::empty()).into())
     }
 
     async fn write(
@@ -31,11 +31,11 @@ impl http_body::Host for ComponentCtx {
         // Validate the body handle and the buffer.
         let buf = buf.as_slice();
 
-        if self.session().is_streaming_body(h) {
-            let body = self.session_mut().streaming_body_mut(h)?;
+        if self.sandbox().is_streaming_body(h) {
+            let body = self.sandbox_mut().streaming_body_mut(h)?;
             body.send_chunk(buf).await?;
         } else {
-            let body = self.session_mut().body_mut(h)?;
+            let body = self.sandbox_mut().body_mut(h)?;
             body.push_back(buf);
         }
 
@@ -57,14 +57,14 @@ impl http_body::Host for ComponentCtx {
         let buf = buf.as_slice();
 
         // Only normal bodies can be front-written
-        if self.session().is_streaming_body(h) {
+        if self.sandbox().is_streaming_body(h) {
             return Err(Error::Unsupported {
                 msg: "can only write to the end of a streaming body",
             }
             .into());
         }
 
-        let body = self.session_mut().body_mut(h)?;
+        let body = self.sandbox_mut().body_mut(h)?;
         body.push_front(buf);
 
         Ok(())
@@ -75,18 +75,18 @@ impl http_body::Host for ComponentCtx {
         dest: Resource<http_body::Body>,
         src: Resource<http_body::Body>,
     ) -> Result<(), types::Error> {
-        // Take the `src` body out of the session, and get a mutable reference
+        // Take the `src` body out of the sandbox, and get a mutable reference
         // to the `dest` body we will append to.
-        let src = self.session_mut().take_body(src.into())?;
+        let src = self.sandbox_mut().take_body(src.into())?;
 
         let dest = dest.into();
-        if self.session().is_streaming_body(dest) {
-            let dest = self.session_mut().streaming_body_mut(dest)?;
+        if self.sandbox().is_streaming_body(dest) {
+            let dest = self.sandbox_mut().streaming_body_mut(dest)?;
             for chunk in src {
                 dest.send_chunk(chunk).await?;
             }
         } else {
-            let dest = self.session_mut().body_mut(dest)?;
+            let dest = self.sandbox_mut().body_mut(dest)?;
             dest.append(src);
         }
         Ok(())
@@ -100,7 +100,7 @@ impl http_body::Host for ComponentCtx {
         let h = h.into();
 
         // only normal bodies (not streaming bodies) can be read from
-        let body = self.session_mut().body_mut(h)?;
+        let body = self.sandbox_mut().body_mut(h)?;
 
         let mut buffer = vec![0; chunk_size as usize];
         let len = body.read(&mut buffer).await?;
@@ -111,21 +111,21 @@ impl http_body::Host for ComponentCtx {
     fn close(&mut self, h: Resource<http_body::Body>) -> Result<(), types::Error> {
         // Drop the body and pass up an error if the handle does not exist
         let h = h.into();
-        if self.session().is_streaming_body(h) {
+        if self.sandbox().is_streaming_body(h) {
             // Make sure a streaming body gets a `finish` message
-            self.session_mut().take_streaming_body(h)?.finish()?;
+            self.sandbox_mut().take_streaming_body(h)?.finish()?;
             Ok(())
         } else {
-            Ok(self.session_mut().drop_body(h)?)
+            Ok(self.sandbox_mut().drop_body(h)?)
         }
     }
 
     fn get_known_length(&mut self, h: Resource<http_body::Body>) -> Option<u64> {
         let h = h.into();
-        if self.session().is_streaming_body(h) {
+        if self.sandbox().is_streaming_body(h) {
             None
         } else {
-            self.session_mut().body_mut(h).unwrap().len()
+            self.sandbox_mut().body_mut(h).unwrap().len()
         }
     }
 
@@ -137,14 +137,14 @@ impl http_body::Host for ComponentCtx {
     ) -> Result<(), types::Error> {
         // Appending trailers is always allowed for bodies and streaming bodies.
         let h = h.into();
-        if self.session().is_streaming_body(h) {
-            let body = self.session_mut().streaming_body_mut(h)?;
+        if self.sandbox().is_streaming_body(h) {
+            let body = self.sandbox_mut().streaming_body_mut(h)?;
             let name = HeaderName::from_bytes(name.as_bytes())?;
             let value = HeaderValue::from_bytes(value.as_slice())?;
             body.append_trailer(name, value);
             Ok(())
         } else {
-            let trailers = &mut self.session_mut().body_mut(h)?.trailers;
+            let trailers = &mut self.sandbox_mut().body_mut(h)?.trailers;
             if name.len() > MAX_HEADER_NAME_LEN {
                 return Err(Error::InvalidArgument.into());
             }
@@ -165,11 +165,11 @@ impl http_body::Host for ComponentCtx {
         let h = h.into();
 
         // Read operations are not allowed on streaming bodies.
-        if self.session().is_streaming_body(h) {
+        if self.sandbox().is_streaming_body(h) {
             return Err(Error::InvalidArgument.into());
         }
 
-        let body = self.session_mut().body_mut(h)?;
+        let body = self.sandbox_mut().body_mut(h)?;
         if !body.trailers_ready {
             return Err(http_body::TrailerError::NotAvailableYet);
         }
@@ -189,11 +189,11 @@ impl http_body::Host for ComponentCtx {
         let h = h.into();
 
         // Read operations are not allowed on streaming bodies.
-        if self.session().is_streaming_body(h) {
+        if self.sandbox().is_streaming_body(h) {
             return Err(Error::InvalidArgument.into());
         }
 
-        let body = self.session_mut().body_mut(h)?;
+        let body = self.sandbox_mut().body_mut(h)?;
         if !body.trailers_ready {
             return Err(http_body::TrailerError::NotAvailableYet);
         }
@@ -233,11 +233,11 @@ impl http_body::Host for ComponentCtx {
         let h = h.into();
 
         // Read operations are not allowed on streaming bodies.
-        if self.session().is_streaming_body(h) {
+        if self.sandbox().is_streaming_body(h) {
             return Err(Error::InvalidArgument.into());
         }
 
-        let body = self.session_mut().body_mut(h).unwrap();
+        let body = self.sandbox_mut().body_mut(h).unwrap();
         if !body.trailers_ready {
             return Err(http_body::TrailerError::NotAvailableYet);
         }

--- a/src/component/compute/http_downstream.rs
+++ b/src/component/compute/http_downstream.rs
@@ -3,8 +3,8 @@ use std::time::Duration;
 use crate::component::bindings::fastly::compute::{http_body, http_downstream, http_req, types};
 use crate::component::compute::headers::get_names;
 use crate::error::Error;
-use crate::linking::{ComponentCtx, SessionView};
-use crate::session::Session;
+use crate::linking::{ComponentCtx, SandboxView};
+use crate::sandbox::Sandbox;
 use crate::wiggle_abi::types::RequestPromiseHandle;
 use wasmtime::component::Resource;
 use wasmtime_wasi_io::IoView;
@@ -16,7 +16,7 @@ impl http_downstream::Host for ComponentCtx {
     ) -> Result<Resource<http_downstream::PendingRequest>, types::Error> {
         let timeout = options.timeout_ms.map(Duration::from_millis);
         let handle = self
-            .session_mut()
+            .sandbox_mut()
             .register_pending_downstream_req(timeout)
             .await?;
 
@@ -31,7 +31,7 @@ impl http_downstream::Host for ComponentCtx {
     ) -> Result<Option<(Resource<http_req::Request>, Resource<http_body::Body>)>, types::Error>
     {
         let handle = RequestPromiseHandle::from(handle).into();
-        let Some((req, body)) = self.session_mut().await_downstream_req(handle).await? else {
+        let Some((req, body)) = self.sandbox_mut().await_downstream_req(handle).await? else {
             return Ok(None);
         };
 
@@ -42,7 +42,7 @@ impl http_downstream::Host for ComponentCtx {
         &mut self,
         h: Resource<http_req::Request>,
     ) -> Option<types::IpAddress> {
-        self.session()
+        self.sandbox()
             .downstream_client_ip(h.into())
             .ok()?
             .map(|ip| ip.into())
@@ -52,7 +52,7 @@ impl http_downstream::Host for ComponentCtx {
         &mut self,
         h: Resource<http_req::Request>,
     ) -> Option<types::IpAddress> {
-        self.session()
+        self.sandbox()
             .downstream_server_ip(h.into())
             .ok()?
             .map(|ip| ip.into())
@@ -70,7 +70,7 @@ impl http_downstream::Host for ComponentCtx {
         h: Resource<http_req::Request>,
         _max_len: u64,
     ) -> Result<Option<Vec<u8>>, types::Error> {
-        Ok(self.session().absent_metadata_value(h)?)
+        Ok(self.sandbox().absent_metadata_value(h)?)
     }
 
     fn downstream_tls_protocol(
@@ -78,7 +78,7 @@ impl http_downstream::Host for ComponentCtx {
         h: Resource<http_req::Request>,
         _max_len: u64,
     ) -> Result<Option<Vec<u8>>, types::Error> {
-        Ok(self.session().absent_metadata_value(h)?)
+        Ok(self.sandbox().absent_metadata_value(h)?)
     }
 
     fn downstream_tls_client_servername(
@@ -86,7 +86,7 @@ impl http_downstream::Host for ComponentCtx {
         h: Resource<http_req::Request>,
         _max_len: u64,
     ) -> Result<Option<String>, types::Error> {
-        self.session().absent_metadata_value(h).map_err(Into::into)
+        self.sandbox().absent_metadata_value(h).map_err(Into::into)
     }
 
     fn downstream_tls_client_hello(
@@ -94,7 +94,7 @@ impl http_downstream::Host for ComponentCtx {
         h: Resource<http_req::Request>,
         _max_len: u64,
     ) -> Result<Option<Vec<u8>>, types::Error> {
-        Ok(self.session().absent_metadata_value(h)?)
+        Ok(self.sandbox().absent_metadata_value(h)?)
     }
 
     fn downstream_tls_raw_client_certificate(
@@ -102,21 +102,21 @@ impl http_downstream::Host for ComponentCtx {
         h: Resource<http_req::Request>,
         _max_len: u64,
     ) -> Result<Option<Vec<u8>>, types::Error> {
-        Ok(self.session().absent_metadata_value(h)?)
+        Ok(self.sandbox().absent_metadata_value(h)?)
     }
 
     fn downstream_tls_client_cert_verify_result(
         &mut self,
         h: Resource<http_req::Request>,
     ) -> Result<Option<http_req::ClientCertVerifyResult>, types::Error> {
-        Ok(self.session().absent_metadata_value(h)?)
+        Ok(self.sandbox().absent_metadata_value(h)?)
     }
 
     fn downstream_tls_ja3_md5(
         &mut self,
         h: Resource<http_req::Request>,
     ) -> Result<Option<Vec<u8>>, types::Error> {
-        Ok(self.session().absent_metadata_value(h)?)
+        Ok(self.sandbox().absent_metadata_value(h)?)
     }
 
     fn downstream_client_h2_fingerprint(
@@ -125,7 +125,7 @@ impl http_downstream::Host for ComponentCtx {
         _max_len: u64,
     ) -> Result<String, types::Error> {
         Ok(self
-            .session()
+            .sandbox()
             .absent_metadata_value(h)?
             .ok_or(Error::MissingDownstreamMetadata)?)
     }
@@ -136,7 +136,7 @@ impl http_downstream::Host for ComponentCtx {
         max_len: u64,
     ) -> Result<String, types::Error> {
         let reqid = self
-            .session()
+            .sandbox()
             .downstream_request_id(h.into())?
             .ok_or(Error::MissingDownstreamMetadata)?;
         let result = format!("{:032x}", reqid);
@@ -156,7 +156,7 @@ impl http_downstream::Host for ComponentCtx {
         _max_len: u64,
     ) -> Result<String, types::Error> {
         Ok(self
-            .session()
+            .sandbox()
             .absent_metadata_value(h)?
             .ok_or(Error::MissingDownstreamMetadata)?)
     }
@@ -166,7 +166,7 @@ impl http_downstream::Host for ComponentCtx {
         h: Resource<http_req::Request>,
         _max_len: u64,
     ) -> Result<Option<String>, types::Error> {
-        Ok(self.session().absent_metadata_value(h)?)
+        Ok(self.sandbox().absent_metadata_value(h)?)
     }
 
     fn downstream_compliance_region(
@@ -174,7 +174,7 @@ impl http_downstream::Host for ComponentCtx {
         h: Resource<http_req::Request>,
         region_max_len: u64,
     ) -> Result<Option<String>, types::Error> {
-        let region = Session::downstream_compliance_region(self.session(), h.into())?
+        let region = Sandbox::downstream_compliance_region(self.sandbox(), h.into())?
             .ok_or(Error::MissingDownstreamMetadata)?;
         let region_len = region.len();
 
@@ -191,7 +191,7 @@ impl http_downstream::Host for ComponentCtx {
         cursor: u32,
     ) -> Result<(String, Option<u32>), types::Error> {
         let headers = self
-            .session()
+            .sandbox()
             .downstream_original_headers(h.into())?
             .ok_or(Error::MissingDownstreamMetadata)?;
         let res = get_names(headers.keys(), max_len, cursor)?;
@@ -204,7 +204,7 @@ impl http_downstream::Host for ComponentCtx {
         h: Resource<http_req::Request>,
     ) -> Result<u32, types::Error> {
         Ok(self
-            .session()
+            .sandbox()
             .downstream_original_headers(h.into())?
             .ok_or(Error::MissingDownstreamMetadata)?
             .len()
@@ -216,7 +216,7 @@ impl http_downstream::Host for ComponentCtx {
         &mut self,
         h: Resource<http_req::Request>,
     ) -> Result<bool, types::Error> {
-        self.session()
+        self.sandbox()
             .check_fastly_key(h.into())
             .map_err(Into::into)
     }
@@ -377,7 +377,7 @@ pub(in super::super) trait MetadataView {
         handle: Resource<http_req::Request>,
     ) -> Result<Option<T>, Error>;
 }
-impl MetadataView for Session {
+impl MetadataView for Sandbox {
     fn absent_metadata_value<T>(
         &self,
         handle: Resource<http_req::Request>,

--- a/src/component/compute/http_req.rs
+++ b/src/component/compute/http_req.rs
@@ -5,8 +5,8 @@ use {
             compute::headers::{get_names, get_values},
         },
         error::Error,
-        linking::{ComponentCtx, SessionView},
-        session::ViceroyRequestMetadata,
+        linking::{ComponentCtx, SandboxView},
+        sandbox::ViceroyRequestMetadata,
     },
     http::{
         Method, Uri,
@@ -52,7 +52,7 @@ impl http_req::Host for ComponentCtx {
     ) -> Result<http_resp::ResponseWithBody, http_req::ErrorWithDetail> {
         let backend_name = self.wasi_table.get(&backend_name).unwrap();
 
-        crate::component::http_req::send(&mut self.session, h, b, backend_name).await
+        crate::component::http_req::send(&mut self.sandbox, h, b, backend_name).await
     }
 
     async fn send_uncached(
@@ -63,7 +63,7 @@ impl http_req::Host for ComponentCtx {
     ) -> Result<http_resp::ResponseWithBody, http_req::ErrorWithDetail> {
         let backend_name = self.wasi_table.get(&backend_name).unwrap();
 
-        crate::component::http_req::send_uncached(&mut self.session, h, b, backend_name).await
+        crate::component::http_req::send_uncached(&mut self.sandbox, h, b, backend_name).await
     }
 
     async fn send_async(
@@ -74,7 +74,7 @@ impl http_req::Host for ComponentCtx {
     ) -> Result<Resource<http_req::PendingRequest>, types::Error> {
         let backend_name = self.wasi_table.get(&backend_name).unwrap();
 
-        crate::component::http_req::send_async(&mut self.session, h, b, backend_name).await
+        crate::component::http_req::send_async(&mut self.sandbox, h, b, backend_name).await
     }
 
     async fn send_async_uncached(
@@ -85,7 +85,7 @@ impl http_req::Host for ComponentCtx {
     ) -> Result<Resource<http_req::PendingRequest>, types::Error> {
         let backend_name = self.wasi_table.get(&backend_name).unwrap();
 
-        crate::component::http_req::send_async_uncached(&mut self.session, h, b, backend_name).await
+        crate::component::http_req::send_async_uncached(&mut self.sandbox, h, b, backend_name).await
     }
 
     async fn send_async_uncached_streaming(
@@ -97,7 +97,7 @@ impl http_req::Host for ComponentCtx {
         let backend_name = self.wasi_table.get(&backend_name).unwrap();
 
         crate::component::http_req::send_async_uncached_streaming(
-            &mut self.session,
+            &mut self.sandbox,
             h,
             b,
             backend_name,
@@ -113,7 +113,7 @@ impl http_req::Host for ComponentCtx {
     ) -> Result<Resource<http_req::PendingRequest>, types::Error> {
         let backend_name = self.wasi_table.get(&backend_name).unwrap();
 
-        crate::component::http_req::send_async_streaming(&mut self.session, h, b, backend_name)
+        crate::component::http_req::send_async_streaming(&mut self.sandbox, h, b, backend_name)
             .await
     }
 
@@ -122,27 +122,27 @@ impl http_req::Host for ComponentCtx {
         h: Resource<http_req::PendingRequest>,
     ) -> Result<http_resp::ResponseWithBody, http_req::ErrorWithDetail> {
         let pending_req = self
-            .session_mut()
+            .sandbox_mut()
             .take_pending_request(h.into())
             .unwrap()
             .recv()
             .await
             .map_err(Into::into)
             .map_err(types::Error::with_empty_detail)?;
-        let (resp_handle, body_handle) = self.session_mut().insert_response(pending_req);
+        let (resp_handle, body_handle) = self.sandbox_mut().insert_response(pending_req);
         Ok((resp_handle.into(), body_handle.into()))
     }
 
     fn close(&mut self, h: Resource<http_req::Request>) -> Result<(), types::Error> {
         // We don't do anything with the parts, but we do pass the error up if
         // the handle given doesn't exist
-        self.session_mut().take_request_parts(h.into())?;
+        self.sandbox_mut().take_request_parts(h.into())?;
         Ok(())
     }
 
     fn upgrade_websocket(&mut self, backend: Resource<String>) -> Result<(), types::Error> {
         let backend = self.wasi_table.get(&backend).unwrap();
-        crate::component::http_req::upgrade_websocket(&mut self.session, backend)
+        crate::component::http_req::upgrade_websocket(&mut self.sandbox, backend)
     }
 }
 
@@ -152,7 +152,7 @@ impl http_req::HostRequest for ComponentCtx {
         h: Resource<http_req::Request>,
         max_len: u64,
     ) -> Result<String, types::Error> {
-        let req = self.session.request_parts(h.into())?;
+        let req = self.sandbox.request_parts(h.into())?;
         let req_method = &req.method;
 
         if req_method.as_str().len() > usize::try_from(max_len).unwrap() {
@@ -169,7 +169,7 @@ impl http_req::HostRequest for ComponentCtx {
         h: Resource<http_req::Request>,
         max_len: u64,
     ) -> Result<String, types::Error> {
-        let req = self.session().request_parts(h.into())?;
+        let req = self.sandbox().request_parts(h.into())?;
         let req_uri = &req.uri;
         let res = req_uri.to_string();
 
@@ -191,7 +191,7 @@ impl http_req::HostRequest for ComponentCtx {
 
     fn new(&mut self) -> Result<Resource<http_req::Request>, types::Error> {
         let (parts, _) = Request::new(()).into_parts();
-        Ok(self.session_mut().insert_request_parts(parts).into())
+        Ok(self.sandbox_mut().insert_request_parts(parts).into())
     }
 
     fn get_header_names(
@@ -200,7 +200,7 @@ impl http_req::HostRequest for ComponentCtx {
         max_len: u64,
         cursor: u32,
     ) -> Result<(String, Option<u32>), types::Error> {
-        let headers = &self.session().request_parts(h.into())?.headers;
+        let headers = &self.sandbox().request_parts(h.into())?.headers;
 
         let (buf, next) = get_names(headers.keys(), max_len, cursor)?;
 
@@ -217,7 +217,7 @@ impl http_req::HostRequest for ComponentCtx {
             return Err(Error::InvalidArgument.into());
         }
 
-        let headers = &self.session().request_parts(h.into())?.headers;
+        let headers = &self.sandbox().request_parts(h.into())?.headers;
         let value = if let Some(value) = headers.get(&name) {
             value
         } else {
@@ -238,7 +238,7 @@ impl http_req::HostRequest for ComponentCtx {
         max_len: u64,
         cursor: u32,
     ) -> Result<(Vec<u8>, Option<u32>), types::Error> {
-        let headers = &self.session().request_parts(h.into()).unwrap().headers;
+        let headers = &self.sandbox().request_parts(h.into()).unwrap().headers;
 
         let (buf, next) = get_values(headers, &name, max_len, cursor)?;
 
@@ -255,7 +255,7 @@ impl http_req::HostRequest for ComponentCtx {
             return Err(Error::InvalidArgument.into());
         }
 
-        let headers = &mut self.session_mut().request_parts_mut(h.into())?.headers;
+        let headers = &mut self.sandbox_mut().request_parts_mut(h.into())?.headers;
 
         let name = HeaderName::from_bytes(name.as_bytes())?;
         let values = {
@@ -289,7 +289,7 @@ impl http_req::HostRequest for ComponentCtx {
             return Err(Error::InvalidArgument.into());
         }
 
-        let headers = &mut self.session_mut().request_parts_mut(h.into())?.headers;
+        let headers = &mut self.sandbox_mut().request_parts_mut(h.into())?.headers;
         let name = HeaderName::from_bytes(name.as_bytes())?;
         let value = HeaderValue::from_bytes(value.as_slice())?;
         headers.insert(name, value);
@@ -307,7 +307,7 @@ impl http_req::HostRequest for ComponentCtx {
             return Err(Error::InvalidArgument.into());
         }
 
-        let headers = &mut self.session_mut().request_parts_mut(h.into())?.headers;
+        let headers = &mut self.sandbox_mut().request_parts_mut(h.into())?.headers;
         let name = HeaderName::from_bytes(name.as_bytes())?;
         let value = HeaderValue::from_bytes(value.as_slice())?;
         headers.append(name, value);
@@ -324,7 +324,7 @@ impl http_req::HostRequest for ComponentCtx {
             return Err(Error::InvalidArgument.into());
         }
 
-        let headers = &mut self.session_mut().request_parts_mut(h.into())?.headers;
+        let headers = &mut self.sandbox_mut().request_parts_mut(h.into())?.headers;
         let name = HeaderName::from_bytes(name.as_bytes())?;
         headers.remove(name).ok_or(types::Error::InvalidArgument)?;
 
@@ -336,13 +336,13 @@ impl http_req::HostRequest for ComponentCtx {
         h: Resource<http_req::Request>,
         method: String,
     ) -> Result<(), types::Error> {
-        let method_ref = &mut self.session_mut().request_parts_mut(h.into())?.method;
+        let method_ref = &mut self.sandbox_mut().request_parts_mut(h.into())?.method;
         *method_ref = Method::from_bytes(method.as_bytes())?;
         Ok(())
     }
 
     fn set_uri(&mut self, h: Resource<http_req::Request>, uri: String) -> Result<(), types::Error> {
-        let uri_ref = &mut self.session_mut().request_parts_mut(h.into())?.uri;
+        let uri_ref = &mut self.sandbox_mut().request_parts_mut(h.into())?.uri;
         *uri_ref = Uri::try_from(uri.as_bytes())?;
         Ok(())
     }
@@ -351,7 +351,7 @@ impl http_req::HostRequest for ComponentCtx {
         &mut self,
         h: Resource<http_req::Request>,
     ) -> Result<http_types::HttpVersion, types::Error> {
-        let req = self.session().request_parts(h.into())?;
+        let req = self.sandbox().request_parts(h.into())?;
         let version = http_types::HttpVersion::try_from(req.version)?;
         Ok(version)
     }
@@ -361,7 +361,7 @@ impl http_req::HostRequest for ComponentCtx {
         h: Resource<http_req::Request>,
         version: http_types::HttpVersion,
     ) -> Result<(), types::Error> {
-        let req = self.session_mut().request_parts_mut(h.into())?;
+        let req = self.sandbox_mut().request_parts_mut(h.into())?;
         req.version = hyper::Version::from(version);
         Ok(())
     }
@@ -374,8 +374,8 @@ impl http_req::HostRequest for ComponentCtx {
         use crate::wiggle_abi::types;
 
         // NOTE: We're going to hide this flag in the extensions of the request in order to decrease
-        // the book-keeping burden inside Session. The flag will get picked up later, in `send_request`.
-        let extensions = &mut self.session_mut().request_parts_mut(h.into())?.extensions;
+        // the book-keeping burden inside Sandbox. The flag will get picked up later, in `send_request`.
+        let extensions = &mut self.sandbox_mut().request_parts_mut(h.into())?.extensions;
 
         let encodings = types::ContentEncodings::try_from(encodings.as_array()[0])?;
 
@@ -400,7 +400,7 @@ impl http_req::HostRequest for ComponentCtx {
         backend: Resource<String>,
     ) -> Result<(), types::Error> {
         let backend = self.wasi_table.get(&backend).unwrap();
-        crate::component::http_req::redirect_to_websocket_proxy(&mut self.session, handle, backend)
+        crate::component::http_req::redirect_to_websocket_proxy(&mut self.sandbox, handle, backend)
     }
 
     fn set_framing_headers_mode(
@@ -417,7 +417,7 @@ impl http_req::HostRequest for ComponentCtx {
             }
         };
 
-        let extensions = &mut self.session_mut().request_parts_mut(h.into())?.extensions;
+        let extensions = &mut self.sandbox_mut().request_parts_mut(h.into())?.extensions;
 
         match extensions.get_mut::<ViceroyRequestMetadata>() {
             None => {
@@ -440,7 +440,7 @@ impl http_req::HostRequest for ComponentCtx {
         backend: Resource<String>,
     ) -> Result<(), types::Error> {
         let backend = self.wasi_table.get(&backend).unwrap();
-        crate::component::http_req::redirect_to_grip_proxy(&mut self.session, req_handle, backend)
+        crate::component::http_req::redirect_to_grip_proxy(&mut self.sandbox, req_handle, backend)
     }
 
     fn drop(&mut self, _request: Resource<http_req::Request>) -> wasmtime::Result<()> {

--- a/src/component/compute/http_resp.rs
+++ b/src/component/compute/http_resp.rs
@@ -5,8 +5,8 @@ use {
             compute::headers::get_names,
         },
         error::Error,
-        linking::{ComponentCtx, SessionView},
-        session::ViceroyResponseMetadata,
+        linking::{ComponentCtx, SandboxView},
+        sandbox::ViceroyResponseMetadata,
         upstream,
     },
     cfg_if::cfg_if,
@@ -29,13 +29,13 @@ impl http_resp::Host for ComponentCtx {
         b: Resource<http_body::Body>,
     ) -> Result<(), types::Error> {
         let resp = {
-            // Take the response parts and body from the session, and use them to build a response.
+            // Take the response parts and body from the sandbox, and use them to build a response.
             // Return an `FastlyStatus::Badf` error code if either of the given handles are invalid.
-            let resp_parts = self.session_mut().take_response_parts(h.into())?;
-            let body = self.session_mut().take_body(b.into())?;
+            let resp_parts = self.sandbox_mut().take_response_parts(h.into())?;
+            let body = self.sandbox_mut().take_body(b.into())?;
             Response::from_parts(resp_parts, body)
         }; // Set the downstream response, and return.
-        self.session_mut().send_downstream_response(resp)?;
+        self.sandbox_mut().send_downstream_response(resp)?;
         Ok(())
     }
 
@@ -45,20 +45,20 @@ impl http_resp::Host for ComponentCtx {
         b: Resource<http_body::Body>,
     ) -> Result<(), types::Error> {
         let resp = {
-            // Take the response parts and body from the session, and use them to build a response.
+            // Take the response parts and body from the sandbox, and use them to build a response.
             // Return an `FastlyStatus::Badf` error code if either of the given handles are invalid.
-            let resp_parts = self.session_mut().take_response_parts(h.into())?;
-            let body = self.session_mut().begin_streaming(b.into())?;
+            let resp_parts = self.sandbox_mut().take_response_parts(h.into())?;
+            let body = self.sandbox_mut().begin_streaming(b.into())?;
             Response::from_parts(resp_parts, body)
         }; // Set the downstream response, and return.
-        self.session_mut().send_downstream_response(resp)?;
+        self.sandbox_mut().send_downstream_response(resp)?;
         Ok(())
     }
 
     fn close(&mut self, h: Resource<http_resp::Response>) -> Result<(), types::Error> {
         // We don't do anything with the parts, but we do pass the error up if
         // the handle given doesn't exist
-        self.session_mut().take_response_parts(h.into())?;
+        self.sandbox_mut().take_response_parts(h.into())?;
         Ok(())
     }
 }
@@ -66,14 +66,14 @@ impl http_resp::Host for ComponentCtx {
 impl http_resp::HostResponse for ComponentCtx {
     fn new(&mut self) -> Result<Resource<http_resp::Response>, types::Error> {
         let (parts, _) = Response::new(()).into_parts();
-        Ok(self.session_mut().insert_response_parts(parts).into())
+        Ok(self.sandbox_mut().insert_response_parts(parts).into())
     }
 
     fn get_status(
         &mut self,
         h: Resource<http_resp::Response>,
     ) -> Result<http_types::HttpStatus, types::Error> {
-        let parts = self.session().response_parts(h.into())?;
+        let parts = self.sandbox().response_parts(h.into())?;
         Ok(parts.status.as_u16())
     }
 
@@ -82,7 +82,7 @@ impl http_resp::HostResponse for ComponentCtx {
         h: Resource<http_resp::Response>,
         status: http_types::HttpStatus,
     ) -> Result<(), types::Error> {
-        let resp = self.session_mut().response_parts_mut(h.into())?;
+        let resp = self.sandbox_mut().response_parts_mut(h.into())?;
         let status = hyper::StatusCode::from_u16(status)?;
         resp.status = status;
         Ok(())
@@ -98,7 +98,7 @@ impl http_resp::HostResponse for ComponentCtx {
             Err(types::Error::InvalidArgument)?;
         }
 
-        let headers = &mut self.session_mut().response_parts_mut(h.into())?.headers;
+        let headers = &mut self.sandbox_mut().response_parts_mut(h.into())?.headers;
         let name = HeaderName::from_bytes(name.as_bytes())?;
         let value = HeaderValue::from_bytes(value.as_slice())?;
         headers.append(name, value);
@@ -111,7 +111,7 @@ impl http_resp::HostResponse for ComponentCtx {
         max_len: u64,
         cursor: u32,
     ) -> Result<(String, Option<u32>), types::Error> {
-        let headers = &self.session_mut().response_parts(h.into())?.headers;
+        let headers = &self.sandbox_mut().response_parts(h.into())?.headers;
 
         let (buf, next) = get_names(headers.keys(), max_len, cursor)?;
 
@@ -128,7 +128,7 @@ impl http_resp::HostResponse for ComponentCtx {
             return Err(Error::InvalidArgument.into());
         }
 
-        let headers = &self.session().response_parts(h.into())?.headers;
+        let headers = &self.sandbox().response_parts(h.into())?.headers;
         let value = if let Some(value) = headers.get(&name) {
             value
         } else {
@@ -162,7 +162,7 @@ impl http_resp::HostResponse for ComponentCtx {
                     return Ok(Err(Error::InvalidArgument.into()));
                 }
 
-                let headers = &self.session().response_parts(h.into()).unwrap().headers;
+                let headers = &self.sandbox().response_parts(h.into()).unwrap().headers;
 
                 let (buf, next) = match get_values(
                     headers,
@@ -189,7 +189,7 @@ impl http_resp::HostResponse for ComponentCtx {
             return Err(Error::InvalidArgument.into());
         }
 
-        let headers = &mut self.session_mut().response_parts_mut(h.into())?.headers;
+        let headers = &mut self.sandbox_mut().response_parts_mut(h.into())?.headers;
 
         let name = HeaderName::from_bytes(name.as_bytes())?;
         let values = {
@@ -223,7 +223,7 @@ impl http_resp::HostResponse for ComponentCtx {
             return Err(Error::InvalidArgument.into());
         }
 
-        let headers = &mut self.session_mut().response_parts_mut(h.into())?.headers;
+        let headers = &mut self.sandbox_mut().response_parts_mut(h.into())?.headers;
         let name = HeaderName::from_bytes(name.as_bytes())?;
         let value = HeaderValue::from_bytes(value.as_slice())?;
         headers.insert(name, value);
@@ -240,7 +240,7 @@ impl http_resp::HostResponse for ComponentCtx {
             return Err(Error::InvalidArgument.into());
         }
 
-        let headers = &mut self.session_mut().response_parts_mut(h.into())?.headers;
+        let headers = &mut self.sandbox_mut().response_parts_mut(h.into())?.headers;
         let name = HeaderName::from_bytes(name.as_bytes())?;
         headers.remove(name).ok_or(types::Error::InvalidArgument)?;
 
@@ -251,7 +251,7 @@ impl http_resp::HostResponse for ComponentCtx {
         &mut self,
         h: Resource<http_resp::Response>,
     ) -> Result<http_types::HttpVersion, types::Error> {
-        let req = self.session().response_parts(h.into())?;
+        let req = self.sandbox().response_parts(h.into())?;
         let version = http_types::HttpVersion::try_from(req.version)?;
         Ok(version)
     }
@@ -261,7 +261,7 @@ impl http_resp::HostResponse for ComponentCtx {
         h: Resource<http_resp::Response>,
         version: http_types::HttpVersion,
     ) -> Result<(), types::Error> {
-        let req = self.session_mut().response_parts_mut(h.into())?;
+        let req = self.sandbox_mut().response_parts_mut(h.into())?;
         req.version = hyper::Version::from(version);
         Ok(())
     }
@@ -280,7 +280,7 @@ impl http_resp::HostResponse for ComponentCtx {
             }
         };
 
-        let extensions = &mut self.session_mut().response_parts_mut(h.into())?.extensions;
+        let extensions = &mut self.sandbox_mut().response_parts_mut(h.into())?.extensions;
 
         match extensions.get_mut::<ViceroyResponseMetadata>() {
             None => {
@@ -318,14 +318,14 @@ impl http_resp::HostResponse for ComponentCtx {
         &mut self,
         resp_handle: Resource<http_resp::Response>,
     ) -> Option<http_resp::IpAddress> {
-        let resp = self.session().response_parts(resp_handle.into()).unwrap();
+        let resp = self.sandbox().response_parts(resp_handle.into()).unwrap();
         let md = resp.extensions.get::<upstream::ConnMetadata>()?;
 
         Some(md.remote_addr.ip().into())
     }
 
     fn get_remote_port(&mut self, resp_handle: Resource<http_resp::Response>) -> Option<u16> {
-        let resp = self.session().response_parts(resp_handle.into()).unwrap();
+        let resp = self.sandbox().response_parts(resp_handle.into()).unwrap();
         let md = resp.extensions.get::<upstream::ConnMetadata>()?;
         let port = md.remote_addr.port();
         Some(port)

--- a/src/component/compute/image_optimizer.rs
+++ b/src/component/compute/image_optimizer.rs
@@ -15,7 +15,7 @@ impl image_optimizer::Host for ComponentCtx {
         let origin_image_request_backend =
             self.wasi_table.get(&origin_image_request_backend).unwrap();
         crate::component::image_optimizer::transform_image_optimizer_request(
-            &mut self.session,
+            &mut self.sandbox,
             origin_image_request,
             origin_image_request_body,
             origin_image_request_backend,

--- a/src/component/compute/kv_store.rs
+++ b/src/component/compute/kv_store.rs
@@ -6,9 +6,9 @@ use {
     },
     crate::{
         error::Error,
-        linking::{ComponentCtx, SessionView},
+        linking::{ComponentCtx, SandboxView},
         object_store::ObjectKey,
-        session::{
+        sandbox::{
             PeekableTask, PendingKvDeleteTask, PendingKvInsertTask, PendingKvListTask,
             PendingKvLookupTask,
         },
@@ -74,7 +74,7 @@ impl kv_store::Host for ComponentCtx {
     > {
         let handle = KvStoreLookupHandle::from(handle).into();
         let resp = self
-            .session_mut()
+            .sandbox_mut()
             .take_pending_kv_lookup(handle)
             .unwrap()
             .task()
@@ -84,7 +84,7 @@ impl kv_store::Host for ComponentCtx {
         match resp {
             Ok(Some(value)) => {
                 let lr = kv_store::Entry {
-                    body: Some(self.session_mut().insert_body(value.body.into()).into()),
+                    body: Some(self.sandbox_mut().insert_body(value.body.into()).into()),
                     metadata: match value.metadata_len {
                         0 => None,
                         _ => Some(value.metadata),
@@ -107,7 +107,7 @@ impl kv_store::Host for ComponentCtx {
     ) -> Result<(), kv_store::KvError> {
         let handle = KvStoreInsertHandle::from(handle).into();
         let resp = self
-            .session_mut()
+            .sandbox_mut()
             .take_pending_kv_insert(handle)
             .unwrap()
             .task()
@@ -126,7 +126,7 @@ impl kv_store::Host for ComponentCtx {
     ) -> Result<bool, kv_store::KvError> {
         let handle = KvStoreDeleteHandle::from(handle).into();
         let resp = self
-            .session_mut()
+            .sandbox_mut()
             .take_pending_kv_delete(handle)
             .unwrap()
             .task()
@@ -145,7 +145,7 @@ impl kv_store::Host for ComponentCtx {
     ) -> Result<Resource<kv_store::Body>, kv_store::KvError> {
         let handle = KvStoreListHandle::from(handle).into();
         let resp = self
-            .session_mut()
+            .sandbox_mut()
             .take_pending_kv_list(handle)
             .unwrap()
             .task()
@@ -153,7 +153,7 @@ impl kv_store::Host for ComponentCtx {
             .await?;
 
         match resp {
-            Ok(value) => Ok(self.session_mut().insert_body(value.into()).into()),
+            Ok(value) => Ok(self.sandbox_mut().insert_body(value.into()).into()),
             Err(e) => Err(e.into()),
         }
     }
@@ -162,12 +162,12 @@ impl kv_store::Host for ComponentCtx {
 impl kv_store::HostStore for ComponentCtx {
     fn open(&mut self, name: String) -> Result<Resource<kv_store::Store>, types::OpenError> {
         if self
-            .session()
+            .sandbox()
             .kv_store()
             .store_exists(&name)
             .map_err(Error::ObjectStoreError)?
         {
-            let h = self.session_mut().kv_store_handle(&name);
+            let h = self.sandbox_mut().kv_store_handle(&name);
             Ok(h.into())
         } else {
             Err(types::OpenError::NotFound)
@@ -190,12 +190,12 @@ impl kv_store::HostStore for ComponentCtx {
         store: Resource<kv_store::Store>,
         key: String,
     ) -> Result<Resource<kv_store::PendingLookup>, types::Error> {
-        let store = self.session.get_kv_store_key(store.into()).unwrap();
+        let store = self.sandbox.get_kv_store_key(store.into()).unwrap();
         // just create a future that's already ready
-        let fut = futures::future::ok(self.session.obj_lookup(store.clone(), ObjectKey::new(key)?));
+        let fut = futures::future::ok(self.sandbox.obj_lookup(store.clone(), ObjectKey::new(key)?));
         let task = PeekableTask::spawn(fut).await;
         let lh = self
-            .session_mut()
+            .sandbox_mut()
             .insert_pending_kv_lookup(PendingKvLookupTask::new(task));
         Ok(KvStoreLookupHandle::from(lh).into())
     }
@@ -221,11 +221,11 @@ impl kv_store::HostStore for ComponentCtx {
         options: kv_store::InsertOptions,
     ) -> Result<Resource<kv_store::PendingInsert>, types::Error> {
         let body = self
-            .session_mut()
+            .sandbox_mut()
             .take_body(body_handle.into())?
             .read_into_vec()
             .await?;
-        let store = self.session.get_kv_store_key(store.into()).unwrap();
+        let store = self.sandbox.get_kv_store_key(store.into()).unwrap();
 
         let mode = match options.mode {
             InsertMode::Overwrite => KvInsertMode::Overwrite,
@@ -241,7 +241,7 @@ impl kv_store::HostStore for ComponentCtx {
             .time_to_live_sec
             .map(|time_to_live_sec| std::time::Duration::from_secs(time_to_live_sec as u64));
 
-        let fut = futures::future::ok(self.session.kv_insert(
+        let fut = futures::future::ok(self.sandbox.kv_insert(
             store.clone(),
             ObjectKey::new(key)?,
             body,
@@ -252,7 +252,7 @@ impl kv_store::HostStore for ComponentCtx {
         ));
         let task = PeekableTask::spawn(fut).await;
         let handle = self
-            .session
+            .sandbox
             .insert_pending_kv_insert(PendingKvInsertTask::new(task));
         Ok(handle.into())
     }
@@ -273,12 +273,12 @@ impl kv_store::HostStore for ComponentCtx {
         store: Resource<kv_store::Store>,
         key: String,
     ) -> Result<Resource<kv_store::PendingDelete>, types::Error> {
-        let store = self.session.get_kv_store_key(store.into()).unwrap();
+        let store = self.sandbox.get_kv_store_key(store.into()).unwrap();
         // just create a future that's already ready
-        let fut = futures::future::ok(self.session.kv_delete(store.clone(), ObjectKey::new(key)?));
+        let fut = futures::future::ok(self.sandbox.kv_delete(store.clone(), ObjectKey::new(key)?));
         let task = PeekableTask::spawn(fut).await;
         let lh = self
-            .session
+            .sandbox
             .insert_pending_kv_delete(PendingKvDeleteTask::new(task));
         Ok(KvStoreDeleteHandle::from(lh).into())
     }
@@ -299,16 +299,16 @@ impl kv_store::HostStore for ComponentCtx {
         store: Resource<kv_store::Store>,
         options: kv_store::ListOptions,
     ) -> Result<Resource<kv_store::PendingList>, types::Error> {
-        let store = self.session.get_kv_store_key(store.into()).unwrap();
+        let store = self.sandbox.get_kv_store_key(store.into()).unwrap();
 
         let cursor = options.cursor;
         let prefix = options.prefix;
         let limit = options.limit;
 
-        let fut = futures::future::ok(self.session.kv_list(store.clone(), cursor, prefix, limit));
+        let fut = futures::future::ok(self.sandbox.kv_list(store.clone(), cursor, prefix, limit));
         let task = PeekableTask::spawn(fut).await;
         let handle = self
-            .session
+            .sandbox
             .insert_pending_kv_list(PendingKvListTask::new(task));
         Ok(KvStoreListHandle::from(handle).into())
     }

--- a/src/component/compute/log.rs
+++ b/src/component/compute/log.rs
@@ -1,6 +1,6 @@
 use {
     crate::component::bindings::fastly::compute::{log, types},
-    crate::linking::{ComponentCtx, SessionView},
+    crate::linking::{ComponentCtx, SandboxView},
     lazy_static::lazy_static,
     wasmtime::component::Resource,
 };
@@ -27,11 +27,11 @@ impl log::HostEndpoint for ComponentCtx {
             return Err(types::OpenError::Reserved);
         }
 
-        Ok(self.session_mut().log_endpoint_handle(name).into())
+        Ok(self.sandbox_mut().log_endpoint_handle(name).into())
     }
 
     fn write(&mut self, h: Resource<log::Endpoint>, msg: Vec<u8>) {
-        let endpoint = self.session().log_endpoint(h.into()).unwrap();
+        let endpoint = self.sandbox().log_endpoint(h.into()).unwrap();
 
         // The log API is infallible, so if we get an error, warn about it
         // rather than bubbling it up through the log API.

--- a/src/component/compute/purge.rs
+++ b/src/component/compute/purge.rs
@@ -13,7 +13,7 @@ impl purge::Host for ComponentCtx {
     ) -> Result<(), types::Error> {
         let soft_purge = options.soft_purge;
         let surrogate_key = surrogate_key.parse()?;
-        let purged = self.session().cache().purge(surrogate_key, soft_purge);
+        let purged = self.sandbox().cache().purge(surrogate_key, soft_purge);
         tracing::debug!("{purged} variants purged");
         Ok(())
     }

--- a/src/component/compute/secret_store.rs
+++ b/src/component/compute/secret_store.rs
@@ -2,7 +2,7 @@ use {
     crate::component::bindings::fastly::compute::{secret_store, types},
     crate::{
         error::Error,
-        linking::{ComponentCtx, SessionView},
+        linking::{ComponentCtx, SandboxView},
         secret_store::SecretLookup,
         wiggle_abi::SecretStoreError,
     },
@@ -14,7 +14,7 @@ impl secret_store::Host for ComponentCtx {}
 impl secret_store::HostStore for ComponentCtx {
     fn open(&mut self, name: String) -> Result<Resource<secret_store::Store>, types::OpenError> {
         let handle = self
-            .session_mut()
+            .sandbox_mut()
             .secret_store_handle(&name)
             .ok_or(types::OpenError::NotFound)?;
         Ok(handle.into())
@@ -27,11 +27,11 @@ impl secret_store::HostStore for ComponentCtx {
     ) -> Result<Option<Resource<secret_store::Secret>>, types::Error> {
         let store = store.into();
         let store_name = self
-            .session()
+            .sandbox()
             .secret_store_name(store)
             .ok_or_else(|| types::Error::from(SecretStoreError::InvalidSecretStoreHandle(store)))?;
         Ok(self
-            .session_mut()
+            .sandbox_mut()
             .secret_handle(&store_name, &key)
             .map(From::from))
     }
@@ -49,7 +49,7 @@ impl secret_store::HostSecret for ComponentCtx {
     ) -> Result<Vec<u8>, types::Error> {
         let secret = secret.into();
         let lookup = self
-            .session()
+            .sandbox()
             .secret_lookup(secret)
             .ok_or(Error::SecretStoreError(
                 SecretStoreError::InvalidSecretHandle(secret),
@@ -60,7 +60,7 @@ impl secret_store::HostSecret for ComponentCtx {
                 store_name,
                 secret_name,
             } => self
-                .session()
+                .sandbox()
                 .secret_stores()
                 .get_store(store_name)
                 .ok_or(Error::SecretStoreError(
@@ -90,7 +90,7 @@ impl secret_store::HostSecret for ComponentCtx {
         &mut self,
         plaintext: Vec<u8>,
     ) -> Result<Resource<secret_store::Secret>, types::Error> {
-        Ok(self.session_mut().add_secret(plaintext).into())
+        Ok(self.sandbox_mut().add_secret(plaintext).into())
     }
 
     fn drop(&mut self, _secret: Resource<secret_store::Secret>) -> wasmtime::Result<()> {

--- a/src/component/compute/security.rs
+++ b/src/component/compute/security.rs
@@ -13,8 +13,8 @@ impl security::Host for ComponentCtx {
         buf_max_len: u64,
     ) -> Result<String, types::Error> {
         // Make sure we're given valid handles, even though we won't use them.
-        let _ = self.session().request_parts(ds_req.into())?;
-        let _ = self.session().body(ds_body.into())?;
+        let _ = self.sandbox().request_parts(ds_req.into())?;
+        let _ = self.sandbox().body(ds_body.into())?;
 
         // For now, corp and workspace arguments are required to actually generate the hostname,
         // but in the future, the lookaside service will be generated using the customer ID, and
@@ -28,7 +28,7 @@ impl security::Host for ComponentCtx {
         }
 
         // Return the mock NGWAF response.
-        let ngwaf_resp = self.session().ngwaf_response();
+        let ngwaf_resp = self.sandbox().ngwaf_response();
         let ngwaf_resp_len = ngwaf_resp.len();
 
         match u64::try_from(ngwaf_resp_len) {

--- a/src/component/compute/shielding.rs
+++ b/src/component/compute/shielding.rs
@@ -5,15 +5,15 @@ use wasmtime::component::Resource;
 
 impl shielding::Host for ComponentCtx {
     fn shield_info(&mut self, name: String, max_len: u64) -> Result<String, types::Error> {
-        let running_on = self.session().shielding_sites().is_local(&name);
+        let running_on = self.sandbox().shielding_sites().is_local(&name);
         let unencrypted = self
-            .session()
+            .sandbox()
             .shielding_sites()
             .get_unencrypted(&name)
             .map(|x| x.to_string())
             .unwrap_or_default();
         let encrypted = self
-            .session()
+            .sandbox()
             .shielding_sites()
             .get_encrypted(&name)
             .map(|x| x.to_string())
@@ -52,7 +52,7 @@ impl shielding::Host for ComponentCtx {
         // `u64::MAX` because we don't need to impose any extra constraints
         // on the length of the backend name string here.
         let name = crate::component::shielding::backend_for_shield(
-            &mut self.session,
+            &mut self.sandbox,
             &mut self.wasi_table,
             &target_shield,
             options,

--- a/src/component/erl.rs
+++ b/src/component/erl.rs
@@ -1,8 +1,8 @@
-use {crate::component::bindings::fastly::compute::types, crate::session::Session};
+use {crate::component::bindings::fastly::compute::types, crate::sandbox::Sandbox};
 
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn check_rate(
-    _session: &mut Session,
+    _sandbox: &mut Sandbox,
     _rc: &str,
     _entry: String,
     _delta: u32,
@@ -15,7 +15,7 @@ pub(crate) fn check_rate(
 }
 
 pub(crate) fn ratecounter_increment(
-    _session: &mut Session,
+    _sandbox: &mut Sandbox,
     _rc: &str,
     _entry: String,
     _delta: u32,
@@ -24,7 +24,7 @@ pub(crate) fn ratecounter_increment(
 }
 
 pub(crate) fn ratecounter_lookup_rate(
-    _session: &mut Session,
+    _sandbox: &mut Sandbox,
     _rc: &str,
     _entry: String,
     _window: u32,
@@ -33,7 +33,7 @@ pub(crate) fn ratecounter_lookup_rate(
 }
 
 pub(crate) fn ratecounter_lookup_count(
-    _session: &mut Session,
+    _sandbox: &mut Sandbox,
     _rc: &str,
     _entry: String,
     _duration: u32,
@@ -42,7 +42,7 @@ pub(crate) fn ratecounter_lookup_count(
 }
 
 pub(crate) fn penaltybox_add(
-    _session: &mut Session,
+    _sandbox: &mut Sandbox,
     _pb: &str,
     _entry: String,
     _ttl: u32,
@@ -51,7 +51,7 @@ pub(crate) fn penaltybox_add(
 }
 
 pub(crate) fn penaltybox_has(
-    _session: &mut Session,
+    _sandbox: &mut Sandbox,
     _pb: &str,
     _entry: String,
 ) -> Result<bool, types::Error> {

--- a/src/component/http_req.rs
+++ b/src/component/http_req.rs
@@ -1,13 +1,13 @@
 use {
     crate::component::bindings::fastly::compute::{http_body, http_req, http_resp, types},
     crate::pushpin::{PushpinRedirectInfo, PushpinRedirectRequestInfo},
-    crate::{error::Error, session::PeekableTask, session::Session, upstream},
+    crate::{error::Error, sandbox::PeekableTask, sandbox::Sandbox, upstream},
     http::request::Request,
     wasmtime::component::Resource,
 };
 
 pub(crate) fn redirect_to_websocket_proxy(
-    _session: &mut Session,
+    _sandbox: &mut Sandbox,
     _handle: Resource<http_req::Request>,
     _backend: &str,
 ) -> Result<(), types::Error> {
@@ -15,11 +15,11 @@ pub(crate) fn redirect_to_websocket_proxy(
 }
 
 pub(crate) fn redirect_to_grip_proxy(
-    session: &mut Session,
+    sandbox: &mut Sandbox,
     req_handle: Resource<http_req::Request>,
     backend_name: &str,
 ) -> Result<(), types::Error> {
-    let request_info = match session.request_parts(req_handle.into()) {
+    let request_info = match sandbox.request_parts(req_handle.into()) {
         Ok(req) => Some(PushpinRedirectRequestInfo::from_parts(req)),
         Err(_) => {
             // This function can legitimately be called with an invalid request handle;
@@ -34,28 +34,28 @@ pub(crate) fn redirect_to_grip_proxy(
         request_info,
     };
 
-    session.redirect_downstream_to_pushpin(redirect_info)?;
+    sandbox.redirect_downstream_to_pushpin(redirect_info)?;
     Ok(())
 }
 
 pub(crate) fn upgrade_websocket(
-    _session: &mut Session,
+    _sandbox: &mut Sandbox,
     _backend: &str,
 ) -> Result<(), types::Error> {
     Err(Error::NotAvailable("WebSocket upgrade").into())
 }
 
 pub(crate) async fn send(
-    session: &mut Session,
+    sandbox: &mut Sandbox,
     h: Resource<http_req::Request>,
     b: Resource<http_body::Body>,
     backend_name: &str,
 ) -> Result<http_resp::ResponseWithBody, http_req::ErrorWithDetail> {
     // prepare the request
-    let req_parts = session.take_request_parts(h.into()).unwrap();
-    let req_body = session.take_body(b.into()).unwrap();
+    let req_parts = sandbox.take_request_parts(h.into()).unwrap();
+    let req_body = sandbox.take_body(b.into()).unwrap();
     let req = Request::from_parts(req_parts, req_body);
-    let backend = session
+    let backend = sandbox
         .backend(backend_name)
         .ok_or_else(|| Error::UnknownBackend(backend_name.to_owned()))
         .map_err(Into::into)
@@ -63,83 +63,83 @@ pub(crate) async fn send(
 
     // synchronously send the request
     // This initial implementation ignores the error detail field
-    let tls_config = session.tls_config();
+    let tls_config = sandbox.tls_config();
     let resp = upstream::send_request(req, backend, tls_config)
         .await
         .map_err(Into::into)
         .map_err(types::Error::with_empty_detail)?;
-    let (resp_handle, body_handle) = session.insert_response(resp);
+    let (resp_handle, body_handle) = sandbox.insert_response(resp);
     Ok((resp_handle.into(), body_handle.into()))
 }
 
 pub(crate) async fn send_uncached(
-    session: &mut Session,
+    sandbox: &mut Sandbox,
     h: Resource<http_req::Request>,
     b: Resource<http_body::Body>,
     backend_name: &str,
 ) -> Result<http_resp::ResponseWithBody, http_req::ErrorWithDetail> {
     // This initial implementation ignores the error detail field
-    send(session, h, b, backend_name).await
+    send(sandbox, h, b, backend_name).await
 }
 
 pub(crate) async fn send_async(
-    session: &mut Session,
+    sandbox: &mut Sandbox,
     h: Resource<http_req::Request>,
     b: Resource<http_body::Body>,
     backend_name: &str,
 ) -> Result<Resource<http_req::PendingRequest>, types::Error> {
     // prepare the request
-    let req_parts = session.take_request_parts(h.into())?;
-    let req_body = session.take_body(b.into())?;
+    let req_parts = sandbox.take_request_parts(h.into())?;
+    let req_body = sandbox.take_body(b.into())?;
     let req = Request::from_parts(req_parts, req_body);
-    let backend = session
+    let backend = sandbox
         .backend(backend_name)
         .ok_or(types::Error::GenericError)?;
 
     // asynchronously send the request
-    let tls_config = session.tls_config();
+    let tls_config = sandbox.tls_config();
     let task = PeekableTask::spawn(upstream::send_request(req, backend, tls_config)).await;
 
     // return a handle to the pending request
-    Ok(session.insert_pending_request(task).into())
+    Ok(sandbox.insert_pending_request(task).into())
 }
 
 pub(crate) async fn send_async_uncached(
-    session: &mut Session,
+    sandbox: &mut Sandbox,
     h: Resource<http_req::Request>,
     b: Resource<http_body::Body>,
     backend_name: &str,
 ) -> Result<Resource<http_req::PendingRequest>, types::Error> {
-    send_async(session, h, b, backend_name).await
+    send_async(sandbox, h, b, backend_name).await
 }
 
 pub(crate) async fn send_async_uncached_streaming(
-    session: &mut Session,
+    sandbox: &mut Sandbox,
     h: Resource<http_req::Request>,
     b: Resource<http_body::Body>,
     backend_name: &str,
 ) -> Result<Resource<http_req::PendingRequest>, types::Error> {
-    send_async_streaming(session, h, b, backend_name).await
+    send_async_streaming(sandbox, h, b, backend_name).await
 }
 
 pub(crate) async fn send_async_streaming(
-    session: &mut Session,
+    sandbox: &mut Sandbox,
     h: Resource<http_req::Request>,
     b: Resource<http_body::Body>,
     backend_name: &str,
 ) -> Result<Resource<http_req::PendingRequest>, types::Error> {
     // prepare the request
-    let req_parts = session.take_request_parts(h.into())?;
-    let req_body = session.begin_streaming(b.into())?;
+    let req_parts = sandbox.take_request_parts(h.into())?;
+    let req_body = sandbox.begin_streaming(b.into())?;
     let req = Request::from_parts(req_parts, req_body);
-    let backend = session
+    let backend = sandbox
         .backend(backend_name)
         .ok_or(types::Error::GenericError)?;
 
     // asynchronously send the request
-    let tls_config = session.tls_config();
+    let tls_config = sandbox.tls_config();
     let task = PeekableTask::spawn(upstream::send_request(req, backend, tls_config)).await;
 
     // return a handle to the pending request
-    Ok(session.insert_pending_request(task).into())
+    Ok(sandbox.insert_pending_request(task).into())
 }

--- a/src/component/image_optimizer.rs
+++ b/src/component/image_optimizer.rs
@@ -1,11 +1,11 @@
 use crate::component::bindings::fastly::compute::{
     http_body, http_req, http_resp, image_optimizer, types,
 };
-use crate::session::Session;
+use crate::sandbox::Sandbox;
 use wasmtime::component::Resource;
 
 pub(crate) fn transform_image_optimizer_request(
-    _session: &mut Session,
+    _sandbox: &mut Sandbox,
     _origin_image_request: Resource<http_req::Request>,
     _origin_image_request_body: Option<Resource<http_body::Body>>,
     _origin_image_request_backend: &str,

--- a/src/component/shielding.rs
+++ b/src/component/shielding.rs
@@ -1,13 +1,13 @@
 use crate::component::bindings::fastly::compute::{shielding, types};
 use crate::config::Backend;
 use crate::error::Error;
-use crate::session::Session;
+use crate::sandbox::Sandbox;
 use http::Uri;
 use std::str::FromStr;
 use wasmtime::component::{Resource, ResourceTable};
 
 pub(crate) fn backend_for_shield(
-    session: &mut Session,
+    sandbox: &mut Sandbox,
     _table: &mut ResourceTable,
     name: &str,
     _options: Option<Resource<shielding::ShieldBackendOptions>>,
@@ -31,7 +31,7 @@ pub(crate) fn backend_for_shield(
         health: crate::config::BackendHealth::Unknown,
     };
 
-    if !session.add_backend(&new_name, new_backend) {
+    if !sandbox.add_backend(&new_name, new_backend) {
         return Err(Error::BackendNameRegistryError(new_name).into());
     }
 

--- a/src/downstream.rs
+++ b/src/downstream.rs
@@ -18,7 +18,7 @@ pub struct DownstreamMetadata {
     pub client_addr: SocketAddr,
     /// The compliance region that this request was received in.
     ///
-    /// For now this is just always `"none"`, but we place the field in the session
+    /// For now this is just always `"none"`, but we place the field in the sandbox
     /// to make it easier to implement custom configuration values later on.
     pub compliance_region: String,
     /// The originally received headers in this request, before the

--- a/src/execute.rs
+++ b/src/execute.rs
@@ -18,8 +18,8 @@ use {
         linking::{ComponentCtx, WasmCtx, create_store, link_host_functions},
         object_store::ObjectStores,
         pushpin::{PushpinRedirectRequestInfo, proxy_through_pushpin},
+        sandbox::Sandbox,
         secret_store::SecretStores,
-        session::Session,
         shielding_site::ShieldingSites,
         upstream::TlsConfig,
     },
@@ -159,7 +159,7 @@ pub struct ExecuteCtx {
     fake_valid_fastly_keys: FakeValidFastlyKeys,
     /// The cache for this service.
     cache: Arc<Cache>,
-    /// Senders waiting for new requests for reusable sessions.
+    /// Senders waiting for new requests for reusable sandboxes.
     pending_reuse: Arc<AsyncMutex<Vec<Sender<NextRequest>>>>,
     epoch_increment_thread: Option<JoinHandle<()>>,
     // `Arc` so that it can be tracked both by this context and `epoch_increment_thread`.
@@ -524,7 +524,7 @@ impl ExecuteCtx {
     }
 
     /// Spawn a new guest to process a request whose processing was never attempted by
-    /// a reused session.
+    /// a reused sandbox.
     pub(crate) fn retry_request(self: Arc<Self>, mut downstream: DownstreamRequest) {
         if downstream.sender.is_closed() {
             return;
@@ -638,7 +638,7 @@ impl ExecuteCtx {
         );
         let start_timestamp = Instant::now();
         let req_id = downstream.metadata.req_id;
-        let session = Session::new(downstream, active_cpu_time_us, self.clone());
+        let sandbox = Sandbox::new(downstream, active_cpu_time_us, self.clone());
 
         let guest_profile_path = self.guest_profile_config.as_deref().map(|pcfg| {
             let now = SystemTime::now()
@@ -660,10 +660,10 @@ impl ExecuteCtx {
                     )
                 });
 
-                let req = session.downstream_request();
-                let body = session.downstream_request_body();
+                let req = sandbox.downstream_request();
+                let body = sandbox.downstream_request_body();
 
-                let mut store = ComponentCtx::create_store(&self, session, profiler, |ctx| {
+                let mut store = ComponentCtx::create_store(&self, sandbox, profiler, |ctx| {
                     ctx.arg("compute-app");
                 })
                 .map_err(ExecutionError::Context)?;
@@ -713,7 +713,7 @@ impl ExecuteCtx {
                     .unwrap_or_default();
                 store
                     .data_mut()
-                    .session
+                    .sandbox
                     .close_downstream_response_sender(resp);
 
                 let request_duration = Instant::now().duration_since(start_timestamp);
@@ -742,7 +742,7 @@ impl ExecuteCtx {
                 // due to wasmtime limitations, in particular the fact that `Instance` is not `Send`.
                 // However, the fact that the module itself is created within `ExecuteCtx::new`
                 // means that the heavy lifting happens only once.
-                let mut store = create_store(&self, session, profiler, |ctx| {
+                let mut store = create_store(&self, sandbox, profiler, |ctx| {
                     ctx.arg("compute-app");
                 })
                 .map_err(ExecutionError::Context)?;
@@ -824,7 +824,7 @@ impl ExecuteCtx {
         };
         let active_cpu_time_us = Arc::new(AtomicU64::new(0));
 
-        let session = Session::new(downstream, active_cpu_time_us.clone(), self.clone());
+        let sandbox = Sandbox::new(downstream, active_cpu_time_us.clone(), self.clone());
 
         if let Instance::Component(_, _) = self.instance_pre.as_ref() {
             panic!("components not currently supported with `run`");
@@ -840,7 +840,7 @@ impl ExecuteCtx {
             )
         });
 
-        let mut store = create_store(&self, session, profiler, |builder| {
+        let mut store = create_store(&self, sandbox, profiler, |builder| {
             builder.arg(program_name);
             for arg in args {
                 builder.arg(arg);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@ pub mod cache;
 pub mod config;
 pub mod error;
 pub mod logging;
-pub mod session;
+pub mod sandbox;
 
 mod acl;
 mod async_io;

--- a/src/linking.rs
+++ b/src/linking.rs
@@ -3,7 +3,7 @@
 use {
     crate::{
         Error, body::Body, config::ExperimentalModule, execute::ExecuteCtx, logging::LogEndpoint,
-        session::Session, wiggle_abi,
+        sandbox::Sandbox, wiggle_abi,
     },
     hyper::Response,
     std::collections::HashSet,
@@ -99,23 +99,23 @@ pub struct ComponentCtx {
     pub wasi_ctx: wasmtime_wasi::WasiCtx,
     pub wasi_table: wasmtime_wasi::ResourceTable,
     pub wasi_random: wasmtime_wasi::random::WasiRandomCtx,
-    pub(crate) session: Session,
+    pub(crate) sandbox: Sandbox,
     guest_profiler: Option<Box<GuestProfiler>>,
 }
 
-/// An extension trait for users of `ComponentCtx` to access the session.
-pub trait SessionView {
-    fn session(&self) -> &Session;
-    fn session_mut(&mut self) -> &mut Session;
+/// An extension trait for users of `ComponentCtx` to access the sandbox.
+pub trait SandboxView {
+    fn sandbox(&self) -> &Sandbox;
+    fn sandbox_mut(&mut self) -> &mut Sandbox;
 }
 
-impl SessionView for ComponentCtx {
-    fn session(&self) -> &Session {
-        &self.session
+impl SandboxView for ComponentCtx {
+    fn sandbox(&self) -> &Sandbox {
+        &self.sandbox
     }
 
-    fn session_mut(&mut self) -> &mut Session {
-        &mut self.session
+    fn sandbox_mut(&mut self) -> &mut Sandbox {
+        &mut self.sandbox
     }
 }
 
@@ -124,8 +124,8 @@ impl ComponentCtx {
         &mut self.wasi_ctx
     }
 
-    pub fn session(&mut self) -> &mut Session {
-        &mut self.session
+    pub fn sandbox(&mut self) -> &mut Sandbox {
+        &mut self.sandbox
     }
 
     pub fn take_guest_profiler(&mut self) -> Option<Box<GuestProfiler>> {
@@ -133,11 +133,11 @@ impl ComponentCtx {
     }
 
     pub fn limiter(&self) -> &Limiter {
-        self.session.limiter()
+        self.sandbox.limiter()
     }
 
     pub fn close_downstream_response_sender(&mut self, resp: Response<Body>) {
-        self.session.close_downstream_response_sender(resp)
+        self.sandbox.close_downstream_response_sender(resp)
     }
 
     /// Initialize a new [`Store`][store], given an [`ExecuteCtx`][ctx].
@@ -146,11 +146,11 @@ impl ComponentCtx {
     /// [store]: https://docs.rs/wasmtime/latest/wasmtime/struct.Store.html
     pub(crate) fn create_store(
         ctx: &ExecuteCtx,
-        session: Session,
+        sandbox: Sandbox,
         guest_profiler: Option<GuestProfiler>,
         extra_init: impl FnOnce(&mut wasmtime_wasi::WasiCtxBuilder),
     ) -> Result<Store<ComponentCtx>, anyhow::Error> {
-        let mut builder = make_wasi_ctx(ctx, &session);
+        let mut builder = make_wasi_ctx(ctx, &sandbox);
 
         extra_init(&mut builder);
 
@@ -158,7 +158,7 @@ impl ComponentCtx {
             wasi_table: wasmtime_wasi::ResourceTable::new(),
             wasi_ctx: builder.build(),
             wasi_random: wasmtime_wasi::random::WasiRandomCtx::default(),
-            session,
+            sandbox,
             guest_profiler: guest_profiler.map(Box::new),
         };
         let mut store = Store::new(ctx.engine(), wasm_ctx);
@@ -182,7 +182,7 @@ impl ComponentCtx {
             Ok(UpdateDeadline::Yield(1))
         });
 
-        store.limiter(|ctx| ctx.session.limiter_mut());
+        store.limiter(|ctx| ctx.sandbox.limiter_mut());
         Ok(store)
     }
 }
@@ -205,7 +205,7 @@ impl wasmtime_wasi_io::IoView for ComponentCtx {
 pub struct WasmCtx {
     wasi: WasiP1Ctx,
     wasi_nn: WasiNnCtx,
-    session: Session,
+    sandbox: Sandbox,
     guest_profiler: Option<Box<GuestProfiler>>,
 }
 
@@ -218,8 +218,8 @@ impl WasmCtx {
         &mut self.wasi_nn
     }
 
-    pub fn session(&mut self) -> &mut Session {
-        &mut self.session
+    pub fn sandbox(&mut self) -> &mut Sandbox {
+        &mut self.sandbox
     }
 
     pub fn take_guest_profiler(&mut self) -> Option<Box<GuestProfiler>> {
@@ -227,13 +227,13 @@ impl WasmCtx {
     }
 
     pub fn limiter(&self) -> &Limiter {
-        self.session.limiter()
+        self.sandbox.limiter()
     }
 }
 
 impl WasmCtx {
     pub fn close_downstream_response_sender(&mut self, resp: Response<Body>) {
-        self.session.close_downstream_response_sender(resp)
+        self.sandbox.close_downstream_response_sender(resp)
     }
 }
 
@@ -243,11 +243,11 @@ impl WasmCtx {
 /// [store]: https://docs.rs/wasmtime/latest/wasmtime/struct.Store.html
 pub(crate) fn create_store(
     ctx: &ExecuteCtx,
-    session: Session,
+    sandbox: Sandbox,
     guest_profiler: Option<GuestProfiler>,
     extra_init: impl FnOnce(&mut wasmtime_wasi::WasiCtxBuilder),
 ) -> Result<Store<WasmCtx>, anyhow::Error> {
-    let mut builder = make_wasi_ctx(ctx, &session);
+    let mut builder = make_wasi_ctx(ctx, &sandbox);
 
     extra_init(&mut builder);
 
@@ -257,7 +257,7 @@ pub(crate) fn create_store(
     let wasm_ctx = WasmCtx {
         wasi,
         wasi_nn,
-        session,
+        sandbox,
         guest_profiler: guest_profiler.map(Box::new),
     };
     let mut store = Store::new(ctx.engine(), wasm_ctx);
@@ -281,12 +281,12 @@ pub(crate) fn create_store(
         Ok(UpdateDeadline::Yield(1))
     });
 
-    store.limiter(|ctx| ctx.session.limiter_mut());
+    store.limiter(|ctx| ctx.sandbox.limiter_mut());
     Ok(store)
 }
 
 /// Constructs a `WasiCtxBuilder` for _each_ incoming request.
-fn make_wasi_ctx(ctx: &ExecuteCtx, session: &Session) -> wasmtime_wasi::WasiCtxBuilder {
+fn make_wasi_ctx(ctx: &ExecuteCtx, sandbox: &Sandbox) -> wasmtime_wasi::WasiCtxBuilder {
     let mut wasi_ctx = wasmtime_wasi::WasiCtxBuilder::new();
 
     // Viceroy provides the same `FASTLY_*` environment variables that the production
@@ -305,7 +305,7 @@ fn make_wasi_ctx(ctx: &ExecuteCtx, session: &Session) -> wasmtime_wasi::WasiCtxB
         // ...which is not the staging environment
         .env("FASTLY_IS_STAGING", "0")
         // request IDs start at 0 and increment, rather than being UUIDs, for ease of testing
-        .env("FASTLY_TRACE_ID", format!("{:032x}", session.session_id()));
+        .env("FASTLY_TRACE_ID", format!("{:032x}", sandbox.sandbox_id()));
 
     if ctx.log_stdout() {
         wasi_ctx.stdout(LogEndpoint::new(b"stdout", ctx.capture_logs()));
@@ -335,30 +335,30 @@ pub fn link_host_functions(
         })?;
 
     wasmtime_wasi::p1::add_to_linker_async(linker, WasmCtx::wasi)?;
-    wiggle_abi::fastly_abi::add_to_linker(linker, WasmCtx::session)?;
-    wiggle_abi::fastly_acl::add_to_linker(linker, WasmCtx::session)?;
-    wiggle_abi::fastly_async_io::add_to_linker(linker, WasmCtx::session)?;
-    wiggle_abi::fastly_backend::add_to_linker(linker, WasmCtx::session)?;
-    wiggle_abi::fastly_cache::add_to_linker(linker, WasmCtx::session)?;
-    wiggle_abi::fastly_compute_runtime::add_to_linker(linker, WasmCtx::session)?;
-    wiggle_abi::fastly_config_store::add_to_linker(linker, WasmCtx::session)?;
-    wiggle_abi::fastly_device_detection::add_to_linker(linker, WasmCtx::session)?;
-    wiggle_abi::fastly_dictionary::add_to_linker(linker, WasmCtx::session)?;
-    wiggle_abi::fastly_erl::add_to_linker(linker, WasmCtx::session)?;
-    wiggle_abi::fastly_geo::add_to_linker(linker, WasmCtx::session)?;
-    wiggle_abi::fastly_http_body::add_to_linker(linker, WasmCtx::session)?;
-    wiggle_abi::fastly_http_cache::add_to_linker(linker, WasmCtx::session)?;
-    wiggle_abi::fastly_http_downstream::add_to_linker(linker, WasmCtx::session)?;
-    wiggle_abi::fastly_http_req::add_to_linker(linker, WasmCtx::session)?;
-    wiggle_abi::fastly_http_resp::add_to_linker(linker, WasmCtx::session)?;
-    wiggle_abi::fastly_image_optimizer::add_to_linker(linker, WasmCtx::session)?;
-    wiggle_abi::fastly_kv_store::add_to_linker(linker, WasmCtx::session)?;
-    wiggle_abi::fastly_log::add_to_linker(linker, WasmCtx::session)?;
-    wiggle_abi::fastly_object_store::add_to_linker(linker, WasmCtx::session)?;
-    wiggle_abi::fastly_purge::add_to_linker(linker, WasmCtx::session)?;
-    wiggle_abi::fastly_secret_store::add_to_linker(linker, WasmCtx::session)?;
-    wiggle_abi::fastly_shielding::add_to_linker(linker, WasmCtx::session)?;
-    wiggle_abi::fastly_uap::add_to_linker(linker, WasmCtx::session)?;
+    wiggle_abi::fastly_abi::add_to_linker(linker, WasmCtx::sandbox)?;
+    wiggle_abi::fastly_acl::add_to_linker(linker, WasmCtx::sandbox)?;
+    wiggle_abi::fastly_async_io::add_to_linker(linker, WasmCtx::sandbox)?;
+    wiggle_abi::fastly_backend::add_to_linker(linker, WasmCtx::sandbox)?;
+    wiggle_abi::fastly_cache::add_to_linker(linker, WasmCtx::sandbox)?;
+    wiggle_abi::fastly_compute_runtime::add_to_linker(linker, WasmCtx::sandbox)?;
+    wiggle_abi::fastly_config_store::add_to_linker(linker, WasmCtx::sandbox)?;
+    wiggle_abi::fastly_device_detection::add_to_linker(linker, WasmCtx::sandbox)?;
+    wiggle_abi::fastly_dictionary::add_to_linker(linker, WasmCtx::sandbox)?;
+    wiggle_abi::fastly_erl::add_to_linker(linker, WasmCtx::sandbox)?;
+    wiggle_abi::fastly_geo::add_to_linker(linker, WasmCtx::sandbox)?;
+    wiggle_abi::fastly_http_body::add_to_linker(linker, WasmCtx::sandbox)?;
+    wiggle_abi::fastly_http_cache::add_to_linker(linker, WasmCtx::sandbox)?;
+    wiggle_abi::fastly_http_downstream::add_to_linker(linker, WasmCtx::sandbox)?;
+    wiggle_abi::fastly_http_req::add_to_linker(linker, WasmCtx::sandbox)?;
+    wiggle_abi::fastly_http_resp::add_to_linker(linker, WasmCtx::sandbox)?;
+    wiggle_abi::fastly_image_optimizer::add_to_linker(linker, WasmCtx::sandbox)?;
+    wiggle_abi::fastly_kv_store::add_to_linker(linker, WasmCtx::sandbox)?;
+    wiggle_abi::fastly_log::add_to_linker(linker, WasmCtx::sandbox)?;
+    wiggle_abi::fastly_object_store::add_to_linker(linker, WasmCtx::sandbox)?;
+    wiggle_abi::fastly_purge::add_to_linker(linker, WasmCtx::sandbox)?;
+    wiggle_abi::fastly_secret_store::add_to_linker(linker, WasmCtx::sandbox)?;
+    wiggle_abi::fastly_shielding::add_to_linker(linker, WasmCtx::sandbox)?;
+    wiggle_abi::fastly_uap::add_to_linker(linker, WasmCtx::sandbox)?;
     link_legacy_aliases(linker)?;
     Ok(())
 }

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -1,4 +1,4 @@
-//! Session type and related facilities.
+//! Sandbox type and related facilities.
 
 mod async_item;
 mod downstream;
@@ -62,9 +62,9 @@ pub struct RequestParts {
 
 /// Data specific to an individual request, including any host-side
 /// allocations on behalf of the guest processing the request.
-pub struct Session {
-    session_id: u64,
-    /// The amount of time we've spent on this session in microseconds.
+pub struct Sandbox {
+    sandbox_id: u64,
+    /// The amount of time we've spent on this sandbox in microseconds.
     pub active_cpu_time_us: Arc<AtomicU64>,
     /// Handle for the downstream request "parts". NB the backing parts data can be mutated
     /// or even removed from the relevant map.
@@ -81,14 +81,14 @@ pub struct Session {
     /// A handle map for items that provide blocking operations. These items are grouped together
     /// in order to support generic async operations that work across different object types.
     async_items: PrimaryMap<AsyncItemHandle, Option<AsyncItem>>,
-    /// The context for executing the service that is shared between sessions.
+    /// The context for executing the service that is shared between sandboxes.
     ctx: Arc<ExecuteCtx>,
-    /// A handle map for the component [`Parts`][parts] of the session's HTTP [`Request`][req]s.
+    /// A handle map for the component [`Parts`][parts] of the sandbox's HTTP [`Request`][req]s.
     ///
     /// [parts]: https://docs.rs/http/latest/http/request/struct.Parts.html
     /// [req]: https://docs.rs/http/latest/http/request/struct.Request.html
     req_parts: PrimaryMap<RequestHandle, RequestParts>,
-    /// A handle map for the component [`Parts`][parts] of the session's HTTP [`Response`][resp]s.
+    /// A handle map for the component [`Parts`][parts] of the sandbox's HTTP [`Response`][resp]s.
     ///
     /// [parts]: https://docs.rs/http/latest/http/response/struct.Parts.html
     /// [resp]: https://docs.rs/http/latest/http/response/struct.Response.html
@@ -104,8 +104,8 @@ pub struct Session {
     /// The NGWAF verdict to return when using the `inspect` hostcall.
     ngwaf_verdict: String,
     /// The backends dynamically added by the program. This is separated from
-    /// `backends` because we do not want one session to effect the backends
-    /// available to any other session.
+    /// `backends` because we do not want one sandbox to effect the backends
+    /// available to any other sandbox.
     dynamic_backends: Backends,
     /// The dictionaries that have been opened by the guest.
     loaded_dictionaries: PrimaryMap<DictionaryHandle, LoadedDictionary>,
@@ -121,26 +121,26 @@ pub struct Session {
     ///
     /// Populated prior to guest execution, and never modified.
     secrets_by_name: PrimaryMap<SecretHandle, SecretLookup>,
-    /// How many additional downstream requests have been receive by this Session.
+    /// How many additional downstream requests have been receive by this Sandbox.
     next_req_accepted: usize,
     /// Memory usage limiter to ensure the guest doesn't use over 128mb of heap.
     limiter: Limiter,
 }
 
-impl Session {
-    /// Create an empty session.
+impl Sandbox {
+    /// Create an empty sandbox.
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         downstream: DownstreamRequest,
         active_cpu_time_us: Arc<AtomicU64>,
         ctx: Arc<ExecuteCtx>,
-    ) -> Session {
+    ) -> Sandbox {
         let (parts, body) = downstream.req.into_parts();
 
         let mut async_items: PrimaryMap<AsyncItemHandle, Option<AsyncItem>> = PrimaryMap::new();
         let mut req_parts = PrimaryMap::new();
 
-        let session_id = downstream.metadata.req_id;
+        let sandbox_id = downstream.metadata.req_id;
         let downstream_req_handle = req_parts.push(RequestParts {
             parts: Some(parts),
             metadata: Some(downstream.metadata),
@@ -153,8 +153,8 @@ impl Session {
             Limiter::for_wasip1()
         };
 
-        Session {
-            session_id,
+        Sandbox {
+            sandbox_id,
             downstream_req_handle,
             downstream_req_body_handle,
             active_cpu_time_us,
@@ -285,7 +285,7 @@ impl Session {
 
     // ----- Bodies API -----
 
-    /// Insert a [`Body`][body] into the session.
+    /// Insert a [`Body`][body] into the sandbox.
     ///
     /// This method returns the [`BodyHandle`][handle], which can then be used to access and mutate
     /// the response parts.
@@ -298,7 +298,7 @@ impl Session {
 
     /// Get a reference to a [`Body`][body], given its [`BodyHandle`][handle].
     ///
-    /// Returns a [`HandleError`][err] if the handle is not associated with a body in the session.
+    /// Returns a [`HandleError`][err] if the handle is not associated with a body in the sandbox.
     ///
     /// [body]: ../body/struct.Body.html
     /// [err]: ../error/enum.HandleError.html
@@ -313,7 +313,7 @@ impl Session {
 
     /// Get a mutable reference to a [`Body`][body], given its [`BodyHandle`][handle].
     ///
-    /// Returns a [`HandleError`][err] if the handle is not associated with a body in the session.
+    /// Returns a [`HandleError`][err] if the handle is not associated with a body in the sandbox.
     ///
     /// [body]: ../body/struct.Body.html
     /// [err]: ../error/enum.HandleError.html
@@ -328,7 +328,7 @@ impl Session {
 
     /// Take ownership of a [`Body`][body], given its [`BodyHandle`][handle].
     ///
-    /// Returns a [`HandleError`][err] if the handle is not associated with a body in the session.
+    /// Returns a [`HandleError`][err] if the handle is not associated with a body in the sandbox.
     ///
     /// [body]: ../body/struct.Body.html
     /// [err]: ../error/enum.HandleError.html
@@ -341,9 +341,9 @@ impl Session {
             .ok_or(HandleError::InvalidBodyHandle(handle))
     }
 
-    /// Drop a [`Body`][crate::body::Body] from the [`Session`], given its [`BodyHandle`][crate::wiggle_abi::types::BodyHandle].
+    /// Drop a [`Body`][crate::body::Body] from the [`Sandbox`], given its [`BodyHandle`][crate::wiggle_abi::types::BodyHandle].
     ///
-    /// Returns a [`HandleError`][crate::error::HandleError] if the handle is not associated with a body in the session.
+    /// Returns a [`HandleError`][crate::error::HandleError] if the handle is not associated with a body in the sandbox.
     pub fn drop_body(&mut self, handle: BodyHandle) -> Result<(), HandleError> {
         self.async_items
             .get_mut(handle.into())
@@ -355,7 +355,7 @@ impl Session {
     /// Transition a normal [`Body`][body] into the write end of a streaming body, returning
     /// the original body with the read end appended.
     ///
-    /// Returns a [`HandleError`][err] if the handle is not associated with a body in the session.
+    /// Returns a [`HandleError`][err] if the handle is not associated with a body in the sandbox.
     ///
     /// [body]: ../body/struct.Body.html
     /// [err]: ../error/enum.HandleError.html
@@ -370,7 +370,7 @@ impl Session {
     /// Returns `true` if and only if the provided `BodyHandle` is the downstream body being sent.
     ///
     /// To get a mutable reference to the streaming body `Sender`, see
-    /// [`Session::streaming_body_mut`](struct.Session.html#method.streaming_body_mut).
+    /// [`Sandbox::streaming_body_mut`](struct.Sandbox.html#method.streaming_body_mut).
     pub fn is_streaming_body(&self, handle: BodyHandle) -> bool {
         if let Some(Some(body)) = self.async_items.get(handle.into()) {
             body.is_streaming()
@@ -383,9 +383,9 @@ impl Session {
     /// `BodyHandle` is the downstream body being sent.
     ///
     /// To check if a handle is the currently-streaming downstream response body, see
-    /// [`Session::is_streaming_body`](struct.Session.html#method.is_streaming_body).
+    /// [`Sandbox::is_streaming_body`](struct.Sandbox.html#method.is_streaming_body).
     ///
-    /// Returns a [`HandleError`][err] if the handle is not associated with a body in the session.
+    /// Returns a [`HandleError`][err] if the handle is not associated with a body in the sandbox.
     ///
     /// [err]: ../error/enum.HandleError.html
     pub fn streaming_body_mut(
@@ -403,9 +403,9 @@ impl Session {
     /// `BodyHandle` is the downstream body being sent.
     ///
     /// To check if a handle is the currently-streaming downstream response body, see
-    /// [`Session::is_streaming_body`](struct.Session.html#method.is_streaming_body).
+    /// [`Sandbox::is_streaming_body`](struct.Sandbox.html#method.is_streaming_body).
     ///
-    /// Returns a [`HandleError`][err] if the handle is not associated with a body in the session.
+    /// Returns a [`HandleError`][err] if the handle is not associated with a body in the sandbox.
     ///
     /// [err]: ../error/enum.HandleError.html
     pub fn take_streaming_body(
@@ -421,7 +421,7 @@ impl Session {
 
     // ----- Request Parts API -----
 
-    /// Insert the [`Parts`][parts] of a [`Request`][req] into the session.
+    /// Insert the [`Parts`][parts] of a [`Request`][req] into the sandbox.
     ///
     /// This method returns a new [`RequestHandle`][handle], which can then be used to access
     /// and mutate the request parts.
@@ -440,7 +440,7 @@ impl Session {
     /// [`RequestHandle`][handle].
     ///
     /// Returns a [`HandleError`][err] if the handle is not associated with a request in the
-    /// session.
+    /// sandbox.
     ///
     /// [err]: ../error/enum.HandleError.html
     /// [handle]: ../wiggle_abi/types/struct.RequestHandle.html
@@ -457,7 +457,7 @@ impl Session {
     /// [`RequestHandle`][handle].
     ///
     /// Returns a [`HandleError`][err] if the handle is not associated with a request in the
-    /// session.
+    /// sandbox.
     ///
     /// [err]: ../error/enum.HandleError.html
     /// [handle]: ../wiggle_abi/types/struct.RequestHandle.html
@@ -477,7 +477,7 @@ impl Session {
     /// [`RequestHandle`][handle].
     ///
     /// Returns a [`HandleError`][err] if the handle is not associated with a request in the
-    /// session.
+    /// sandbox.
     ///
     /// [err]: ../error/enum.HandleError.html
     /// [handle]: ../wiggle_abi/types/struct.RequestHandle.html
@@ -495,7 +495,7 @@ impl Session {
 
     // ----- Response Parts API -----
 
-    /// Insert the [`Parts`][parts] of a [`Response`][resp] into the session.
+    /// Insert the [`Parts`][parts] of a [`Response`][resp] into the sandbox.
     ///
     /// This method returns a new [`ResponseHandle`][handle], which can then be used to access
     /// and mutate the response parts.
@@ -511,7 +511,7 @@ impl Session {
     /// [`ResponseHandle`][handle].
     ///
     /// Returns a [`HandleError`][err] if the handle is not associated with a response in the
-    /// session.
+    /// sandbox.
     ///
     /// [err]: ../error/enum.HandleError.html
     /// [handle]: ../wiggle_abi/types/struct.ResponseHandle.html
@@ -528,7 +528,7 @@ impl Session {
     /// [`ResponseHandle`][handle].
     ///
     /// Returns a [`HandleError`][err] if the handle is not associated with a response in the
-    /// session.
+    /// sandbox.
     ///
     /// [err]: ../error/enum.HandleError.html
     /// [handle]: ../wiggle_abi/types/struct.ResponseHandle.html
@@ -548,7 +548,7 @@ impl Session {
     /// [`ResponseHandle`][handle].
     ///
     /// Returns a [`HandleError`][err] if the handle is not associated with a response in the
-    /// session.
+    /// sandbox.
     ///
     /// [err]: ../error/enum.HandleError.html
     /// [handle]: ../wiggle_abi/types/struct.ResponseHandle.html
@@ -573,7 +573,7 @@ impl Session {
 
     // ----- Logging Endpoints API -----
 
-    /// Get an [`EndpointHandle`][handle] from the session, corresponding to the provided
+    /// Get an [`EndpointHandle`][handle] from the sandbox, corresponding to the provided
     /// endpoint name. A new backing [`LogEndpoint`] will be created if one does not
     /// already exist.
     ///
@@ -592,7 +592,7 @@ impl Session {
     /// Get a reference to a [`LogEndpoint`][endpoint], given its [`EndpointHandle`][handle].
     ///
     /// Returns a [`HandleError`][err] if the handle is not associated with an endpoint in the
-    /// session.
+    /// sandbox.
     ///
     /// [err]: ../error/enum.HandleError.html
     /// [handle]: ../wiggle_abi/types/struct.EndpointHandle.html
@@ -708,7 +708,7 @@ impl Session {
 
     // ----- NGWAF Inspect API -----
 
-    /// Retrieve the compliance region that received the request for this session.
+    /// Retrieve the compliance region that received the request for this sandbox.
     pub fn ngwaf_response(&self) -> String {
         format!(
             r#"{{"waf_response":200,"redirect_url":"","tags":[],"verdict":"{}","decision_ms":0}}"#,
@@ -751,7 +751,7 @@ impl Session {
             .insert(obj_store_key, obj_key, obj, mode, generation, metadata, ttl)
     }
 
-    /// Insert a [`PendingKvInsert`] into the session.
+    /// Insert a [`PendingKvInsert`] into the sandbox.
     ///
     /// This method returns a new [`PendingKvInsertHandle`], which can then be used to access
     /// and mutate the pending insert.
@@ -767,7 +767,7 @@ impl Session {
     /// Take ownership of a [`PendingKvInsert`], given its [`PendingKvInsertHandle`].
     ///
     /// Returns a [`HandleError`] if the handle is not associated with a pending insert in the
-    /// session.
+    /// sandbox.
     pub fn take_pending_kv_insert(
         &mut self,
         handle: PendingKvInsertHandle,
@@ -785,7 +785,7 @@ impl Session {
     /// Get a reference to a [`PendingInsert`], given its [`PendingKvInsertHandle`].
     ///
     /// Returns a [`HandleError`] if the handle is not associated with an insert in the
-    /// session.
+    /// sandbox.
     pub fn pending_kv_insert(
         &self,
         handle: PendingKvInsertHandle,
@@ -805,7 +805,7 @@ impl Session {
         self.kv_store().delete(obj_store_key, obj_key)
     }
 
-    /// Insert a [`PendingKvDelete`] into the session.
+    /// Insert a [`PendingKvDelete`] into the sandbox.
     ///
     /// This method returns a new [`PendingKvDeleteHandle`], which can then be used to access
     /// and mutate the pending delete.
@@ -821,7 +821,7 @@ impl Session {
     /// Take ownership of a [`PendingKvDelete`], given its [`PendingKvDeleteHandle`].
     ///
     /// Returns a [`HandleError`] if the handle is not associated with a pending delete in the
-    /// session.
+    /// sandbox.
     pub fn take_pending_kv_delete(
         &mut self,
         handle: PendingKvDeleteHandle,
@@ -839,7 +839,7 @@ impl Session {
     /// Get a reference to a [`PendingDelete`], given its [`PendingKvDeleteHandle`].
     ///
     /// Returns a [`HandleError`] if the handle is not associated with a delete in the
-    /// session.
+    /// sandbox.
     pub fn pending_kv_delete(
         &self,
         handle: PendingKvDeleteHandle,
@@ -859,7 +859,7 @@ impl Session {
         self.kv_store().lookup(obj_store_key, obj_key)
     }
 
-    /// Insert a [`PendingLookup`] into the session.
+    /// Insert a [`PendingLookup`] into the sandbox.
     ///
     /// This method returns a new [`PendingKvLookupHandle`], which can then be used to access
     /// and mutate the pending lookup.
@@ -875,7 +875,7 @@ impl Session {
     /// Take ownership of a [`PendingLookup`], given its [`PendingKvLookupHandle`].
     ///
     /// Returns a [`HandleError`] if the handle is not associated with a pending lookup in the
-    /// session.
+    /// sandbox.
     pub fn take_pending_kv_lookup(
         &mut self,
         handle: PendingKvLookupHandle,
@@ -893,7 +893,7 @@ impl Session {
     /// Get a reference to a [`PendingLookup`], given its [`PendingKvLookupHandle`].
     ///
     /// Returns a [`HandleError`] if the handle is not associated with a lookup in the
-    /// session.
+    /// sandbox.
     pub fn pending_kv_lookup(
         &self,
         handle: PendingKvLookupHandle,
@@ -917,7 +917,7 @@ impl Session {
         self.kv_store().list(obj_store_key, cursor, prefix, limit)
     }
 
-    /// Insert a [`PendingList`] into the session.
+    /// Insert a [`PendingList`] into the sandbox.
     ///
     /// This method returns a new [`PendingKvListHandle`], which can then be used to access
     /// and mutate the pending list.
@@ -930,7 +930,7 @@ impl Session {
     /// Take ownership of a [`PendingList`], given its [`PendingKvListHandle`].
     ///
     /// Returns a [`HandleError`] if the handle is not associated with a pending list in the
-    /// session.
+    /// sandbox.
     pub fn take_pending_kv_list(
         &mut self,
         handle: PendingKvListHandle,
@@ -948,7 +948,7 @@ impl Session {
     /// Get a reference to a [`PendingList`], given its [`PendingKvListHandle`].
     ///
     /// Returns a [`HandleError`] if the handle is not associated with a list in the
-    /// session.
+    /// sandbox.
     pub fn pending_kv_list(
         &self,
         handle: PendingKvListHandle,
@@ -996,7 +996,7 @@ impl Session {
 
     // ----- Pending Requests API -----
 
-    /// Insert a [`PendingRequest`] into the session.
+    /// Insert a [`PendingRequest`] into the sandbox.
     ///
     /// This method returns a new [`PendingRequestHandle`], which can then be used to access
     /// and mutate the pending request.
@@ -1012,7 +1012,7 @@ impl Session {
     /// Get a reference to a [`PendingRequest`], given its [`PendingRequestHandle`].
     ///
     /// Returns a [`HandleError`] if the handle is not associated with a request in the
-    /// session.
+    /// sandbox.
     pub fn pending_request(
         &self,
         handle: PendingRequestHandle,
@@ -1027,7 +1027,7 @@ impl Session {
     /// Get a mutable reference to a [`PendingRequest`], given its [`PendingRequestHandle`].
     ///
     /// Returns a [`HandleError`] if the handle is not associated with a request in the
-    /// session.
+    /// sandbox.
     pub fn pending_request_mut(
         &mut self,
         handle: PendingRequestHandle,
@@ -1042,7 +1042,7 @@ impl Session {
     /// Take ownership of a [`PendingRequest`], given its [`PendingRequestHandle`].
     ///
     /// Returns a [`HandleError`] if the handle is not associated with a pending request in the
-    /// session.
+    /// sandbox.
     pub fn take_pending_request(
         &mut self,
         handle: PendingRequestHandle,
@@ -1141,7 +1141,7 @@ impl Session {
     /// Take ownership of multiple AsyncItems in preparation for a `select`.
     ///
     /// Returns a [`HandleError`] if any of the handles are not associated with a pending
-    /// request in the session.
+    /// request in the sandbox.
     pub fn prepare_select_targets(
         &mut self,
         handles: impl IntoIterator<Item = AsyncItemHandle>,
@@ -1181,14 +1181,14 @@ impl Session {
         self.async_items.push(Some(AsyncItem::Ready))
     }
 
-    /// Returns the unique identifier for the current session.
+    /// Returns the unique identifier for the current sandbox.
     ///
     /// While this corresponds to the request ID for the initial request that spawned
-    /// the session, subsequent downstream requests received by the session will have
+    /// the sandbox, subsequent downstream requests received by the sandbox will have
     /// their own unique identifier. Care should be taken to not conflate the two, and
-    /// to use [Session::downstream_request_id] whenever a request needs to be identified.
-    pub fn session_id(&self) -> u64 {
-        self.session_id
+    /// to use [Sandbox::downstream_request_id] whenever a request needs to be identified.
+    pub fn sandbox_id(&self) -> u64 {
+        self.sandbox_id
     }
 
     /// Access the path to the configuration file for this invocation.
@@ -1229,7 +1229,7 @@ impl Session {
         &mut self,
         handles: impl IntoIterator<Item = AsyncItemHandle>,
     ) -> Result<usize, Error> {
-        // we have to temporarily move the async items out of the session table,
+        // we have to temporarily move the async items out of the sandbox table,
         // because we need &mut borrows of all of them simultaneously.
         let targets = self.prepare_select_targets(handles)?;
         let mut selected = SelectedTargets::new(self, targets);
@@ -1378,14 +1378,14 @@ impl Session {
     }
 }
 
-pub struct SelectedTargets<'session> {
-    session: &'session mut Session,
+pub struct SelectedTargets<'sandbox> {
+    sandbox: &'sandbox mut Sandbox,
     targets: Vec<SelectTarget>,
 }
 
-impl<'session> SelectedTargets<'session> {
-    fn new(session: &'session mut Session, targets: Vec<SelectTarget>) -> Self {
-        Self { session, targets }
+impl<'sandbox> SelectedTargets<'sandbox> {
+    fn new(sandbox: &'sandbox mut Sandbox, targets: Vec<SelectTarget>) -> Self {
+        Self { sandbox, targets }
     }
 
     fn future(&mut self) -> Box<dyn Future<Output = usize> + Unpin + Send + Sync + '_> {
@@ -1405,10 +1405,10 @@ impl<'session> SelectedTargets<'session> {
     }
 }
 
-impl<'session> Drop for SelectedTargets<'session> {
+impl<'sandbox> Drop for SelectedTargets<'sandbox> {
     fn drop(&mut self) {
         let targets = std::mem::take(&mut self.targets);
-        self.session.reinsert_select_targets(targets);
+        self.sandbox.reinsert_select_targets(targets);
     }
 }
 

--- a/src/sandbox/async_item.rs
+++ b/src/sandbox/async_item.rs
@@ -147,7 +147,7 @@ impl PendingCacheTask {
 /// Represents either a full body, or the write end of a streaming body.
 ///
 /// This enum is needed because we reuse the handle for a body when it is transformed into a streaming
-/// body (writeable only). It is used within the body handle map in `Session`.
+/// body (writeable only). It is used within the body handle map in `Sandbox`.
 #[derive(Debug)]
 pub enum AsyncItem {
     Body(Body),

--- a/src/sandbox/downstream.rs
+++ b/src/sandbox/downstream.rs
@@ -8,7 +8,7 @@ use {
         framing::{content_length_is_valid, transfer_encoding_is_supported},
         headers::filter_outgoing_headers,
         pushpin::PushpinRedirectInfo,
-        session::ViceroyResponseMetadata,
+        sandbox::ViceroyResponseMetadata,
         wiggle_abi::types::FramingHeadersMode,
     },
     hyper::http::response::Response,
@@ -18,11 +18,11 @@ use {
 
 /// Downstream response states.
 ///
-/// See [`Session::set_downstream_response_sender`][set] and
-/// [`Session::send_downstream_response`][send] for more information.
+/// See [`Sandbox::set_downstream_response_sender`][set] and
+/// [`Sandbox::send_downstream_response`][send] for more information.
 ///
-/// [send]: struct.Session.html#method.send_downstream_response
-/// [set]: struct.Session.html#method.set_downstream_response_sender
+/// [send]: struct.Sandbox.html#method.send_downstream_response
+/// [set]: struct.Sandbox.html#method.set_downstream_response_sender
 pub enum DownstreamResponseState {
     /// No channel to send the response has been opened yet.
     Closed,

--- a/src/upstream.rs
+++ b/src/upstream.rs
@@ -5,7 +5,7 @@ use crate::{
     error::Error,
     framing::{content_length_is_valid, transfer_encoding_is_supported},
     headers::filter_outgoing_headers,
-    session::{AsyncItem, AsyncItemHandle, ViceroyRequestMetadata},
+    sandbox::{AsyncItem, AsyncItemHandle, ViceroyRequestMetadata},
     wiggle_abi::types::{ContentEncodings, FramingHeadersMode},
 };
 use futures::Future;
@@ -436,7 +436,7 @@ pub enum PendingRequest {
     // NB: we use channels rather than a `JoinHandle` in order to support the `poll` API.
 }
 
-/// A pair of a pending request and the handle that pointed to it in the session, suitable for
+/// A pair of a pending request and the handle that pointed to it in the sandbox, suitable for
 /// invoking the futures select API.
 ///
 /// We need this type because `future::select_all` does not guarantee anything about the order of

--- a/src/wiggle_abi.rs
+++ b/src/wiggle_abi.rs
@@ -20,7 +20,7 @@ use {
         fastly_abi::FastlyAbi,
         types::{FastlyStatus, UserErrorConversion},
     },
-    crate::{error::Error, session::Session},
+    crate::{error::Error, sandbox::Sandbox},
     tracing::{Level, event},
     wiggle::{GuestErrorType, GuestMemory, GuestPtr},
 };
@@ -194,7 +194,7 @@ impl TryFrom<http::version::Version> for types::HttpVersion {
     }
 }
 
-impl FastlyAbi for Session {
+impl FastlyAbi for Sandbox {
     fn init(&mut self, _memory: &mut GuestMemory<'_>, abi_version: u64) -> Result<(), Error> {
         if abi_version != ABI_VERSION {
             Err(Error::AbiVersionMismatch)
@@ -204,7 +204,7 @@ impl FastlyAbi for Session {
     }
 }
 
-impl UserErrorConversion for Session {
+impl UserErrorConversion for Sandbox {
     fn fastly_status_from_error(&mut self, e: Error) -> Result<FastlyStatus, anyhow::Error> {
         match e {
             Error::UnknownBackend(ref backend) => {

--- a/src/wiggle_abi/acl.rs
+++ b/src/wiggle_abi/acl.rs
@@ -1,9 +1,9 @@
 use crate::error::{Error, HandleError};
-use crate::session::Session;
+use crate::sandbox::Sandbox;
 use crate::wiggle_abi::{fastly_acl, types};
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
-impl fastly_acl::FastlyAcl for Session {
+impl fastly_acl::FastlyAcl for Sandbox {
     /// Open a handle to an ACL by its linked name.
     fn open(
         &mut self,

--- a/src/wiggle_abi/backend_impl.rs
+++ b/src/wiggle_abi/backend_impl.rs
@@ -1,19 +1,19 @@
 use super::fastly_backend::FastlyBackend;
-use crate::{config::Backend, error::Error, session::Session};
+use crate::{config::Backend, error::Error, sandbox::Sandbox};
 
 fn lookup_backend_definition<'sess>(
-    session: &'sess Session,
+    sandbox: &'sess Sandbox,
     memory: &mut wiggle::GuestMemory<'_>,
     backend: wiggle::GuestPtr<str>,
 ) -> Result<&'sess Backend, Error> {
     let name = memory.as_str(backend)?.ok_or(Error::SharedMemory)?;
-    session
+    sandbox
         .backend(name)
         .map(AsRef::as_ref)
         .ok_or(Error::InvalidArgument)
 }
 
-impl FastlyBackend for Session {
+impl FastlyBackend for Sandbox {
     fn exists(
         &mut self,
         memory: &mut wiggle::GuestMemory<'_>,

--- a/src/wiggle_abi/body_impl.rs
+++ b/src/wiggle_abi/body_impl.rs
@@ -8,7 +8,7 @@ use {
     crate::{
         body::Body,
         error::Error,
-        session::Session,
+        sandbox::Sandbox,
         wiggle_abi::{
             fastly_http_body::FastlyHttpBody,
             types::{
@@ -20,14 +20,14 @@ use {
     wiggle::{GuestMemory, GuestPtr},
 };
 
-impl FastlyHttpBody for Session {
+impl FastlyHttpBody for Sandbox {
     async fn append(
         &mut self,
         _memory: &mut GuestMemory<'_>,
         dest: BodyHandle,
         src: BodyHandle,
     ) -> Result<(), Error> {
-        // Take the `src` body out of the session, and get a mutable reference
+        // Take the `src` body out of the sandbox, and get a mutable reference
         // to the `dest` body we will append to.
         let mut src = self.take_body(src)?;
         let trailers = std::mem::take(&mut src.trailers);

--- a/src/wiggle_abi/cache.rs
+++ b/src/wiggle_abi/cache.rs
@@ -7,7 +7,7 @@ use http::HeaderMap;
 
 use crate::body::Body;
 use crate::cache::{CacheKey, SurrogateKeySet, VaryRule, WriteOptions};
-use crate::session::{PeekableTask, PendingCacheTask, Session};
+use crate::sandbox::{PeekableTask, PendingCacheTask, Sandbox};
 use crate::wiggle_abi::types::CacheWriteOptionsMask;
 
 use super::fastly_cache::FastlyCache;
@@ -140,7 +140,7 @@ struct LookupOptions {
 }
 
 fn load_lookup_options(
-    session: &Session,
+    sandbox: &Sandbox,
     memory: &wiggle::GuestMemory<'_>,
     mut options_mask: types::CacheLookupOptionsMask,
     options: wiggle::GuestPtr<types::CacheLookupOptions>,
@@ -148,7 +148,7 @@ fn load_lookup_options(
     let options = memory.read(options)?;
     let headers = if options_mask.contains(types::CacheLookupOptionsMask::REQUEST_HEADERS) {
         let handle = options.request_headers;
-        let parts = session.request_parts(handle)?;
+        let parts = sandbox.request_parts(handle)?;
         parts.headers.clone()
     } else {
         HeaderMap::default()
@@ -178,7 +178,7 @@ fn load_lookup_options(
 }
 
 #[allow(unused_variables)]
-impl FastlyCache for Session {
+impl FastlyCache for Sandbox {
     async fn lookup(
         &mut self,
         memory: &mut wiggle::GuestMemory<'_>,
@@ -578,20 +578,20 @@ impl FastlyCache for Session {
             return Err(Error::NotAvailable("unknown cache get_body option"));
         }
 
-        // We wind up re-borrowing `found` and `self.session` several times here, to avoid
+        // We wind up re-borrowing `found` and `self.sandbox` several times here, to avoid
         // borrowing the both of them at once.
         // (It possible that inserting a body would change the address of Found, by re-shuffling
         // the AsyncItems table; we have to live by borrowck's rules.)
         //
-        // We have an exclusive borrow &mut self.session for the lifetime of this call,
+        // We have an exclusive borrow &mut self.sandbox for the lifetime of this call,
         // so even though we're re-borrowing/repeating lookups, we know we won't run into TOCTOU.
 
         let entry = self.cache_entry(handle).await?;
 
         // Preemptively (optimistically) start a read. Don't worry, the Drop impl for Body will
         // clean up the copying task.
-        // We have to do this to allow `found`'s lifetime to end before self.session.body, which
-        // has to re-borrow self.self.session.
+        // We have to do this to allow `found`'s lifetime to end before self.sandbox.body, which
+        // has to re-borrow self.self.sandbox.
         let body = entry.body(from, to).await?;
 
         let found = entry

--- a/src/wiggle_abi/compute_runtime.rs
+++ b/src/wiggle_abi/compute_runtime.rs
@@ -1,10 +1,10 @@
 use crate::error::Error;
-use crate::session::Session;
+use crate::sandbox::Sandbox;
 use crate::wiggle_abi::fastly_compute_runtime::FastlyComputeRuntime;
 use std::sync::atomic::Ordering;
 use wiggle::GuestMemory;
 
-impl FastlyComputeRuntime for Session {
+impl FastlyComputeRuntime for Sandbox {
     fn get_vcpu_ms(&mut self, _memory: &mut GuestMemory<'_>) -> Result<u64, Error> {
         // we internally track microseconds, because our wasmtime tick length
         // is too short for ms to work. but we want to shrink this to ms to

--- a/src/wiggle_abi/config_store.rs
+++ b/src/wiggle_abi/config_store.rs
@@ -3,10 +3,10 @@ use super::{
     fastly_dictionary::FastlyDictionary,
     types::{ConfigStoreHandle, DictionaryHandle},
 };
-use crate::{Error, session::Session};
+use crate::{Error, sandbox::Sandbox};
 use wiggle::{GuestMemory, GuestPtr};
 
-impl FastlyConfigStore for Session {
+impl FastlyConfigStore for Sandbox {
     fn open(
         &mut self,
         memory: &mut GuestMemory<'_>,

--- a/src/wiggle_abi/device_detection_impl.rs
+++ b/src/wiggle_abi/device_detection_impl.rs
@@ -1,7 +1,7 @@
 //! fastly_device_detection` hostcall implementations.
 
 use crate::error::Error;
-use crate::wiggle_abi::{FastlyStatus, Session, fastly_device_detection::FastlyDeviceDetection};
+use crate::wiggle_abi::{FastlyStatus, Sandbox, fastly_device_detection::FastlyDeviceDetection};
 use std::convert::TryFrom;
 use wiggle::{GuestMemory, GuestPtr};
 
@@ -22,7 +22,7 @@ impl DeviceDetectionError {
     }
 }
 
-impl FastlyDeviceDetection for Session {
+impl FastlyDeviceDetection for Sandbox {
     fn lookup(
         &mut self,
         memory: &mut GuestMemory<'_>,

--- a/src/wiggle_abi/dictionary_impl.rs
+++ b/src/wiggle_abi/dictionary_impl.rs
@@ -3,7 +3,7 @@
 use {
     crate::{
         error::Error,
-        session::Session,
+        sandbox::Sandbox,
         wiggle_abi::{
             fastly_dictionary::FastlyDictionary,
             types::{DictionaryHandle, FastlyStatus},
@@ -33,7 +33,7 @@ impl DictionaryError {
     }
 }
 
-impl FastlyDictionary for Session {
+impl FastlyDictionary for Sandbox {
     fn open(
         &mut self,
         memory: &mut GuestMemory<'_>,

--- a/src/wiggle_abi/erl_impl.rs
+++ b/src/wiggle_abi/erl_impl.rs
@@ -1,11 +1,11 @@
 use crate::{
     error::Error,
-    session::Session,
+    sandbox::Sandbox,
     wiggle_abi::fastly_erl::FastlyErl,
     wiggle_abi::{GuestMemory, GuestPtr},
 };
 
-impl FastlyErl for Session {
+impl FastlyErl for Sandbox {
     fn check_rate(
         &mut self,
         _memory: &mut GuestMemory<'_>,

--- a/src/wiggle_abi/fastly_purge_impl.rs
+++ b/src/wiggle_abi/fastly_purge_impl.rs
@@ -2,11 +2,11 @@
 
 use {
     super::types::{PurgeOptions, PurgeOptionsMask},
-    crate::{error::Error, session::Session, wiggle_abi::fastly_purge::FastlyPurge},
+    crate::{error::Error, sandbox::Sandbox, wiggle_abi::fastly_purge::FastlyPurge},
     wiggle::{GuestMemory, GuestPtr},
 };
 
-impl FastlyPurge for Session {
+impl FastlyPurge for Sandbox {
     fn purge_surrogate_key(
         &mut self,
         memory: &mut GuestMemory<'_>,

--- a/src/wiggle_abi/geo_impl.rs
+++ b/src/wiggle_abi/geo_impl.rs
@@ -6,12 +6,12 @@ use std::{
 };
 
 use {
-    crate::{error::Error, session::Session, wiggle_abi::fastly_geo::FastlyGeo},
+    crate::{error::Error, sandbox::Sandbox, wiggle_abi::fastly_geo::FastlyGeo},
     std::convert::TryFrom,
     wiggle::{GuestMemory, GuestPtr},
 };
 
-impl FastlyGeo for Session {
+impl FastlyGeo for Sandbox {
     fn lookup(
         &mut self,
         memory: &mut GuestMemory<'_>,

--- a/src/wiggle_abi/http_cache.rs
+++ b/src/wiggle_abi/http_cache.rs
@@ -1,4 +1,4 @@
-use crate::session::Session;
+use crate::sandbox::Sandbox;
 
 use super::fastly_http_cache::FastlyHttpCache;
 use super::{Error, types};
@@ -6,7 +6,7 @@ use super::{Error, types};
 use wiggle::{GuestMemory, GuestPtr};
 
 #[allow(unused_variables)]
-impl FastlyHttpCache for Session {
+impl FastlyHttpCache for Sandbox {
     async fn lookup(
         &mut self,
         memory: &mut GuestMemory<'_>,

--- a/src/wiggle_abi/http_downstream.rs
+++ b/src/wiggle_abi/http_downstream.rs
@@ -2,7 +2,7 @@ use std::net::IpAddr;
 use std::time::Duration;
 
 use crate::error::Error;
-use crate::session::{AsyncItemHandle, Session};
+use crate::sandbox::{AsyncItemHandle, Sandbox};
 use crate::wiggle_abi::fastly_http_downstream::FastlyHttpDownstream;
 use crate::wiggle_abi::headers::HttpHeaders;
 use crate::wiggle_abi::types::{
@@ -12,7 +12,7 @@ use crate::wiggle_abi::types::{
 
 use wiggle::{GuestMemory, GuestPtr};
 
-impl FastlyHttpDownstream for Session {
+impl FastlyHttpDownstream for Sandbox {
     async fn next_request(
         &mut self,
         memory: &mut GuestMemory<'_>,
@@ -296,7 +296,7 @@ impl FastlyHttpDownstream for Session {
         region_max_len: u32,
         nwritten_out: GuestPtr<u32>,
     ) -> Result<(), Error> {
-        let region = Session::downstream_compliance_region(self, handle)?
+        let region = Sandbox::downstream_compliance_region(self, handle)?
             .ok_or(Error::MissingDownstreamMetadata)?;
         let region_len = region.len();
 
@@ -476,7 +476,7 @@ trait MetadataView {
     /// Stub for metadata that Viceroy does not support. Validates the handle normally, but always returns Error::ValueAbsent rather than a meaningful value.
     fn absent_metadata_value<T>(&self, handle: RequestHandle) -> Result<T, Error>;
 }
-impl MetadataView for Session {
+impl MetadataView for Sandbox {
     fn absent_metadata_value<T>(&self, handle: RequestHandle) -> Result<T, Error> {
         let _ = self
             .downstream_metadata(handle)?

--- a/src/wiggle_abi/image_optimizer.rs
+++ b/src/wiggle_abi/image_optimizer.rs
@@ -1,9 +1,9 @@
 use crate::error::Error;
-use crate::session::Session;
+use crate::sandbox::Sandbox;
 use crate::wiggle_abi::{fastly_image_optimizer, types};
 use wiggle::{GuestMemory, GuestPtr};
 
-impl fastly_image_optimizer::FastlyImageOptimizer for Session {
+impl fastly_image_optimizer::FastlyImageOptimizer for Sandbox {
     async fn transform_image_optimizer_request(
         &mut self,
         _memory: &mut GuestMemory<'_>,

--- a/src/wiggle_abi/kv_store_impl.rs
+++ b/src/wiggle_abi/kv_store_impl.rs
@@ -1,8 +1,8 @@
 //! fastly_obj_store` hostcall implementations.
 
 use crate::object_store::KvStoreError;
-use crate::session::PeekableTask;
-use crate::session::{
+use crate::sandbox::PeekableTask;
+use crate::sandbox::{
     PendingKvDeleteTask, PendingKvInsertTask, PendingKvListTask, PendingKvLookupTask,
 };
 
@@ -10,7 +10,7 @@ use {
     crate::{
         error::Error,
         object_store::{ObjectKey, ObjectStoreError},
-        session::Session,
+        sandbox::Sandbox,
         wiggle_abi::{
             fastly_kv_store::FastlyKvStore,
             types::{
@@ -24,7 +24,7 @@ use {
     wiggle::{GuestMemory, GuestPtr},
 };
 
-impl FastlyKvStore for Session {
+impl FastlyKvStore for Sandbox {
     fn open(
         &mut self,
         memory: &mut GuestMemory<'_>,

--- a/src/wiggle_abi/log_impl.rs
+++ b/src/wiggle_abi/log_impl.rs
@@ -3,7 +3,7 @@
 use {
     crate::{
         error::Error,
-        session::Session,
+        sandbox::Sandbox,
         wiggle_abi::{fastly_log::FastlyLog, types::EndpointHandle},
     },
     lazy_static::lazy_static,
@@ -22,7 +22,7 @@ fn is_reserved_endpoint(name: &[u8]) -> bool {
     RESERVED_ENDPOINT_RE.is_match(name)
 }
 
-impl FastlyLog for Session {
+impl FastlyLog for Sandbox {
     fn endpoint_get(
         &mut self,
         memory: &mut GuestMemory<'_>,

--- a/src/wiggle_abi/obj_store_impl.rs
+++ b/src/wiggle_abi/obj_store_impl.rs
@@ -1,15 +1,15 @@
 //! fastly_obj_store` hostcall implementations.
 
 use super::types::{PendingKvDeleteHandle, PendingKvInsertHandle, PendingKvLookupHandle};
-use crate::session::PeekableTask;
-use crate::session::{PendingKvDeleteTask, PendingKvInsertTask, PendingKvLookupTask};
+use crate::sandbox::PeekableTask;
+use crate::sandbox::{PendingKvDeleteTask, PendingKvInsertTask, PendingKvLookupTask};
 
 use {
     crate::{
         body::Body,
         error::Error,
         object_store::{ObjectKey, ObjectStoreError},
-        session::Session,
+        sandbox::Sandbox,
         wiggle_abi::{
             fastly_object_store::FastlyObjectStore,
             types::{BodyHandle, ObjectStoreHandle},
@@ -18,7 +18,7 @@ use {
     wiggle::{GuestMemory, GuestPtr},
 };
 
-impl FastlyObjectStore for Session {
+impl FastlyObjectStore for Sandbox {
     fn open(
         &mut self,
         memory: &mut GuestMemory<'_>,

--- a/src/wiggle_abi/req_impl.rs
+++ b/src/wiggle_abi/req_impl.rs
@@ -12,7 +12,7 @@ use {
         config::Backend,
         error::Error,
         pushpin::{PushpinRedirectInfo, PushpinRedirectRequestInfo},
-        session::{AsyncItem, PeekableTask, Session, ViceroyRequestMetadata},
+        sandbox::{AsyncItem, PeekableTask, Sandbox, ViceroyRequestMetadata},
         upstream,
         wiggle_abi::{
             fastly_http_downstream::FastlyHttpDownstream,
@@ -32,7 +32,7 @@ use {
     wiggle::{GuestMemory, GuestPtr},
 };
 
-impl FastlyHttpReq for Session {
+impl FastlyHttpReq for Sandbox {
     fn body_downstream_get(
         &mut self,
         _memory: &mut GuestMemory<'_>,
@@ -1071,7 +1071,7 @@ impl FastlyHttpReq for Session {
         encodings: ContentEncodings,
     ) -> Result<(), Error> {
         // NOTE: We're going to hide this flag in the extensions of the request in order to decrease
-        // the book-keeping burden inside Session. The flag will get picked up later, in `send_request`.
+        // the book-keeping burden inside Sandbox. The flag will get picked up later, in `send_request`.
         let extensions = &mut self.request_parts_mut(req_handle)?.extensions;
 
         match extensions.get_mut::<ViceroyRequestMetadata>() {

--- a/src/wiggle_abi/resp_impl.rs
+++ b/src/wiggle_abi/resp_impl.rs
@@ -3,7 +3,7 @@
 use {
     crate::{
         error::Error,
-        session::{Session, ViceroyResponseMetadata},
+        sandbox::{Sandbox, ViceroyResponseMetadata},
         upstream,
         wiggle_abi::{
             fastly_http_resp::FastlyHttpResp,
@@ -20,7 +20,7 @@ use {
     wiggle::{GuestMemory, GuestPtr},
 };
 
-impl FastlyHttpResp for Session {
+impl FastlyHttpResp for Sandbox {
     fn new(&mut self, _memory: &mut GuestMemory<'_>) -> Result<ResponseHandle, Error> {
         // KTM: Unfortunately `response::Parts` doesn't expose a constructor. This is a workaround.
         let (parts, _) = Response::new(()).into_parts();
@@ -158,7 +158,7 @@ impl FastlyHttpResp for Session {
         streaming: u32,
     ) -> Result<(), Error> {
         let resp = {
-            // Take the response parts and body from the session, and use them to build a response.
+            // Take the response parts and body from the sandbox, and use them to build a response.
             // Return an `FastlyStatus::Badf` error code if either of the given handles are invalid.
             let resp_parts = self.take_response_parts(resp_handle)?;
             let body = if streaming == 1 {

--- a/src/wiggle_abi/secret_store_impl.rs
+++ b/src/wiggle_abi/secret_store_impl.rs
@@ -1,8 +1,8 @@
 use {
     crate::{
         error::Error,
+        sandbox::Sandbox,
         secret_store::SecretLookup,
-        session::Session,
         wiggle_abi::{
             fastly_secret_store::FastlySecretStore,
             types::{FastlyStatus, SecretHandle, SecretStoreHandle},
@@ -43,7 +43,7 @@ impl From<&SecretStoreError> for FastlyStatus {
     }
 }
 
-impl FastlySecretStore for Session {
+impl FastlySecretStore for Sandbox {
     fn open(
         &mut self,
         memory: &mut GuestMemory<'_>,

--- a/src/wiggle_abi/shielding.rs
+++ b/src/wiggle_abi/shielding.rs
@@ -1,11 +1,11 @@
 use crate::config::Backend;
 use crate::error::Error;
-use crate::session::Session;
+use crate::sandbox::Sandbox;
 use crate::wiggle_abi::{fastly_shielding, types};
 use http::Uri;
 use std::str::FromStr;
 
-impl fastly_shielding::FastlyShielding for Session {
+impl fastly_shielding::FastlyShielding for Sandbox {
     fn shield_info(
         &mut self,
         memory: &mut wiggle::GuestMemory<'_>,

--- a/src/wiggle_abi/uap_impl.rs
+++ b/src/wiggle_abi/uap_impl.rs
@@ -1,11 +1,11 @@
 //! fastly_uap` hostcall implementations.
 
 use {
-    crate::{error::Error, session::Session, wiggle_abi::fastly_uap::FastlyUap},
+    crate::{error::Error, sandbox::Sandbox, wiggle_abi::fastly_uap::FastlyUap},
     wiggle::{GuestMemory, GuestPtr},
 };
 
-impl FastlyUap for Session {
+impl FastlyUap for Sandbox {
     fn parse(
         &mut self,
         _memory: &mut GuestMemory<'_>,

--- a/test-fixtures/src/bin/downstream-req.rs
+++ b/test-fixtures/src/bin/downstream-req.rs
@@ -34,10 +34,10 @@ fn main() {
 
     assert_eq!(client_req.take_body_str(), "Hello, world!");
 
-    // Request ID matches session ID for first request:
+    // Request ID matches sandbox ID for first request:
     let req_id = client_req.get_client_request_id().unwrap().to_string();
-    let session_id = std::env::var("FASTLY_TRACE_ID").unwrap();
-    assert_eq!(req_id, session_id);
+    let sandbox_id = std::env::var("FASTLY_TRACE_ID").unwrap();
+    assert_eq!(req_id, sandbox_id);
 
     // Check that we can get addresses used in downstream connection:
     let localhost: IpAddr = "127.0.0.1".parse().unwrap();

--- a/test-fixtures/src/bin/reusable-sandboxes.rs
+++ b/test-fixtures/src/bin/reusable-sandboxes.rs
@@ -1,4 +1,4 @@
-//! A guest program that tests the hostcalls for fetching multiple requests per session.
+//! A guest program that tests the hostcalls for fetching multiple requests per sandbox.
 
 use fastly::{Request, Response};
 use fastly::handle::{BodyHandle, RequestHandle};

--- a/wasm_abi/adapter/src/fastly/core.rs
+++ b/wasm_abi/adapter/src/fastly/core.rs
@@ -2,11 +2,11 @@
 // not be confused with types of similar names in the `fastly` crate which are used to provide safe
 // wrappers around these definitions.
 
-use super::{FastlyStatus, convert_result};
+use super::{convert_result, FastlyStatus};
 use crate::fastly::decode_ip_address;
 use crate::{
-    TrappingUnwrap, alloc_result, alloc_result_opt, handle_buffer_len, make_vec, with_buffer,
-    write_bool_result,
+    alloc_result, alloc_result_opt, handle_buffer_len, make_vec, with_buffer, write_bool_result,
+    TrappingUnwrap,
 };
 use core::mem::ManuallyDrop;
 
@@ -600,9 +600,9 @@ pub mod fastly_log {
 pub mod fastly_http_downstream {
     use super::*;
     use crate::{
-        TrappingUnwrap,
         bindings::fastly::compute::{http_downstream, http_req},
         fastly::encode_ip_address,
+        TrappingUnwrap,
     };
 
     bitflags::bitflags! {
@@ -1391,12 +1391,12 @@ pub mod fastly_http_req {
 
     use super::*;
     use crate::{
-        TrappingUnwrap,
         bindings::fastly::{
             self,
             adapter::adapter_http_req,
             compute::{backend, http_req, http_types, security},
         },
+        TrappingUnwrap,
     };
 
     bitflags::bitflags! {


### PR DESCRIPTION
This matches the public documentation of the production platform, which has begun using 'sandbox' as the term to define an instance of a WASM package in memory.

There are no functional changes here, but this is a breaking change for users of viceroy-lib.