### PR TITLE
fix: snapshot CacheData on lookup to lock Found metadata (#492)

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -252,21 +252,13 @@ pub struct Found {
     /// We mirror the BodyHandle here when we create it; we can later check whether the handle is
     /// still valid, to find an outstanding read.
     pub last_body_handle: Option<BodyHandle>,
-
-    // Length is snapshoted at lookup time.
-    // CacheData::length() consults the live streamed body, which can transition from none to
-    // some as the body completes. This cannot happen on Compute. length is either known at lookup or
-    // never known. We capture it once here so Found::length() returns a stable value when it is called.
-    known_length: Option<u64>,
 }
 
 impl From<CacheData> for Found {
     fn from(data: CacheData) -> Self {
-        let known_length = data.length();
         Found {
             data,
             last_body_handle: None,
-            known_length,
         }
     }
 }
@@ -283,7 +275,7 @@ impl Found {
 
     /// The length of the cached object, if known at lookup time.
     pub fn length(&self) -> Option<u64> {
-        self.known_length
+        self.data.get_meta().length()
     }
 }
 

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -252,13 +252,22 @@ pub struct Found {
     /// We mirror the BodyHandle here when we create it; we can later check whether the handle is
     /// still valid, to find an outstanding read.
     pub last_body_handle: Option<BodyHandle>,
+
+    /// The length of the cached object, snapshotted at lookup time.
+    ///
+    /// On Compute, length is locked-in at lookup time: it is either known immediately or never
+    /// known. Viceroy mirrors this behavior by capturing the length once when `Found` is created,
+    /// rather than re-querying the (potentially still-streaming) body on each call.
+    length: Option<u64>,
 }
 
 impl From<Arc<CacheData>> for Found {
     fn from(data: Arc<CacheData>) -> Self {
+        let length = data.length();
         Found {
             data,
             last_body_handle: None,
+            length,
         }
     }
 }
@@ -273,9 +282,9 @@ impl Found {
         self.data.get_meta()
     }
 
-    /// The length of the cached object, if known.
+    /// The length of the cached object, if known at lookup time.
     pub fn length(&self) -> Option<u64> {
-        self.data.length()
+        self.length
     }
 }
 
