### PR TITLE
Add 'release-lto-stripped' profile

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,23 +5,25 @@ on:
     tags:
       - "v*.*.*"
 
+  workflow_dispatch:
+
 jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-24.04, macos-14, windows-2022]
+        runner: [ubuntu24.04-8cpu-32ram, macos-14, windows-2022]
         arch: [amd64, arm64]
         exclude:
-          - os: windows-2022
+          - runner: windows-2022
             arch: arm64
         include:
-          - os: ubuntu-24.04
+          - runner: ubuntu24.04-8cpu-32ram
             name: linux
             rust_abi: unknown-linux-gnu
-          - os: macos-14
+          - runner: macos-14
             name: darwin
             rust_abi: apple-darwin
-          - os: windows-2022
+          - runner: windows-2022
             name: windows
             rust_abi: pc-windows-msvc
             extension: .exe
@@ -30,7 +32,7 @@ jobs:
           - arch: amd64
             rust_arch: x86_64
 
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.runner }}
     outputs:
       draft_release_id: ${{ steps.release.outputs.id }}
     steps:
@@ -57,17 +59,7 @@ jobs:
 
       - name: Build
         run: |
-          cargo build --release --workspace --locked --target=${{ matrix.rust_arch }}-${{ matrix.rust_abi }}
-
-      - name: Strip symbols (linux)
-        if: ${{ matrix.name == 'linux' }}
-        run: |
-          ${{ matrix.rust_arch }}-linux-gnu-strip target/${{ matrix.rust_arch }}-${{ matrix.rust_abi }}/release/viceroy${{ matrix.extension }}
-
-      - name: Strip symbols (non-linux)
-        if: ${{ matrix.name != 'linux' }}
-        run: |
-          strip target/${{ matrix.rust_arch }}-${{ matrix.rust_abi }}/release/viceroy${{ matrix.extension }}
+          cargo build --profile=release-lto-stripped --workspace --locked --target=${{ matrix.rust_arch }}-${{ matrix.rust_abi }}
 
       - name: Package
         run: |
@@ -75,6 +67,7 @@ jobs:
           tar czf viceroy_${{ steps.tagName.outputs.tag }}_${{ matrix.name }}-${{ matrix.arch }}.tar.gz viceroy${{ matrix.extension }}
 
       - name: Release
+        if: github.event_name == 'push'
         id: release
         uses: softprops/action-gh-release@v1
         with:
@@ -83,8 +76,10 @@ jobs:
             target/${{ matrix.rust_arch }}-${{ matrix.rust_abi }}/release/viceroy_${{ steps.tagName.outputs.tag }}_${{ matrix.name }}-${{ matrix.arch }}.tar.gz
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   publish:
     needs: build
+    if: github.event_name == 'push'
     runs-on: ubuntu-24.04
     steps:
       - name: publish
@@ -99,8 +94,10 @@ jobs:
             })
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   publish-lib:
     needs: build
+    if: github.event_name == 'push'
     permissions:
       id-token: write
       contents: read
@@ -108,8 +105,10 @@ jobs:
     with:
       crate_name: viceroy-lib
       expected_version: ${{ github.ref_name }}
+
   publish-bin:
     needs: publish-lib
+    if: github.event_name == 'push'
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,6 +63,29 @@ jobs:
       run: make trap-test-ci
       shell: bash
 
+  # Run the LTO test in an isolated job. It uses a large amount of RAM
+  # and the differences between it and the regular build are not
+  # platform-dependent.
+  lto-test:
+    runs-on: ubuntu24.04-8cpu-32ram
+    env:
+      SCCACHE_GHA_ENABLED: "true"
+      RUSTC_WRAPPER: "sccache"
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+    - name: Cache cargo
+      uses: actions/cache@v3
+      with:
+        path: |
+          ~/.cargo/registry
+        key: cargo-lto-test-v${{ env.CACHE_GENERATION }}-${{ hashFiles('**/Cargo.lock') }}
+    - name: Run sccache-cache
+      uses: mozilla-actions/sccache-action@v0.0.9
+    - name: lto-test
+      run: make test-crates-lto
+      shell: bash
+
   package-check:
     runs-on: ubuntu-24.04
     steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,6 +103,23 @@ default-members = [ "cli" ]
 # toward making the test suite not take forever
 opt-level = 1
 
+[profile.release-lto-stripped]
+# This profile is only used to produce binaries for actual releases,
+# since the build time is signficantly extended due to the use of
+# 'fat' LTO and a single codegen unit.
+inherits = "release"
+strip = "symbols"
+lto = "fat"
+codegen-units = 1
+
+[profile.test-lto]
+# This profile is only used to test builds for actual releases,
+# since the build time is signficantly extended due to the use of
+# 'fat' LTO and a single codegen unit.
+inherits = "dev"
+lto = "fat"
+codegen-units = 1
+
 [workspace.dependencies]
 anyhow = "1.0.31"
 base64 = "0.21.2"

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,10 @@ test: test-crates trap-test  ## Run all tests.
 test-crates: fix-build
 	RUST_BACKTRACE=1 $(VICEROY_CARGO) test --all
 
+.PHONY: test-crates-lto
+test-crates-lto: fix-build
+	RUST_BACKTRACE=1 $(VICEROY_CARGO) test --all --profile=test-lto
+
 .PHONY: fix-build
 fix-build:
 	cd test-fixtures && $(VICEROY_CARGO) build --target=wasm32-wasip1


### PR DESCRIPTION
This profile is used by the 'release' workflow, and provides two benefits:

1. There is no need to 'strip' symbols in the workflow, because the symbols will be stripped during the build.

2. 'fat' LTO mode is used to reduce the size of the binary and improve inlining and other optimization opportunities. With Rust 1.95.0 on x86_64 this reduces the size of the final binary from 41MB to 35MB.

Also adds a 'test-crates-lto' target to the Makefile to run the test suite against an LTO-optimized build, and extends the 'test' workflow to execute it along with the other test jobs.