### PR TITLE
Fix bugs in release workflow and rename it

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Main
+name: Release
 
 on:
   push:
@@ -63,7 +63,7 @@ jobs:
 
       - name: Package
         run: |
-          cd target/${{ matrix.rust_arch }}-${{ matrix.rust_abi }}/release
+          cd target/${{ matrix.rust_arch }}-${{ matrix.rust_abi }}/release-lto-stripped
           tar czf viceroy_${{ steps.tagName.outputs.tag }}_${{ matrix.name }}-${{ matrix.arch }}.tar.gz viceroy${{ matrix.extension }}
 
       - name: Release
@@ -73,7 +73,7 @@ jobs:
         with:
           draft: true
           files: |
-            target/${{ matrix.rust_arch }}-${{ matrix.rust_abi }}/release/viceroy_${{ steps.tagName.outputs.tag }}_${{ matrix.name }}-${{ matrix.arch }}.tar.gz
+            target/${{ matrix.rust_arch }}-${{ matrix.rust_abi }}/release-lto-stripped/viceroy_${{ steps.tagName.outputs.tag }}_${{ matrix.name }}-${{ matrix.arch }}.tar.gz
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
Renamed from 'Main' to 'Release', and corrected the path to the directory containing the built binaries (directory name has changed since the release-lto-stripped profile is used to build)