### PR TITLE
Update release workflow to publish crates automatically

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,3 +99,27 @@ jobs:
             })
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  publish-crates:
+    needs: build
+    runs-on: ubuntu-24.04
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: true
+      - name: Install Rust
+        run: rustup show
+      - name: Authenticate with crates.io
+        uses: rust-lang/crates-io-auth-action@v1
+        id: auth
+      - name: Publish viceroy-lib
+        run: cargo publish -p viceroy-lib --locked
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+      - name: Publish viceroy
+        run: cargo publish -p viceroy --locked
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}

--- a/doc/RELEASING.md
+++ b/doc/RELEASING.md
@@ -15,9 +15,8 @@ Below are the steps needed to do a Viceroy release:
 1. Run `make ci` locally to make sure that everything will pass before pushing
    the branch and opening up a PR.
 1. After you get approval, run `git tag vx.y.z HEAD && git push origin vx.y.z`.
-   Pushing this tag will kick off a build for all of the release artifacts.
-1. After CI completes, we should publish all crates in the workspace to the
-   crates.io registry: `cargo publish --workspace`.
+   Pushing this tag will kick off a build for all of the release artifacts, create
+   a release on GitHub, and publish the crates to crates.io.
 1. Now, we should return to our release PR.
     1. Update the version fields in `Cargo.toml` and `cli/Cargo.toml` to the
      next patch version (so `z + 1`).


### PR DESCRIPTION
This pull request enhances the release workflow by automating the step of releasing to crates.io.

Before merging, the Trusted Publishing configuration needs to be added at:
- https://crates.io/crates/viceroy/settings
- https://crates.io/crates/viceroy-lib/settings