@@ -310,10 +319,7 @@ impl Cache {
             .get_with_by_ref(key, async { Default::default() })
             .await
             .get(headers)
-            .map(|data| Found {
-                data,
-                last_body_handle: None,
-            });
+            .map(|data| Found::from(data));
         CacheEntry {
             key: key.clone(),
             found,

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -243,7 +243,7 @@ impl CacheEntry {
 /// A successful retrieval of an item from the cache.
 #[derive(Debug)]
 pub struct Found {
-    data: Arc<CacheData>,
+    data: CacheData,
 
     /// The handle for the last body used to read from this Found.
     ///
@@ -253,28 +253,27 @@ pub struct Found {
     /// still valid, to find an outstanding read.
     pub last_body_handle: Option<BodyHandle>,
 
-    /// The length of the cached object, snapshotted at lookup time.
-    ///
-    /// On Compute, length is locked-in at lookup time: it is either known immediately or never
-    /// known. Viceroy mirrors this behavior by capturing the length once when `Found` is created,
-    /// rather than re-querying the (potentially still-streaming) body on each call.
-    length: Option<u64>,
+    // Length is snapshoted at lookup time.
+    // CacheData::length() consults the live streamed body, which can transition from none to
+    // some as the body completes. This cannot happen on Compute. length is either known at lookup or
+    // never known. We capture it once here so Found::length() returns a stable value when it is called.
+    known_length: Option<u64>,
 }
 
-impl From<Arc<CacheData>> for Found {
-    fn from(data: Arc<CacheData>) -> Self {
-        let length = data.length();
+impl From<CacheData> for Found {
+    fn from(data: CacheData) -> Self {
+        let known_length = data.length();
         Found {
             data,
             last_body_handle: None,
-            length,
+            known_length,
         }
     }
 }
 
 impl Found {
     fn get_body(&self) -> GetBodyBuilder<'_> {
-        self.data.as_ref().body()
+        self.data.body()
     }
 
     /// Access the metadata of the cached object.
@@ -284,7 +283,7 @@ impl Found {
 
     /// The length of the cached object, if known at lookup time.
     pub fn length(&self) -> Option<u64> {
-        self.length
+        self.known_length
     }
 }
 
@@ -319,7 +318,7 @@ impl Cache {
             .get_with_by_ref(key, async { Default::default() })
             .await
             .get(headers)
-            .map(|data| Found::from(data));
+            .map(|data| Found::from((*data).clone()));
         CacheEntry {
             key: key.clone(),
             found,
@@ -343,7 +342,7 @@ impl Cache {
             .await;
         CacheEntry {
             key: key.clone(),
-            found: found.map(|v| v.into()),
+            found: found.map(|v| Found::from((*v).clone())),
             go_get: obligation,
             always_use_requested_range: false,
         }

--- a/src/cache/store.rs
+++ b/src/cache/store.rs
@@ -47,6 +47,7 @@ pub struct ObjectMeta {
     soft_purge: AtomicBool,
 }
 
+
 impl ObjectMeta {
     /// Retrieve the current age of this object.
     pub fn age(&self) -> Duration {
@@ -121,7 +122,24 @@ impl ObjectMeta {
         }
     }
 }
-
+impl Clone for ObjectMeta {
+    fn clone(&self) -> Self {
+        ObjectMeta {
+            inserted: self.inserted,
+            initial_age: self.initial_age,
+            max_age: self.max_age,
+            stale_while_revalidate: self.stale_while_revalidate,
+            request_headers: self.request_headers.clone(),
+            vary_rule: self.vary_rule.clone(),
+            user_metadata: self.user_metadata.clone(),
+            length: self.length,
+            surrogate_keys: self.surrogate_keys.clone(),
+            soft_purge: AtomicBool::new(
+                self.soft_purge.load(std::sync::atomic::Ordering::SeqCst),
+                ),
+            }
+        }
+}
 /// Object(s) indexed by a CacheKey.
 #[derive(Debug, Default)]
 pub struct CacheKeyObjects(watch::Sender<CacheKeyObjectsInner>);
@@ -500,7 +518,7 @@ impl Obligation {
         // Mild optimization: avoid re-acquiring the lock when we drop.
         // We've already cleared the obligation flag.
         self.completed = true;
-        data.into()
+        (*data).clone().into()
     }
 
     /// Fulfill the obligation by freshening the existing entry.
@@ -554,6 +572,23 @@ impl Drop for Obligation {
 pub(crate) struct CacheData {
     meta: ObjectMeta,
     body: CollectingBody,
+}
+
+impl Clone for CacheData {
+    fn clone(&self) -> Self {
+        // Resolve the length question at clone time.
+        // After this, the cloned CacheData's meta.length will be the single source of truth
+
+        let resolved_length = self.length();
+        let meta = ObjectMeta {
+            length: resolved_length,
+            ..self.meta.clone()
+        };
+        CacheData {
+            meta,
+            body: self.body.clone(),
+        }
+    }
 }
 
 /// A holder for the get_body options.
@@ -669,7 +704,7 @@ impl CacheData {
 
     /// Return the length of this object, if the final or expected length is known.
     pub fn length(&self) -> Option<u64> {
-        self.body.length().or(self.meta.length)
+        self.meta.length.or_else(|| self.body.length())
     }
 }
 

--- a/src/cache/store.rs
+++ b/src/cache/store.rs
@@ -47,7 +47,6 @@ pub struct ObjectMeta {
     soft_purge: AtomicBool,
 }
 
-
 impl ObjectMeta {
     /// Retrieve the current age of this object.
     pub fn age(&self) -> Duration {
@@ -134,11 +133,9 @@ impl Clone for ObjectMeta {
             user_metadata: self.user_metadata.clone(),
             length: self.length,
             surrogate_keys: self.surrogate_keys.clone(),
-            soft_purge: AtomicBool::new(
-                self.soft_purge.load(std::sync::atomic::Ordering::SeqCst),
-                ),
-            }
+            soft_purge: AtomicBool::new(self.soft_purge.load(std::sync::atomic::Ordering::SeqCst)),
         }
+    }
 }
 /// Object(s) indexed by a CacheKey.
 #[derive(Debug, Default)]
@@ -574,11 +571,12 @@ pub(crate) struct CacheData {
     body: CollectingBody,
 }
 
+// Resolve the length question at clone time.
+// After this, the cloned CacheData's meta.length will be the single source of truth.
+// The cloned body shares the same watch channel and will eventually report a length as well,
+// but found Found::length() bypasses CacheData.length() entirely and reads known_length directly.
 impl Clone for CacheData {
     fn clone(&self) -> Self {
-        // Resolve the length question at clone time.
-        // After this, the cloned CacheData's meta.length will be the single source of truth
-
         let resolved_length = self.length();
         let meta = ObjectMeta {
             length: resolved_length,
@@ -704,7 +702,7 @@ impl CacheData {
 
     /// Return the length of this object, if the final or expected length is known.
     pub fn length(&self) -> Option<u64> {
-        self.meta.length.or_else(|| self.body.length())
+        self.body.length().or(self.meta.length)
     }
 }
 

--- a/src/cache/store.rs
+++ b/src/cache/store.rs
@@ -46,7 +46,6 @@ pub struct ObjectMeta {
     // This can only transition false -> true.
     soft_purge: AtomicBool,
 }
-
 impl ObjectMeta {
     /// Retrieve the current age of this object.
     pub fn age(&self) -> Duration {
@@ -86,6 +85,10 @@ impl ObjectMeta {
 
     pub fn user_metadata(&self) -> Bytes {
         self.user_metadata.clone()
+    }
+
+    pub fn length(&self) -> Option<u64> {
+        self.length
     }
 }
 
@@ -356,16 +359,15 @@ impl CacheKeyObjects {
         options: WriteOptions,
         body: Body,
         clear_obligation: Option<Variant>,
-    ) -> Arc<CacheData> {
+    ) -> CacheData {
         let meta = ObjectMeta::new(options, request_headers);
         let vary_rule = meta.vary_rule().clone();
 
         let variant = meta.variant();
         let body = CollectingBody::new(body, meta.length);
-        let object = Arc::new(CacheData { body, meta });
-
-        // We return the updated object as well
-        let result = Arc::clone(&object);
+        let data = CacheData { meta, body };
+        let result = data.clone();
+        let object = Arc::new(data);
 
         self.0.send_modify(|cache_key_objects| {
             if let Some(clear_obligation) = clear_obligation
@@ -515,7 +517,7 @@ impl Obligation {
         // Mild optimization: avoid re-acquiring the lock when we drop.
         // We've already cleared the obligation flag.
         self.completed = true;
-        (*data).clone().into()
+        data.into()
     }
 
     /// Fulfill the obligation by freshening the existing entry.
@@ -701,7 +703,7 @@ impl CacheData {
     }
 
     /// Return the length of this object, if the final or expected length is known.
-    pub fn length(&self) -> Option<u64> {
+    fn length(&self) -> Option<u64> {
         self.body.length().or(self.meta.length)
     }
 }

--- a/src/collecting_body.rs
+++ b/src/collecting_body.rs
@@ -26,7 +26,7 @@ use crate::{
 /// CollectingBody provides a place for this to happen. It accepts a `Body` as a source of data,
 /// e.g. one from a `StreamingBody` or an origin response; stores the data for future retrieval;
 /// and can return new `Body`s from `::read` that produce the full content.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct CollectingBody {
     inner: watch::Receiver<CollectingBodyInner>,
 }

--- a/test-fixtures/src/bin/cache.rs
+++ b/test-fixtures/src/bin/cache.rs
@@ -575,7 +575,7 @@ fn test_length_locked_at_lookup() {
     // A *new* lookup after the stream finishes should immediately see the correct length.
     let key = new_key();
 
-    let body = "hello beautiful world".as_bytes();
+    let body = "hello world".as_bytes();
     let mut writer = insert(key.clone(), Duration::from_secs(115))
         .execute()
         .unwrap();

--- a/test-fixtures/src/bin/cache.rs
+++ b/test-fixtures/src/bin/cache.rs
@@ -40,6 +40,7 @@ fn main() {
     run_test!(test_vary_combine);
 
     run_test!(test_length_from_body);
+    run_test!(test_length_locked_at_lookup);
     run_test!(test_inconsistent_body_length);
     run_test!(test_nonconcurrent_range);
     run_test!(test_concurrent_range);
@@ -566,6 +567,44 @@ fn test_length_from_body() {
 
     let got = poll_known_length(&key);
     assert_eq!(got.known_length().unwrap(), body.len() as u64);
+}
+
+fn test_length_locked_at_lookup() {
+    // Length is locked-in at lookup time: a Found whose lookup happened while the body was still
+    // streaming must always report None for length, even after the stream completes.
+    // A *new* lookup after the stream finishes should immediately see the correct length.
+    let key = new_key();
+
+    let body = "hello beautiful world".as_bytes();
+    let mut writer = insert(key.clone(), Duration::from_secs(115))
+        .execute()
+        .unwrap();
+
+    // Lookup while the body is still streaming: length must be None.
+    let mid_stream = lookup(key.clone()).execute().unwrap().unwrap();
+    assert!(
+        mid_stream.known_length().is_none(),
+        "length must be None while body is still streaming"
+    );
+
+    writer.write_all(body).unwrap();
+    writer.finish().unwrap();
+
+    // The original Found must still report None after the stream completes.
+    // poll_known_length re-looks up until a new Found with known length appears, which confirms
+    // the body is fully collected by this point.
+    let post_stream = poll_known_length(&key);
+    assert_eq!(
+        post_stream.known_length(),
+        Some(body.len() as u64),
+        "a new lookup after body completion must report the correct length"
+    );
+
+    // The original mid-stream Found must remain locked at None.
+    assert!(
+        mid_stream.known_length().is_none(),
+        "length must remain None on the original Found even after body completes"
+    );
 }
 
 fn test_inconsistent_body_length() {


### PR DESCRIPTION
Fixes #492.

Problem:
A found could acquire a known length after the fact. This does not match Compute, where 'poll_known_length' either gets a length on the first try or never gets one. Length should be locked in at lookup time.

Fix:
Snapshot the length when Found is constructed and have Found::length() return that snapshot. After this change, a Found whose lookup occurs midstream should report none forever, matching the behavior of Compute.

Added a test titled test_length_locked_up_at_lookup to the cache test fixtures. This test
1. Inserts without a known length and starts streaming
2. Looks up while the body is still streaming and asserts known_length() is None
3. Finishes the stream
4. Asserts that a fresh lookup can now see the final length
This test you should have failed prior to this fix.

