### PR TITLE
Implement the blocking KV store WIT functions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Always use an `unsafe` block to `unsafe_main_ptr`. ([#643](https://github.com/fastly/Viceroy/pull/643))
 - Add support for healthchecking dynamic backends ([#635](https://github.com/fastly/Viceroy/pull/635))
 - Add support for headers-based bot detection mocking, as well as headless bots in the API, updated to v0.13.0 of Fastly crate ([#658](https://github.com/fastly/Viceroy/pull/658))
+- Implement the blocking KV store WIT functions. ([#657](https://github.com/fastly/Viceroy/pull/657))
 
 ## 0.19.0 (2026-06-16)
 

--- a/src/component/compute/kv_store.rs
+++ b/src/component/compute/kv_store.rs
@@ -176,13 +176,36 @@ impl kv_store::HostStore for ComponentCtx {
 
     async fn lookup(
         &mut self,
-        _store: Resource<kv_store::Store>,
-        _key: String,
+        store: Resource<kv_store::Store>,
+        key: String,
     ) -> Result<Option<Resource<kv_store::Entry>>, kv_store::KvError> {
-        Err(Error::Unsupported {
-            msg: "kv-store.lookup is not supported in Viceroy",
+        let store = self.sandbox.get_kv_store_key(store.into()).unwrap();
+        let resp = self.sandbox.obj_lookup(
+            store.clone(),
+            ObjectKey::new(key).map_err(|_| kv_store::KvError::BadRequest)?,
+        );
+
+        match resp {
+            Ok(Some(value)) => {
+                let lr = kv_store::Entry {
+                    body: Some(self.sandbox_mut().insert_body(value.body.into()).into()),
+                    metadata: match value.metadata_len {
+                        0 => None,
+                        _ => Some(value.metadata),
+                    },
+                    generation: value.generation,
+                };
+
+                let res = self
+                    .table()
+                    .push(lr)
+                    .map_err(|_| kv_store::KvError::GenericError)?;
+
+                Ok(Some(res))
+            }
+            Ok(None) => Ok(None),
+            Err(e) => Err(e.into()),
         }
-        .into())
     }
 
     async fn lookup_async(
@@ -202,15 +225,42 @@ impl kv_store::HostStore for ComponentCtx {
 
     async fn insert(
         &mut self,
-        _store: Resource<kv_store::Store>,
-        _key: String,
-        _body_handle: Resource<kv_store::Body>,
-        _options: kv_store::InsertOptions,
+        store: Resource<kv_store::Store>,
+        key: String,
+        body_handle: Resource<kv_store::Body>,
+        options: kv_store::InsertOptions,
     ) -> Result<(), kv_store::KvError> {
-        Err(Error::Unsupported {
-            msg: "kv-store.insert is not supported in Viceroy",
-        }
-        .into())
+        let body = self
+            .sandbox_mut()
+            .take_body(body_handle.into())
+            .map_err(|_| kv_store::KvError::GenericError)?
+            .read_into_vec()
+            .await?;
+        let store = self.sandbox.get_kv_store_key(store.into()).unwrap();
+
+        let mode = match options.mode {
+            InsertMode::Overwrite => KvInsertMode::Overwrite,
+            InsertMode::Add => KvInsertMode::Add,
+            InsertMode::Append => KvInsertMode::Append,
+            InsertMode::Prepend => KvInsertMode::Prepend,
+        };
+
+        let meta = options.metadata;
+        let igm = options.if_generation_match;
+
+        let ttl = options
+            .time_to_live_sec
+            .map(|time_to_live_sec| std::time::Duration::from_secs(time_to_live_sec as u64));
+
+        Ok(self.sandbox.kv_insert(
+            store.clone(),
+            ObjectKey::new(key).map_err(|_| kv_store::KvError::BadRequest)?,
+            body,
+            Some(mode),
+            igm,
+            meta,
+            ttl,
+        )?)
     }
 
     async fn insert_async(
@@ -259,13 +309,14 @@ impl kv_store::HostStore for ComponentCtx {
 
     async fn delete(
         &mut self,
-        _store: Resource<kv_store::Store>,
-        _key: String,
+        store: Resource<kv_store::Store>,
+        key: String,
     ) -> Result<bool, kv_store::KvError> {
-        Err(Error::Unsupported {
-            msg: "kv-store.delete is not supported in Viceroy",
-        }
-        .into())
+        let store = self.sandbox.get_kv_store_key(store.into()).unwrap();
+        Ok(self.sandbox.kv_delete(
+            store.clone(),
+            ObjectKey::new(key).map_err(|_| kv_store::KvError::BadRequest)?,
+        )?)
     }
 
     async fn delete_async(
@@ -285,13 +336,18 @@ impl kv_store::HostStore for ComponentCtx {
 
     async fn list(
         &mut self,
-        _store: Resource<kv_store::Store>,
-        _options: kv_store::ListOptions,
+        store: Resource<kv_store::Store>,
+        options: kv_store::ListOptions,
     ) -> Result<Resource<kv_store::PendingList>, kv_store::KvError> {
-        Err(Error::Unsupported {
-            msg: "kv-store.list is not supported in Viceroy",
-        }
-        .into())
+        let store = self.sandbox.get_kv_store_key(store.into()).unwrap();
+
+        let cursor = options.cursor;
+        let prefix = options.prefix;
+        let limit = options.limit;
+
+        let value = self.sandbox.kv_list(store.clone(), cursor, prefix, limit)?;
+
+        Ok(self.sandbox_mut().insert_body(value.into()).into())
     }
 
     async fn list_async(


### PR DESCRIPTION
Implement the KV store `list`/`lookup`/`insert`/`delete` functions, which are like their `*_async` coutnerparts, except that they wait for the result.