### PR TITLE
Add Stellate customizations to Viceroy 0.18.0

### DIFF
--- a/cli/tests/integration/common/backends.rs
+++ b/cli/tests/integration/common/backends.rs
@@ -77,6 +77,7 @@ impl TestBackends {
                 client_cert: None,
                 ca_certs: vec![],
                 health: viceroy_lib::config::BackendHealth::Unknown,
+                handler: None,
             };
             backends.insert(name.to_string(), Arc::new(backend_config));
         }

--- a/src/cache/store.rs
+++ b/src/cache/store.rs
@@ -131,16 +131,32 @@ impl CacheKeyObjects {
     pub fn get(&self, request_headers: &HeaderMap) -> Option<Arc<CacheData>> {
         let key_objects = self.0.borrow();
 
+        tracing::debug!(
+            "CacheKeyObjects::get() - vary_rules.len(): {}, objects.len(): {}",
+            key_objects.vary_rules.len(),
+            key_objects.objects.len()
+        );
+
         for vary_rule in key_objects.vary_rules.iter() {
             let response_key = vary_rule.variant(request_headers);
-            if let Some(object) = key_objects
-                .objects
-                .get(&response_key)
-                .and_then(|v| v.present.clone())
-            {
-                return Some(object);
+            tracing::debug!(
+                "  Checking vary_rule, variant signature len: {}",
+                response_key.signature.len()
+            );
+            if let Some(cache_value) = key_objects.objects.get(&response_key) {
+                tracing::debug!(
+                    "    Found cache_value, present: {}, obligated: {}",
+                    cache_value.present.is_some(),
+                    cache_value.obligated
+                );
+                if let Some(data) = cache_value.present.clone() {
+                    return Some(data);
+                }
+            } else {
+                tracing::debug!("    No cache_value for this variant");
             }
         }
+        tracing::debug!("  No matching entry found");
         None
     }
 
@@ -342,10 +358,17 @@ impl CacheKeyObjects {
         body: Body,
         clear_obligation: Option<Variant>,
     ) -> Arc<CacheData> {
-        let meta = ObjectMeta::new(options, request_headers);
+        let meta = ObjectMeta::new(options, request_headers.clone());
         let vary_rule = meta.vary_rule().clone();
 
         let variant = meta.variant();
+
+        tracing::debug!(
+            "CacheKeyObjects::insert() - variant signature len: {}, vary_rule headers: {:?}",
+            variant.signature.len(),
+            request_headers.keys().map(|k| k.as_str()).collect::<Vec<_>>()
+        );
+
         let body = CollectingBody::new(body, meta.length);
         let object = Arc::new(CacheData { body, meta });
 
@@ -353,6 +376,11 @@ impl CacheKeyObjects {
         let result = Arc::clone(&object);
 
         self.0.send_modify(|cache_key_objects| {
+            tracing::debug!(
+                "  Before insert: vary_rules.len(): {}, objects.len(): {}",
+                cache_key_objects.vary_rules.len(),
+                cache_key_objects.objects.len()
+            );
             if let Some(clear_obligation) = clear_obligation
                 && let Some(v) = cache_key_objects.objects.get_mut(&clear_obligation)
             {
@@ -380,6 +408,12 @@ impl CacheKeyObjects {
                 .entry(variant)
                 .or_default()
                 .present = Some(object);
+
+            tracing::debug!(
+                "  After insert: vary_rules.len(): {}, objects.len(): {}",
+                cache_key_objects.vary_rules.len(),
+                cache_key_objects.objects.len()
+            );
         });
 
         result

--- a/src/component/backend.rs
+++ b/src/component/backend.rs
@@ -145,6 +145,7 @@ pub(crate) async fn register_dynamic_backend(
         client_cert,
         ca_certs,
         health: crate::config::BackendHealth::Unknown,
+        handler: None,
     };
 
     if !sandbox.add_backend(name, new_backend) {

--- a/src/component/shielding.rs
+++ b/src/component/shielding.rs
@@ -29,6 +29,7 @@ pub(crate) fn backend_for_shield(
         client_cert: None,
         ca_certs: Vec::new(),
         health: crate::config::BackendHealth::Unknown,
+        handler: None,
     };
 
     if !sandbox.add_backend(&new_name, new_backend) {

--- a/src/config.rs
+++ b/src/config.rs
@@ -28,7 +28,7 @@ mod limits;
 /// Types and deserializers for dictionaries configuration settings.
 mod dictionaries;
 
-pub use self::dictionaries::{Dictionary, LoadedDictionary};
+pub use self::dictionaries::{Dictionary, DictionaryName, LoadedDictionary};
 
 pub type Dictionaries = HashMap<String, Dictionary>;
 
@@ -39,7 +39,10 @@ pub use crate::acl::Acls;
 /// Types and deserializers for backend configuration settings.
 mod backends;
 
-pub use self::backends::{Backend, BackendHealth, ClientCertError, ClientCertInfo};
+pub use self::backends::{
+    Backend, BackendHealth, ClientCertError, ClientCertInfo,
+    DynamicBackendRegistrationInterceptor, Handler, InMemoryBackendHandler,
+};
 
 pub type Backends = HashMap<String, Arc<Backend>>;
 
@@ -56,7 +59,7 @@ pub use self::geolocation::Geolocation;
 /// Types and deserializers for object store configuration settings.
 mod object_store;
 
-pub use crate::object_store::ObjectStores;
+pub use crate::object_store::{ObjectKey, ObjectStoreKey, ObjectStores};
 
 /// Types and deserializers for secret store configuration settings.
 mod secret_store;

--- a/src/config/backends.rs
+++ b/src/config/backends.rs
@@ -30,6 +30,8 @@ pub struct Backend {
     pub client_cert: Option<ClientCertInfo>,
     pub ca_certs: Vec<rustls::Certificate>,
     pub health: BackendHealth,
+    /// Optional in-memory handler for mocking backend responses.
+    pub handler: Option<Handler>,
 }
 
 /// A map of [`Backend`] definitions, keyed by their name.
@@ -192,6 +194,7 @@ mod deserialization {
                 grpc,
                 ca_certs,
                 health,
+                handler: None,
             })
         }
     }

--- a/src/config/backends.rs
+++ b/src/config/backends.rs
@@ -248,3 +248,45 @@ mod deserialization {
         }
     }
 }
+
+// Stellate-specific types for backend handling
+
+use crate::body::Body;
+use hyper::{Request, Response};
+
+/// A wrapper for an in-memory backend handler.
+#[derive(Clone)]
+pub struct Handler {
+    handler: Arc<Box<dyn InMemoryBackendHandler>>,
+}
+
+impl Handler {
+    pub fn new(handler: Box<dyn InMemoryBackendHandler>) -> Self {
+        Self {
+            handler: Arc::new(handler),
+        }
+    }
+
+    pub async fn handle(&self, req: Request<Body>) -> Response<Body> {
+        self.handler.handle(req).await
+    }
+}
+
+impl std::fmt::Debug for Handler {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Handler")
+            .field("handler", &"opaque handler function".to_string())
+            .finish()
+    }
+}
+
+/// Trait for handling backend requests in-memory.
+#[async_trait::async_trait]
+pub trait InMemoryBackendHandler: Send + Sync + 'static {
+    async fn handle(&self, req: Request<Body>) -> Response<Body>;
+}
+
+/// Trait for intercepting dynamic backend registration.
+pub trait DynamicBackendRegistrationInterceptor: Send + Sync + 'static {
+    fn register(&self, backend: Backend) -> Backend;
+}

