### PR TITLE
Make the OCI package version patch the WIT package version.

### DIFF
--- a/.github/workflows/publish-wit.yml
+++ b/.github/workflows/publish-wit.yml
@@ -50,7 +50,7 @@ jobs:
           description: 'The APIs of the Fastly Compute platform'
           source: 'https://github.com/fastly/Viceroy'
           homepage: 'https://www.fastly.com/documentation/guides/compute/'
-          version: '0.0.0'
+          version: '0.1.0'
           licenses: 'Apache-2.0 WITH LLVM-exception'
 
       - name: Attest build provenance


### PR DESCRIPTION
fastly:compute is currently at version 0.1.0.