### PR TITLE
Make sure we enable TLS for wss in addition to https

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - Add support for sending `PendingRequestHandle` downstream ([#631](https://github.com/fastly/Viceroy/pull/631))
+- Fix to correctly apply TLS when using `wss:` URL schema with WebSockets passthrough ([#636](https://github.com/fastly/Viceroy/pull/636))
 
 ## 0.18.0 (2026-05-21)
 

--- a/src/execute.rs
+++ b/src/execute.rs
@@ -590,19 +590,24 @@ impl ExecuteCtx {
                     };
 
                     let backend_uri = backend.uri.clone();
-                    let tls_handoff_config = if backend_uri.scheme_str() == Some("https") {
-                        Some(HandoffTlsConfig {
-                            ca_certs: backend.ca_certs.clone(),
-                            client_cert: backend.client_cert.clone(),
-                            use_sni: backend.use_sni,
-                            cert_host: backend.cert_host.clone(),
-                            dns_name_fallback: backend.uri.host().unwrap_or_default().to_string(),
-                            is_grpc: backend.grpc,
-                            base_tls_config: tls_config.clone(), // Pass the builder from self
-                        })
-                    } else {
-                        None
-                    };
+                    let tls_handoff_config =
+                        if matches!(backend_uri.scheme_str(), Some("https" | "wss")) {
+                            Some(HandoffTlsConfig {
+                                ca_certs: backend.ca_certs.clone(),
+                                client_cert: backend.client_cert.clone(),
+                                use_sni: backend.use_sni,
+                                cert_host: backend.cert_host.clone(),
+                                dns_name_fallback: backend
+                                    .uri
+                                    .host()
+                                    .unwrap_or_default()
+                                    .to_string(),
+                                is_grpc: backend.grpc,
+                                base_tls_config: tls_config.clone(), // Pass the builder from self
+                            })
+                        } else {
+                            None
+                        };
 
                     let backend_host = backend_uri
                         .authority()


### PR DESCRIPTION
This is a quick follow-up for #621 

This PR corrects a bug to handling during WebSocket passthrough so that backends defined with the `wss://` schema are treated with TLS.

We already have code that handles https, this fix adds wss to the check.

### Background

When using Viceroy for WebSocket passthrough, it's reasonable to accept backends with the `ws://` or `wss://` schemas, so that one may write:

```toml
[local_server.backends.backend]
url = "wss://echo.websocket.org/"
override_host = "echo.websocket.org"
```

instead of:
```toml
[local_server.backends.backend]
url = "https://echo.websocket.org/"
override_host = "echo.websocket.org"
```

There is already code that adds a default port number `:443` to `wss` URLs to backends when used with WebSocket passthrough.