### PR TITLE
Publish the WIT for `fastly:compute`, rather than `fastly:viceroy`.

### DIFF
--- a/.github/workflows/publish-wit.yml
+++ b/.github/workflows/publish-wit.yml
@@ -15,6 +15,7 @@ jobs:
 
     env:
       WKG_VERSION: 0.15.0
+      WASM_TOOLS_VERSION: 1.255.0
 
     steps:
       - name: Checkout repository
@@ -29,6 +30,10 @@ jobs:
         shell: bash
         run: cargo binstall -y "wkg@${{ env.WKG_VERSION }}"
 
+      - name: Install wasm-tools
+        shell: bash
+        run: cargo binstall -y "wasm-tools@${{ env.WASM_TOOLS_VERSION }}"
+
       - name: Login to GitHub Container Registry
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
@@ -39,7 +44,17 @@ jobs:
       - name: Build WIT package
         shell: bash
         run: |
-          wkg wit build -o "$GITHUB_WORKSPACE/fastly-compute.wasm" --wit-dir wasm_abi/wit
+          # We want to publish compute.wit, not adapter.wit or viceroy.wit, so
+          # copy the WIT dir, delete those, and put compute.wit at the top level.
+          cp -r wasm_abi/wit "$GITHUB_WORKSPACE/fastly-compute-wit"
+          rm -r "$GITHUB_WORKSPACE/fastly-compute-wit/deps/fastly-adapter"
+          rm "$GITHUB_WORKSPACE/fastly-compute-wit/viceroy.wit"
+          mv "$GITHUB_WORKSPACE/fastly-compute-wit/deps/fastly/compute.wit" "$GITHUB_WORKSPACE/fastly-compute-wit"
+          rmdir "$GITHUB_WORKSPACE/fastly-compute-wit/deps/fastly"
+
+          # Use wasm-tools component wit instead of wkg wit build because the
+          # former understands deps directories.
+          wasm-tools component wit "$GITHUB_WORKSPACE/fastly-compute-wit" --wasm -o "$GITHUB_WORKSPACE/fastly-compute.wasm"
 
       - name: Publish to GitHub Container Registry
         id: publish


### PR DESCRIPTION
Modify the WIT publishing script to publish the `fastly:compute` package in compute.wit, rather than the `fastly:viceroy` package in viceroy.wit.

In support of this, switch from `wkg wit build` to `wasm-tools component wit`, which supports the deps directory.