### PR TITLE
add cargo-binstall metadata for faster installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,18 @@ To install Viceroy as a standalone tool, you'll need to first
 Then run `cargo install --locked viceroy`, which will download and build the latest
 Viceroy release.
 
+### As a prebuilt binary
+
+To avoid compiling from source, you can download a prebuilt binary for your
+platform from the [releases page], or install one with
+[`cargo-binstall`](https://github.com/cargo-bins/cargo-binstall):
+
+```
+cargo binstall viceroy
+```
+
+[releases page]: https://github.com/fastly/Viceroy/releases
+
 ## Usage as a library
 
 Viceroy can be used as a [Rust library](https://docs.rs/viceroy-lib/). This is useful if you want to run integration tests in the same codebase. We provide a helper method [`handle_request`](https://docs.rs/viceroy-lib/0.2.6/viceroy_lib/struct.ExecuteCtx.html#method.handle_request). Before you build or test your code, we recommend to set the release flag e.g. `cargo test --release` otherwise, the execution will be very slow. This has to do with the Cranelift compiler, which is extremely slow when compiled in debug mode. Besides that, if you use GitHub Actions don't forget to set up a build [cache](https://github.com/actions/cache/blob/main/examples.md#rust---cargo) for Rust. This will speed up your build times a lot.

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -25,6 +25,28 @@ include = [
     "src/**/*"
 ]
 
+# Install prebuilt binaries from GitHub releases instead of compiling.
+# Release assets are named e.g. `viceroy_v0.18.1_linux-amd64.tar.gz` and contain
+# a single `viceroy` binary at the archive root.
+[package.metadata.binstall]
+pkg-fmt = "tgz"
+bin-dir = "{ bin }{ binary-ext }"
+
+[package.metadata.binstall.overrides.x86_64-apple-darwin]
+pkg-url = "{ repo }/releases/download/v{ version }/viceroy_v{ version }_darwin-amd64.tar.gz"
+
+[package.metadata.binstall.overrides.aarch64-apple-darwin]
+pkg-url = "{ repo }/releases/download/v{ version }/viceroy_v{ version }_darwin-arm64.tar.gz"
+
+[package.metadata.binstall.overrides.x86_64-unknown-linux-gnu]
+pkg-url = "{ repo }/releases/download/v{ version }/viceroy_v{ version }_linux-amd64.tar.gz"
+
+[package.metadata.binstall.overrides.aarch64-unknown-linux-gnu]
+pkg-url = "{ repo }/releases/download/v{ version }/viceroy_v{ version }_linux-arm64.tar.gz"
+
+[package.metadata.binstall.overrides.x86_64-pc-windows-msvc]
+pkg-url = "{ repo }/releases/download/v{ version }/viceroy_v{ version }_windows-amd64.tar.gz"
+
 [[bin]]
 name = "viceroy"
 path = "src/main.rs"


### PR DESCRIPTION
When using `cargo install` on CI it can take quite some time to install the `viceroy` cli (10/15 minutes somtimes). 

Since we're already publishing the binary in gh releases, we can also use that. 

edit:  https://github.com/cargo-bins/cargo-binstall/blob/main/SUPPORT.md