### PR TITLE
Update to the latest bytecodealliance/wkg-github-action.

### DIFF
--- a/.github/workflows/publish-wit.yml
+++ b/.github/workflows/publish-wit.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Publish to GitHub Container Registry
         id: publish
-        uses: bytecodealliance/wkg-github-action@10b3b04b9059ba46208cd7daf7d352af14bded0f # v5
+        uses: bytecodealliance/wkg-github-action@5b7005d1fc81c8c3380a059e58345033e3a97638 # `main`, at the time of this comment, because we need bytecodealliance/wkg-github-action#9
         with:
           oci-reference-without-tag: 'ghcr.io/fastly/Viceroy/fastly-compute'
           file: 'fastly-compute.wasm'


### PR DESCRIPTION
Viceroy was recently configured to reject actions that aren't pinned to a specific SHA hash, which appears to apply to transitive dependencies as well. The latest version of bytecodealliance/wkg-github-action transitively depends on actions/upload-artifact@v4, which caused it to be rejected by this configuration. Fortunately, this dependency was recently removed, so this PR updates to the newer version to pick up this change.