--- a/src/config/dictionaries.rs
+++ b/src/config/dictionaries.rs
@@ -2,11 +2,44 @@ use {
     crate::error::DictionaryConfigError,
     std::{
         collections::HashMap,
+        fmt,
         fs,
         path::{Path, PathBuf},
         sync::Arc,
     },
 };
+
+/// A wrapper type for dictionary names.
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
+pub struct DictionaryName(String);
+
+impl DictionaryName {
+    pub fn new(name: String) -> Self {
+        Self(name)
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for DictionaryName {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl From<String> for DictionaryName {
+    fn from(name: String) -> Self {
+        Self(name)
+    }
+}
+
+impl From<&str> for DictionaryName {
+    fn from(name: &str) -> Self {
+        Self(name.to_owned())
+    }
+}
 
 /// A single Dictionary definition.
 ///

--- a/src/execute.rs
+++ b/src/execute.rs
@@ -493,6 +493,12 @@ impl ExecuteCtx {
         self.dynamic_backend_interceptor.as_ref()
     }
 
+    /// Set the cache for this execution context.
+    pub fn with_cache(mut self, cache: Arc<Cache>) -> Self {
+        self.cache = cache;
+        self
+    }
+
     /// Runs a guest handle to completion and returns any error that might have occurred.
     pub async fn run_to_completion(handle: GuestHandle) -> Option<anyhow::Error> {
         match handle.handle.await.expect("guest worker finished") {
@@ -1250,6 +1256,12 @@ impl ExecuteCtxBuilder {
         interceptor: Box<dyn DynamicBackendRegistrationInterceptor>,
     ) -> Self {
         self.inner.dynamic_backend_interceptor = Some(Arc::new(interceptor));
+        self
+    }
+
+    /// Set the cache for this execution context.
+    pub fn with_cache(mut self, cache: Arc<Cache>) -> Self {
+        self.inner.cache = cache;
         self
     }
 }

--- a/src/execute.rs
+++ b/src/execute.rs
@@ -1222,6 +1222,29 @@ impl ExecuteCtxBuilder {
         self.inner.local_pushpin_proxy_port = local_pushpin_proxy_port;
         self
     }
+
+    // Stellate-specific builder methods
+
+    /// Set the endpoints monitor for this execution context.
+    pub fn with_endpoints(mut self, endpoints: EndpointsMonitor) -> Self {
+        self.inner.endpoints_monitor = endpoints;
+        self
+    }
+
+    /// Set the in-memory cache for this execution context.
+    pub fn with_in_memory_cache(mut self, cache: InMemoryCache) -> Self {
+        self.inner.in_memory_cache = cache;
+        self
+    }
+
+    /// Set the dynamic backend interceptor for this execution context.
+    pub fn with_dynamic_backend_interceptor(
+        mut self,
+        interceptor: Box<dyn DynamicBackendRegistrationInterceptor>,
+    ) -> Self {
+        self.inner.dynamic_backend_interceptor = Some(Arc::new(interceptor));
+        self
+    }
 }
 
 fn write_profile_to_file(profile: Box<GuestProfiler>, path: &PathBuf) {

--- a/src/execute.rs
+++ b/src/execute.rs
@@ -486,6 +486,13 @@ impl ExecuteCtx {
         &self.in_memory_cache
     }
 
+    /// Get the dynamic backend interceptor, if one is set.
+    pub fn dynamic_backend_interceptor(
+        &self,
+    ) -> Option<&Arc<Box<dyn DynamicBackendRegistrationInterceptor>>> {
+        self.dynamic_backend_interceptor.as_ref()
+    }
+
     /// Runs a guest handle to completion and returns any error that might have occurred.
     pub async fn run_to_completion(handle: GuestHandle) -> Option<anyhow::Error> {
         match handle.handle.await.expect("guest worker finished") {

--- a/src/execute.rs
+++ b/src/execute.rs
@@ -10,12 +10,13 @@ use {
         cache::Cache,
         component as compute,
         config::{
-            Backends, DeviceDetection, Dictionaries, ExperimentalModule, FakeValidFastlyKeys,
-            Geolocation, UnknownImportBehavior,
+            Backends, DeviceDetection, Dictionaries, DynamicBackendRegistrationInterceptor,
+            ExperimentalModule, FakeValidFastlyKeys, Geolocation, UnknownImportBehavior,
         },
         downstream::{DownstreamMetadata, DownstreamRequest, DownstreamResponse, prepare_request},
         error::{ExecutionError, NonHttpResponse},
         handoff::{HandoffConfig, HandoffRequestInfo, HandoffTlsConfig, perform_handoff},
+        in_memory_cache::InMemoryCache,
         linking::{ComponentCtx, WasmCtx, create_store, link_host_functions},
         object_store::ObjectStores,
         sandbox::Sandbox,
@@ -31,20 +32,21 @@ use {
     hyper::{Request, Response},
     pin_project::pin_project,
     std::{
-        collections::HashSet,
+        collections::{BTreeMap, HashSet},
         fmt, fs,
         io::Write,
         net::{Ipv4Addr, SocketAddr},
         path::{Path, PathBuf},
         pin::Pin,
         sync::{
-            Arc, Mutex,
+            Arc, Mutex, RwLock,
             atomic::{AtomicBool, AtomicU64, Ordering},
         },
         thread::{self, JoinHandle},
         time::{Duration, Instant, SystemTime},
     },
     tokio::sync::Mutex as AsyncMutex,
+    tokio::sync::mpsc::{self, Receiver, Sender as MpscSender},
     tokio::sync::oneshot::{self, Sender},
     tracing::{Instrument, Level, error, event, info, info_span, warn},
     wasmtime::{
@@ -76,6 +78,51 @@ impl Instance {
             Instance::Component(_, _) => panic!("unwrap_module called on a component"),
         }
     }
+}
+
+// Stellate-specific types for programmatic access
+
+/// A monitor for logging endpoints. Messages written to the contained endpoints will instead be
+/// directed at the wrapped channel, allowing programmatic access to the logs on the receiver side.
+#[derive(Clone, Default)]
+pub struct EndpointsMonitor {
+    pub endpoints: Arc<RwLock<BTreeMap<Vec<u8>, MpscSender<Vec<u8>>>>>,
+}
+
+impl EndpointsMonitor {
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    /// Registers a listener for the given endpoint name.
+    /// Any messages the invocation sends to this endpoint will be captured by this listener.
+    pub fn register_listener<T: Into<Vec<u8>>>(&self, name: T) -> EndpointListener {
+        let (sender, receiver) = mpsc::channel(100);
+        self.endpoints.write().unwrap().insert(name.into(), sender);
+        EndpointListener { receiver }
+    }
+}
+
+/// Listener for endpoint messages.
+pub struct EndpointListener {
+    receiver: Receiver<Vec<u8>>,
+}
+
+impl EndpointListener {
+    /// Drains and returns all (raw) messages from this listener.
+    /// Will _not_ block and wait for messages.
+    pub fn messages(&mut self) -> Vec<Vec<u8>> {
+        let mut messages = Vec::new();
+        while let Ok(msg) = self.receiver.try_recv() {
+            messages.push(msg);
+        }
+        messages
+    }
+}
+
+/// Handle to a running guest task.
+pub struct GuestHandle {
+    pub(crate) handle: tokio::task::JoinHandle<Result<(), ExecutionError>>,
 }
 
 #[derive(Clone)]
@@ -166,6 +213,13 @@ pub struct ExecuteCtx {
     epoch_increment_stop: Arc<AtomicBool>,
     /// Configuration for guest profiling if enabled
     guest_profile_config: Option<Arc<GuestProfileConfig>>,
+    // Stellate-specific fields
+    /// Endpoints to monitor for messages.
+    endpoints_monitor: EndpointsMonitor,
+    /// In-memory cache for local testing.
+    in_memory_cache: InMemoryCache,
+    /// If set, intercepts dynamic backend registrations.
+    dynamic_backend_interceptor: Option<Arc<Box<dyn DynamicBackendRegistrationInterceptor>>>,
 }
 
 impl ExecuteCtx {
@@ -318,6 +372,10 @@ impl ExecuteCtx {
             guest_profile_config: guest_profile_config.map(Arc::new),
             cache: Arc::new(Cache::default()),
             pending_reuse: Arc::new(AsyncMutex::new(vec![])),
+            // Stellate-specific fields
+            endpoints_monitor: EndpointsMonitor::new(),
+            in_memory_cache: InMemoryCache::new(),
+            dynamic_backend_interceptor: None,
         };
 
         Ok(ExecuteCtxBuilder { inner })
@@ -393,6 +451,55 @@ impl ExecuteCtx {
     /// Gets the TLS configuration
     pub fn tls_config(&self) -> &TlsConfig {
         &self.tls_config
+    }
+
+    // Stellate-specific builder methods
+
+    /// Set the endpoints monitor for this execution context.
+    pub fn with_endpoints(mut self, endpoints: EndpointsMonitor) -> Self {
+        self.endpoints_monitor = endpoints;
+        self
+    }
+
+    /// Set the in-memory cache for this execution context.
+    pub fn with_in_memory_cache(mut self, cache: InMemoryCache) -> Self {
+        self.in_memory_cache = cache;
+        self
+    }
+
+    /// Set the dynamic backend interceptor for this execution context.
+    pub fn with_dynamic_backend_interceptor(
+        mut self,
+        interceptor: Box<dyn DynamicBackendRegistrationInterceptor>,
+    ) -> Self {
+        self.dynamic_backend_interceptor = Some(Arc::new(interceptor));
+        self
+    }
+
+    /// Get the endpoints monitor for this execution context.
+    pub fn endpoints_monitor(&self) -> &EndpointsMonitor {
+        &self.endpoints_monitor
+    }
+
+    /// Get the in-memory cache for this execution context.
+    pub fn in_memory_cache(&self) -> &InMemoryCache {
+        &self.in_memory_cache
+    }
+
+    /// Runs a guest handle to completion and returns any error that might have occurred.
+    pub async fn run_to_completion(handle: GuestHandle) -> Option<anyhow::Error> {
+        match handle.handle.await.expect("guest worker finished") {
+            Ok(_) => None,
+            Err(ExecutionError::WasmTrap(e)) => {
+                event!(
+                    Level::ERROR,
+                    "There was an error running the guest to completion {}",
+                    e.to_string()
+                );
+                Some(e)
+            }
+            Err(e) => panic!("failed to run guest: {}", e),
+        }
     }
 
     async fn maybe_receive_response(

--- a/src/in_memory_cache.rs
+++ b/src/in_memory_cache.rs
@@ -1,0 +1,175 @@
+use crate::wiggle_abi::types;
+use crate::Error;
+use http::{request::Parts, HeaderMap};
+use std::{
+    collections::{btree_map::Entry, BTreeMap, HashMap, HashSet},
+    fmt::Display,
+    sync::{
+        atomic::{AtomicU32, Ordering},
+        Arc, RwLock,
+    },
+    time::Instant,
+};
+use tracing::{event, Level};
+
+pub fn not_found_handle() -> types::CacheHandle {
+    types::CacheHandle::from(u32::MAX)
+}
+
+type PrimaryCacheKey = Vec<u8>;
+
+#[derive(Clone, Default, Debug)]
+pub struct InMemoryCache {
+    /// Cache entries, indexable by handle ID.
+    pub cache_entries: Arc<RwLock<HashMap<u32, Option<CacheEntry>>>>,
+    /// Next handle ID to assign.
+    next_handle_id: Arc<AtomicU32>,
+    /// Primary cache key to a list of variants.
+    pub key_candidates: Arc<RwLock<BTreeMap<PrimaryCacheKey, Vec<types::CacheHandle>>>>,
+    /// Pending transaction markers.
+    pub pending_tx: Arc<RwLock<HashMap<types::CacheHandle, PrimaryCacheKey>>>,
+}
+
+impl InMemoryCache {
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    pub fn purge(&self, surrogates: Vec<String>) {
+        let mut cache_entries = self.cache_entries.write().unwrap();
+        let surrogates_to_purge: HashSet<String> = surrogates.into_iter().collect();
+        for (_handle_id, handle_entry) in cache_entries.iter_mut() {
+            if let Some(entry) = handle_entry {
+                if entry.surrogate_keys.intersection(&surrogates_to_purge).count() != 0 {
+                    handle_entry.take();
+                }
+            }
+        }
+    }
+
+    pub fn get_entry(&self, key: &PrimaryCacheKey, headers: &HeaderMap) -> Option<types::CacheHandle> {
+        let candidates_lock = self.key_candidates.read().unwrap();
+        candidates_lock.get(key).and_then(|candidates| {
+            let entry_lock = self.cache_entries.write().unwrap();
+            candidates.iter().find_map(|candidate_handle| {
+                let handle_id: u32 = (*candidate_handle).into();
+                entry_lock.get(&handle_id).and_then(|candidate_entry| {
+                    candidate_entry.as_ref().and_then(|entry| {
+                        (entry.vary_matches(headers) && entry.is_usable()).then(|| *candidate_handle)
+                    })
+                })
+            })
+        })
+    }
+
+    /// Insert a cache entry with pre-extracted options.
+    pub fn insert_with_options(
+        &self,
+        key: PrimaryCacheKey,
+        max_age_ns: u64,
+        swr_ns: Option<u64>,
+        initial_age_ns: Option<u64>,
+        surrogate_keys: Vec<String>,
+        user_metadata: Vec<u8>,
+        vary: BTreeMap<String, Option<String>>,
+        request_parts: Option<&Parts>,
+    ) -> Result<types::CacheHandle, Error> {
+        let _ = request_parts; // May be used for vary matching in the future
+
+        let entry = CacheEntry {
+            key: key.clone(),
+            body_bytes: vec![],
+            vary,
+            initial_age_ns,
+            max_age_ns: Some(max_age_ns),
+            swr_ns,
+            created_at: Instant::now(),
+            user_metadata,
+            surrogate_keys: surrogate_keys.into_iter().collect(),
+        };
+
+        let existing_entry_handle = self.get_entry(
+            &key,
+            request_parts.map(|p| &p.headers).unwrap_or(&HeaderMap::new()),
+        );
+
+        let entry_handle = match existing_entry_handle {
+            Some(handle) => {
+                event!(Level::TRACE, "Overwriting cache entry {}", handle);
+                let handle_id: u32 = handle.into();
+                self.cache_entries.write().unwrap().get_mut(&handle_id).map(|old_entry| old_entry.replace(entry));
+                handle
+            }
+            None => {
+                // Write new entry.
+                let new_handle_id = self.next_handle_id.fetch_add(1, Ordering::SeqCst);
+                let new_entry_handle = types::CacheHandle::from(new_handle_id);
+                self.cache_entries.write().unwrap().insert(new_handle_id, Some(entry));
+                event!(Level::TRACE, "Wrote new cache entry {}", new_entry_handle);
+                match self.key_candidates.write().unwrap().entry(key) {
+                    Entry::Vacant(vacant) => { vacant.insert(vec![new_entry_handle]); }
+                    Entry::Occupied(mut occupied) => { occupied.get_mut().push(new_entry_handle); }
+                }
+                new_entry_handle
+            }
+        };
+        Ok(entry_handle)
+    }
+}
+
+#[derive(Debug)]
+pub struct CacheEntry {
+    pub key: PrimaryCacheKey,
+    pub body_bytes: Vec<u8>,
+    pub vary: BTreeMap<String, Option<String>>,
+    pub surrogate_keys: HashSet<String>,
+    pub initial_age_ns: Option<u64>,
+    pub max_age_ns: Option<u64>,
+    pub swr_ns: Option<u64>,
+    pub created_at: Instant,
+    pub user_metadata: Vec<u8>,
+}
+
+impl CacheEntry {
+    pub fn vary_matches(&self, headers: &HeaderMap) -> bool {
+        self.vary.iter().all(|(vary_key, vary_value)| {
+            headers.get(vary_key).and_then(|h| h.to_str().ok()) == vary_value.as_deref()
+        })
+    }
+
+    pub fn age_ns(&self) -> u64 {
+        self.created_at.elapsed().as_nanos().try_into().ok()
+            .and_then(|age_ns: u64| age_ns.checked_add(self.initial_age_ns.unwrap_or(0)))
+            .unwrap_or(u64::MAX)
+    }
+
+    pub fn is_stale(&self) -> bool {
+        let age = self.age_ns();
+        match (self.max_age_ns, self.swr_ns) {
+            (Some(max_age), Some(_)) => age > max_age && age < self.total_ttl_ns(),
+            _ => false,
+        }
+    }
+
+    pub fn is_usable(&self) -> bool {
+        self.age_ns() < self.total_ttl_ns()
+    }
+
+    fn total_ttl_ns(&self) -> u64 {
+        self.max_age_ns.unwrap_or(0) + self.swr_ns.unwrap_or(0)
+    }
+}
+
+impl Display for InMemoryCache {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(f, "Cache State:")?;
+        for (handle_id, entry) in self.cache_entries.read().unwrap().iter() {
+            let handle = types::CacheHandle::from(*handle_id);
+            match entry {
+                Some(e) => writeln!(f, "  [{}]: key={:?}", handle, e.key)?,
+                None => writeln!(f, "  [{}]: Purged", handle)?,
+            }
+        }
+        Ok(())
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,6 +43,7 @@ mod upstream;
 pub mod wiggle_abi;
 
 pub use {
+    cache::Cache,
     error::Error,
     execute::{EndpointListener, EndpointsMonitor, ExecuteCtx, GuestHandle, GuestProfileConfig, WasmFeatures},
     in_memory_cache::InMemoryCache,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,7 @@ mod execute;
 mod framing;
 mod handoff;
 mod headers;
+mod in_memory_cache;
 mod linking;
 mod object_store;
 mod secret_store;
@@ -42,6 +43,14 @@ mod upstream;
 pub mod wiggle_abi;
 
 pub use {
-    error::Error, execute::ExecuteCtx, execute::GuestProfileConfig, execute::WasmFeatures,
-    service::ViceroyService, upstream::BackendConnector, wasmtime::ProfilingStrategy,
+    error::Error,
+    execute::{EndpointListener, EndpointsMonitor, ExecuteCtx, GuestHandle, GuestProfileConfig, WasmFeatures},
+    in_memory_cache::InMemoryCache,
+    service::ViceroyService,
+    upstream::BackendConnector,
+    wasmtime::ProfilingStrategy,
 };
+
+pub use async_trait;
+pub use http;
+pub use hyper;

--- a/src/object_store.rs
+++ b/src/object_store.rs
@@ -183,6 +183,24 @@ impl ObjectStores {
         Ok(())
     }
 
+    /// Simplified insert with default options (Overwrite mode, no TTL, no metadata, no generation).
+    pub fn insert_simple(
+        &self,
+        obj_store_key: ObjectStoreKey,
+        obj_key: ObjectKey,
+        obj: Vec<u8>,
+    ) -> Result<(), KvStoreError> {
+        self.insert(
+            obj_store_key,
+            obj_key,
+            obj,
+            KvInsertMode::Overwrite,
+            None, // generation
+            None, // metadata
+            None, // ttl
+        )
+    }
+
     pub fn delete(
         &self,
         obj_store_key: ObjectStoreKey,

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -65,10 +65,19 @@ struct TeeWriter {
 
 impl Write for TeeWriter {
     fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-        // Write to stdout
+        // Write the full formatted message to stdout
         self.stdout.lock().unwrap().write_all(buf)?;
-        // Send to channel (best effort, ignore send errors)
-        let _ = self.channel.try_send(buf.to_vec());
+
+        // For the channel, strip the "endpoint_name :: " prefix
+        // The format is: "name :: json_content\n"
+        if let Some(pos) = buf.windows(4).position(|w| w == b" :: ") {
+            let json_start = pos + 4;
+            let json_end = buf.len().saturating_sub(1); // remove trailing newline
+            if json_start < json_end {
+                let _ = self.channel.try_send(buf[json_start..json_end].to_vec());
+            }
+        }
+
         Ok(buf.len())
     }
 

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -16,6 +16,7 @@ use std::path::Path;
 use std::sync::atomic::AtomicU64;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
+use tokio::sync::mpsc::Sender as MpscSender;
 
 use crate::cache::{Cache, CacheEntry};
 use crate::linking::Limiter;
@@ -54,6 +55,27 @@ use {
 const NEXT_REQ_ACCEPT_MAX: usize = 5;
 const NEXT_REQ_TIMEOUT: Duration = Duration::from_secs(10);
 const NGWAF_ALLOW_VERDICT: &str = "allow";
+
+/// A writer that writes to both stdout (or another writer) and an async channel.
+/// Used to capture log messages for the EndpointsMonitor.
+struct TeeWriter {
+    stdout: Arc<Mutex<dyn Write + Send>>,
+    channel: MpscSender<Vec<u8>>,
+}
+
+impl Write for TeeWriter {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        // Write to stdout
+        self.stdout.lock().unwrap().write_all(buf)?;
+        // Send to channel (best effort, ignore send errors)
+        let _ = self.channel.try_send(buf.to_vec());
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        self.stdout.lock().unwrap().flush()
+    }
+}
 
 pub struct RequestParts {
     parts: Option<request::Parts>,
@@ -598,7 +620,22 @@ impl Sandbox {
         if let Some(handle) = self.log_endpoints_by_name.get(name).copied() {
             return handle;
         }
-        let endpoint = LogEndpoint::new(name, self.capture_logs.clone());
+
+        // Check if there's a registered endpoint listener in the EndpointsMonitor
+        let writer: Arc<Mutex<dyn Write + Send>> = {
+            let endpoints = self.ctx.endpoints_monitor().endpoints.read().unwrap();
+            if let Some(sender) = endpoints.get(name) {
+                // Create a writer that sends to both stdout and the channel
+                Arc::new(Mutex::new(TeeWriter {
+                    stdout: self.capture_logs.clone(),
+                    channel: sender.clone(),
+                }))
+            } else {
+                self.capture_logs.clone()
+            }
+        };
+
+        let endpoint = LogEndpoint::new(name, writer);
         let handle = self.log_endpoints.push(endpoint);
         self.log_endpoints_by_name.insert(name.to_owned(), handle);
         handle

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -664,6 +664,14 @@ impl Sandbox {
             return false;
         }
 
+        // Call the interceptor if one is set, allowing it to modify the backend
+        // (e.g., to inject a custom handler for testing)
+        let info = if let Some(interceptor) = self.ctx.dynamic_backend_interceptor() {
+            interceptor.register(info)
+        } else {
+            info
+        };
+
         self.dynamic_backends
             .insert(name.to_string(), Arc::new(info));
 

--- a/src/upstream.rs
+++ b/src/upstream.rs
@@ -8,7 +8,7 @@ use crate::{
     sandbox::{AsyncItem, AsyncItemHandle, ViceroyRequestMetadata},
     wiggle_abi::types::{ContentEncodings, FramingHeadersMode},
 };
-use futures::Future;
+use futures::{Future, future::Either};
 use http::{HeaderValue, Version, uri};
 use hyper::{Client, HeaderMap, Request, Response, Uri, client::HttpConnector, header};
 use rustls::client::ServerName;
@@ -325,6 +325,12 @@ pub fn send_request(
     backend_name: &str,
     tls_config: &TlsConfig,
 ) -> impl Future<Output = Result<Response<Body>, Error>> + use<> {
+    // If the backend has a handler, use it instead of making a real HTTP request
+    if let Some(handler) = &backend.handler {
+        let handler = handler.clone();
+        return Either::Left(async move { Ok(handler.handle(req).await) });
+    }
+
     let connector = BackendConnector::new(backend.clone(), tls_config.clone());
 
     let host = canonical_host_header(req.headers(), req.uri(), backend);
@@ -379,7 +385,7 @@ pub fn send_request(
     let h2only = backend.grpc;
     let backend_name = backend_name.to_string();
     let backend_uri = backend.uri.to_string();
-    async move {
+    Either::Right(async move {
         let mut builder = Client::builder();
 
         if req.version() == Version::HTTP_2 {
@@ -433,7 +439,7 @@ pub fn send_request(
         } else {
             Ok(basic_response.map(Body::from))
         }
-    }
+    })
 }
 
 /// The type ultimately yielded by a `PendingRequest`.

--- a/src/wiggle_abi/req_impl.rs
+++ b/src/wiggle_abi/req_impl.rs
@@ -586,6 +586,7 @@ impl FastlyHttpReq for Sandbox {
             client_cert,
             ca_certs,
             health: crate::config::BackendHealth::Unknown,
+            handler: None,
         };
 
         if !self.add_backend(&name, new_backend) {

--- a/src/wiggle_abi/shielding.rs
+++ b/src/wiggle_abi/shielding.rs
@@ -96,6 +96,7 @@ impl fastly_shielding::FastlyShielding for Sandbox {
             client_cert: None,
             ca_certs: Vec::new(),
             health: crate::config::BackendHealth::Unknown,
+            handler: None,
         };
 
         if !self.add_backend(&new_name, new_backend) {


### PR DESCRIPTION
- InMemoryCache for local cache testing
- EndpointsMonitor/EndpointListener for log capture
- GuestHandle for execution control
- Handler/InMemoryBackendHandler for backend mocking
- DynamicBackendRegistrationInterceptor
- DictionaryName wrapper
- ExecuteCtx builder methods (with_endpoints, with_in_memory_cache, with_dynamic_backend_interceptor)