### PR TITLE
Implement `backend.get-host` on the component ABI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 - Enable support for the wide-arithmetic feature. ([#679](https://github.com/fastly/Viceroy/pull/679))
 
+- Implement `backend.get-host` on the component ABI, which previously always returned
+  `error.unsupported` even though the witx ABI implemented it, and report the required buffer
+  length from the component `get-host`/`get-override-host` accessors. ([#677](https://github.com/fastly/Viceroy/pull/677))
+
 ## 0.20.1 (2026-07-16)
 
 - Fix wiggle abi implementation for bot detection mocking. ([#664](https://github.com/fastly/Viceroy/pull/664))

--- a/cli/tests/integration/backend_introspection.rs
+++ b/cli/tests/integration/backend_introspection.rs
@@ -1,0 +1,41 @@
+use {
+    crate::{
+        common::{Test, TestResult},
+        viceroy_test,
+    },
+    hyper::{Request, Response, StatusCode},
+};
+
+viceroy_test!(backend_accessors_report_configuration, |is_component| {
+    let test = Test::using_fixture("backend-introspection.wasm")
+        .adapt_component(is_component)
+        .backend("origin", "/", Some("otherhost.com"), |_| {
+            Response::new(Vec::new())
+        })
+        .await;
+
+    test.start_backend_servers().await;
+    let backend_uri = test.uri_for_backend_server("origin").await;
+    let authority = backend_uri.authority().expect("backend uri has authority");
+
+    let resp = test
+        .against(Request::get("/").body("").unwrap())
+        .await
+        .expect("response");
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let body = std::str::from_utf8(&hyper::body::to_bytes(resp.into_body()).await?)
+        .expect("body is valid UTF-8")
+        .to_owned();
+
+    assert_eq!(
+        body,
+        format!(
+            "host={}\nport={}\nis_ssl=false\noverride_host=otherhost.com\n",
+            authority.host(),
+            authority.port_u16().expect("backend uri has a port"),
+        )
+    );
+
+    Ok(())
+});

--- a/cli/tests/integration/main.rs
+++ b/cli/tests/integration/main.rs
@@ -1,6 +1,7 @@
 mod acl;
 mod args;
 mod async_io;
+mod backend_introspection;
 mod body;
 mod bot_detection;
 mod cache;

--- a/src/component/backend.rs
+++ b/src/component/backend.rs
@@ -200,14 +200,18 @@ pub(crate) fn is_dynamic(sandbox: &mut Sandbox, backend: &str) -> Result<bool, t
 pub(crate) fn get_host(
     sandbox: &mut Sandbox,
     backend: &str,
-    _max_len: u64,
+    max_len: u64,
 ) -> Result<String, types::Error> {
-    // just doing this to get a different error if the backend doesn't exist
-    let _ = sandbox.backend(backend).ok_or(Error::InvalidArgument)?;
-    Err(Error::Unsupported {
-        msg: "`get-host` is not actually supported in Viceroy",
+    let backend = sandbox.backend(backend).ok_or(Error::InvalidArgument)?;
+    let host = backend.uri.host().ok_or(Error::InvalidArgument)?;
+
+    if host.len() > usize::try_from(max_len).unwrap() {
+        // Report the required length, so that guests (and the adapter's `alloc_result!`) can
+        // retry with a large enough buffer.
+        return Err(types::Error::BufferLen(u64::try_from(host.len()).unwrap()));
     }
-    .into())
+
+    Ok(host.to_owned())
 }
 
 pub(crate) fn get_override_host(
@@ -220,11 +224,7 @@ pub(crate) fn get_override_host(
         let host = host.to_str()?;
 
         if host.len() > usize::try_from(max_len).unwrap() {
-            return Err(Error::BufferLengthError {
-                buf: "host_out",
-                len: "host_max_len",
-            }
-            .into());
+            return Err(types::Error::BufferLen(u64::try_from(host.len()).unwrap()));
         }
 
         Ok(Some(host.as_bytes().to_owned()))

--- a/test-fixtures/src/bin/backend-introspection.rs
+++ b/test-fixtures/src/bin/backend-introspection.rs
@@ -1,0 +1,22 @@
+use fastly::{Backend, Request, Response};
+
+/// Report the host-visible properties of the `origin` backend back to the client, so that the same
+/// accessors can be checked on both the core-wasm and component ABIs.
+fn main() {
+    let _client_req = Request::from_client();
+
+    let backend = Backend::from_name("origin").expect("`origin` backend exists");
+
+    let body = format!(
+        "host={}\nport={}\nis_ssl={}\noverride_host={}\n",
+        backend.get_host(),
+        backend.get_port(),
+        backend.is_ssl(),
+        backend
+            .get_host_override()
+            .map(|host| host.to_str().expect("override host is valid UTF-8").to_owned())
+            .unwrap_or_else(|| "<none>".to_owned()),
+    );
+
+    Response::from_body(body).send_to_client();
+}


### PR DESCRIPTION
### Summary

`fastly:compute/backend.[method]backend.get-host` always returned `error.unsupported` in Viceroy's
component-model implementation, even for a backend declared in `[local_server.backends.*]` whose
host Viceroy already knows and already uses for other accessors:

```rust
pub(crate) fn get_host(
    sandbox: &mut Sandbox,
    backend: &str,
    _max_len: u64,
) -> Result<String, types::Error> {
    // just doing this to get a different error if the backend doesn't exist
    let _ = sandbox.backend(backend).ok_or(Error::InvalidArgument)?;
    Err(Error::Unsupported {
        msg: "`get-host` is not actually supported in Viceroy",
    }
    .into())
}
```

The witx/`wiggle_abi` implementation of the same hostcall returns the host correctly
(`backend.uri.host()` in `src/wiggle_abi/backend_impl.rs`). So a guest on the component ABI saw
behaviour that differed both from real Compute and from a witx-ABI guest running under the same
Viceroy binary.

This reads as something that simply hadn't been implemented yet rather than a deliberate limitation:
the data is plainly available, and the immediate neighbours in the *same* component file already read
it out of the same `Backend` struct -- `get_port` uses `backend.uri.port_u16()`, `is_tls` uses
`backend.uri.scheme()`, and `get_override_host` returns a real value. The other `Unsupported`
stubs in that file (the connect/first-byte/between-bytes timeouts, the TLS version flags) return the same
error on *both* ABIs, so those are genuine "Viceroy doesn't model this" limitations; `get-host` was the odd one out.

### Changes

`get_host` now reads the host from `backend.uri`, mirroring the witx path. It uses the same
`sandbox.backend()` lookup the witx path reaches through `lookup_backend_definition`, so the
`InvalidArgument` behaviour for an unknown backend is unchanged.

A hostless URI returns `InvalidArgument` rather than panicking. The witx path does
`.expect("backend uri has host")`, but nothing validates that a backend URL has a host at
config-parse time (`src/config/backends.rs` just parses the string into a `Uri`), so the panic is
reachable from configuration. `ValueAbsent` -- the semantically closest error -- is not an option
here: it explicitly panics in the component error conversion
(`src/component/compute/error.rs`: `` Error::ValueAbsent => panic!("`ValueAbsent` should not be used in components") ``).

Buffer overflow now returns `types::Error::BufferLen(host.len())`, not `Error::BufferLengthError`.
This part is not cosmetic. `Error::BufferLengthError` maps to `types::Error::BufferLen(0)` in
`src/component/compute/error.rs`, which discards the length. Guests probe for the required size by
calling with `max_len` 0 and reading the length back out of `nwritten` -- the adapter's
`handle_buffer_len!` only writes `nwritten` from the `BufferLen(n)` payload. With `BufferLen(0)`, a
guest allocates a zero-capacity buffer, calls again, gets `BUFLEN` a second time and panics. The
Rust SDK's `Backend::get_host` does exactly this probe, so a `get-host` implemented with
`BufferLengthError` would still have been unusable from it.

`get_override_host` had the identical defect, and is fixed the same way. It is a distinct bug
from `get-host` -- the value was returned correctly, only the overflow path lost the length -- so
it went unnoticed by guests that pass a generously sized buffer instead of probing. Under the Rust
SDK, `Backend::get_host_override` panics with
`fastly_backend::get_override_host returned an unexpected result: FastlyStatus::BUFLEN` before this
change. Happy to split this hunk into its own PR if you'd prefer to keep the change surgical.

### Tests

New `backend-introspection` fixture and integration test, registered through the `viceroy_test!`
macro so it runs under both the core-wasm and component ABIs. It asserts host, port, TLS flag and
override host against the URI the test harness actually bound the backend to.

Before this change the `component` variant fails and `core_wasm` passes -- which is precisely the
parity gap being fixed. After it, both pass, along with the rest of the suite (168 tests). No new
clippy warnings.

### Reproduction

`fastly.toml`:

```toml
[local_server.backends.origin]
url = "http://127.0.0.1:8085/"
override_host = "otherhost.com"
```

The relevant slice of `fastly:compute/backend`:

```wit
resource backend {
  open: static func(name: string) -> result<backend, open-error>;
  get-host: func(max-len: u64) -> result<string, error>;
  get-override-host: func(max-len: u64) -> result<option<list<u8>>, error>;
  get-port: func() -> result<u16, error>;
  is-tls: func() -> result<bool, error>;
}
```

A guest against the generated bindings for that world, annotated with what each call returned
before this change:

```rust
let backend = Backend::open("origin").unwrap();

backend.get_port();      // Ok(8085)
backend.is_tls();        // Ok(false)

backend.get_host(64);    // Err(Error::Unsupported)   <-- the bug
```

Host-side, all three of those read the same `Backend` struct: `get_port` takes
`backend.uri.port_u16()` and `is_tls` takes `backend.uri.scheme()`. Every accessor backed by
`backend.uri` worked except the one that reads its host.

Sizing a buffer is the second half of it. `error.buffer-len(u64)` is defined in the WIT as
"Includes the buffer length that would allow the operation to succeed", so the intended sequence for
a guest that does not know the length up front is a zero-length probe followed by a correctly sized
call:

```rust
let len = match backend.get_host(0) {
    Err(Error::BufferLen(n)) => n,     // n = 9, the length of "127.0.0.1"
    other => panic!("unexpected: {other:?}"),
};
let host = backend.get_host(len).unwrap();   // Ok("127.0.0.1")
```

That is what this PR makes work. Returning `Error::BufferLengthError` instead -- as the obvious
one-line fix would -- maps to `buffer-len(0)`, and the probe becomes unusable:

```rust
backend.get_host(0);      // Err(Error::BufferLen(0))   -- no length reported
backend.get_host(0);      // Err(Error::BufferLen(0))   -- and again, forever
```

`get_override_host` behaved exactly that way before this change, which is why the second hunk is
here:

```rust
backend.get_override_host(0);    // Err(Error::BufferLen(0))
backend.get_override_host(0);    // Err(Error::BufferLen(0)) -- no way to learn it needs 13
backend.get_override_host(64);   // Ok(Some(b"otherhost.com")) -- fine if you guessed big enough
```

The value itself was always correct there, so only guests that probe were affected; guests that pass
a generously sized buffer never noticed. After this change the first probe returns
`Err(Error::BufferLen(13))`.

For comparison, the witx ABI got both of these right all along: it writes the needed length into
`nwritten_out` before returning `BufferLengthError`, which is the witx spelling of the same
contract.

### Impact

Without this, it is not possible to introspect the host of a backend on Viceroy.

### Versions

Present on `main` and in 0.20.1; `src/component/backend.rs` was byte-identical between the two.