### PR TITLE
Correct the mechanism that reports when Fanout and WebSocket passthrough are `unsupported` to the guest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
   generated a plain-text 500 that the guest had no part in producing. The hostcall now returns
   `FastlyStatus::Unsupported` before the handoff is signaled, matching the behavior of a
   deployed service that does not have Fanout enabled, so that SDK-level error handling can run.
+  ([#678](https://github.com/fastly/Viceroy/pull/678))
 
 - Add `--enable-local-websocket-passthrough=<true|false>` (default `true`), to simulate a
   service that does not have the WebSockets feature enabled.
@@ -15,6 +16,7 @@
   When set to `false`, `redirect_to_websocket_proxy` (and `_v2`) reports
   `FastlyStatus::Unsupported` to the guest rather than proxying the request, which makes the
   "WebSockets not enabled" path testable locally for the first time.
+  ([#678](https://github.com/fastly/Viceroy/pull/678))
 
 ## 0.20.1 (2026-07-16)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 ## Unreleased
 
+- Report Fanout as `unsupported` to the guest when it is not enabled, instead of failing after
+  the guest has returned.
+
+  Previously, calling `redirect_to_grip_proxy` (or `_v2`) without
+  `--local-pushpin-proxy-port` succeeded from the guest's point of view, and Viceroy then
+  generated a plain-text 500 that the guest had no part in producing. The hostcall now returns
+  `FastlyStatus::Unsupported` before the handoff is signaled, matching the behavior of a
+  deployed service that does not have Fanout enabled, so that SDK-level error handling can run.
+
+- Add `--enable-local-websocket-passthrough=<true|false>` (default `true`), to simulate a
+  service that does not have the WebSockets feature enabled.
+
+  When set to `false`, `redirect_to_websocket_proxy` (and `_v2`) reports
+  `FastlyStatus::Unsupported` to the guest rather than proxying the request, which makes the
+  "WebSockets not enabled" path testable locally for the first time.
+
 ## 0.20.1 (2026-07-16)
 
 - Fix wiggle abi implementation for bot detection mocking. ([#664](https://github.com/fastly/Viceroy/pull/664))

--- a/cli/src/execute_ctx.rs
+++ b/cli/src/execute_ctx.rs
@@ -81,7 +81,8 @@ pub(crate) async fn create_execution_context(
     )?
     .with_log_stderr(args.log_stderr())
     .with_log_stdout(args.log_stdout())
-    .with_local_pushpin_proxy_port(args.local_pushpin_proxy_port());
+    .with_local_pushpin_proxy_port(args.local_pushpin_proxy_port())
+    .with_enable_local_websocket_passthrough(args.enable_local_websocket_passthrough());
 
     let Some(config_path) = args.config_path() else {
         event!(

--- a/cli/src/opts.rs
+++ b/cli/src/opts.rs
@@ -107,6 +107,23 @@ pub struct SharedArgs {
     /// is disabled.
     #[arg(long = "local-pushpin-proxy-port")]
     local_pushpin_proxy_port: Option<u16>,
+    /// Whether WebSocket passthrough is enabled for the service.
+    ///
+    /// Set this to `false` to simulate a service that does not have the WebSockets
+    /// feature enabled: `redirect_to_websocket_proxy` will report `unsupported` to
+    /// the guest, so that it can exercise its handling of that state locally.
+    #[arg(
+        long = "enable-local-websocket-passthrough",
+        value_name = "BOOL",
+        default_value = "true",
+        action = clap::ArgAction::Set,
+        // `require_equals` keeps the bare form from swallowing the following positional
+        // argument as its value.
+        num_args = 0..=1,
+        require_equals = true,
+        default_missing_value = "true",
+    )]
+    enable_local_websocket_passthrough: bool,
     /// Set of experimental WASI modules to link against.
     #[arg(value_enum, long = "experimental_modules", required = false)]
     experimental_modules: Vec<ExperimentalModuleArg>,
@@ -200,6 +217,11 @@ impl SharedArgs {
     /// Port running local Pushpin proxy.
     pub fn local_pushpin_proxy_port(&self) -> Option<u16> {
         self.local_pushpin_proxy_port
+    }
+
+    /// Whether WebSocket passthrough is enabled for the service.
+    pub fn enable_local_websocket_passthrough(&self) -> bool {
+        self.enable_local_websocket_passthrough
     }
 
     /// Configuration for guest profiling if enabled

--- a/cli/tests/integration/common.rs
+++ b/cli/tests/integration/common.rs
@@ -97,6 +97,7 @@ pub struct Test {
     adapt_component: bool,
     profiling_strategy: ProfilingStrategy,
     guest_profile_config: Option<viceroy_lib::GuestProfileConfig>,
+    enable_local_websocket_passthrough: bool,
 }
 
 impl Test {
@@ -124,6 +125,7 @@ impl Test {
             adapt_component: false,
             profiling_strategy: ProfilingStrategy::None,
             guest_profile_config: None,
+            enable_local_websocket_passthrough: true,
         }
     }
 
@@ -151,6 +153,7 @@ impl Test {
             adapt_component: false,
             profiling_strategy: ProfilingStrategy::None,
             guest_profile_config: None,
+            enable_local_websocket_passthrough: true,
         }
     }
 
@@ -346,6 +349,12 @@ impl Test {
         self
     }
 
+    /// Set whether WebSocket passthrough is enabled for this test.
+    pub fn enable_local_websocket_passthrough(mut self, enable: bool) -> Self {
+        self.enable_local_websocket_passthrough = enable;
+        self
+    }
+
     /// Enable guest profiling with the specified configuration.
     pub fn with_guest_profiling(mut self, config: viceroy_lib::GuestProfileConfig) -> Self {
         self.guest_profile_config = Some(config);
@@ -412,6 +421,7 @@ impl Test {
         .with_secret_stores(self.secret_stores.clone())
         .with_shielding_sites(self.shielding_sites.clone())
         .with_fake_valid_fastly_keys(self.fake_valid_fastly_keys.clone())
+        .with_enable_local_websocket_passthrough(self.enable_local_websocket_passthrough)
         .with_capture_logs(self.capture_logs.clone())
         .with_log_stderr(self.log_stderr)
         .with_log_stdout(self.log_stdout)

--- a/cli/tests/integration/handoff.rs
+++ b/cli/tests/integration/handoff.rs
@@ -1,0 +1,104 @@
+use {
+    crate::{
+        common::{Test, TestResult},
+        viceroy_test,
+    },
+    hyper::{Request, StatusCode},
+};
+
+/// `FastlyStatus::UNSUPPORTED`, which is what a guest sees when a feature is not enabled for
+/// the service.
+const UNSUPPORTED: &str = "status=5";
+
+/// `FastlyStatus::ERROR`, the generic error.
+const ERROR: &str = "status=1";
+
+/// Define the backend the fixture hands off to.
+///
+/// A backend has to exist even for the cases that are expected to fail: on the component path
+/// the adapter resolves the backend name before invoking the hostcall, so an undefined backend
+/// would fail with `FastlyStatus::NONE` before the feature check is ever reached.
+async fn with_backend(test: Test) -> Test {
+    test.backend("origin", "/", None, |_| {
+        hyper::Response::builder()
+            .status(StatusCode::IM_A_TEAPOT)
+            .body(Vec::from("from the backend"))
+            .unwrap()
+    })
+    .await
+}
+
+viceroy_test!(fanout_is_unsupported_when_not_enabled, |is_component| {
+    // No `--local-pushpin-proxy-port` is configured, so Fanout is not enabled. The guest must
+    // observe that itself, rather than Viceroy manufacturing a response after the fact.
+    let resp = with_backend(Test::using_fixture("handoff.wasm").adapt_component(is_component))
+        .await
+        .against(Request::get("/fanout").body("")?)
+        .await?;
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    assert_eq!(resp.into_body().read_into_string().await?, UNSUPPORTED);
+
+    Ok(())
+});
+
+viceroy_test!(
+    websocket_passthrough_is_unsupported_when_disabled,
+    |is_component| {
+        let resp = with_backend(
+            Test::using_fixture("handoff.wasm")
+                .adapt_component(is_component)
+                .enable_local_websocket_passthrough(false),
+        )
+        .await
+        .against(Request::get("/websocket").body("")?)
+        .await?;
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(resp.into_body().read_into_string().await?, UNSUPPORTED);
+
+        Ok(())
+    }
+);
+
+viceroy_test!(websocket_passthrough_proxies_when_enabled, |is_component| {
+    // Enabled by default: the handoff should go through to the backend, and the backend's
+    // response — not the guest's — is what reaches the client.
+    let resp = with_backend(Test::using_fixture("handoff.wasm").adapt_component(is_component))
+        .await
+        .against(Request::get("/websocket").body("")?)
+        .await?;
+
+    assert_eq!(resp.status(), StatusCode::IM_A_TEAPOT);
+    assert_eq!(
+        resp.into_body().read_into_string().await?,
+        "from the backend"
+    );
+
+    Ok(())
+});
+
+viceroy_test!(
+    already_sent_response_takes_precedence_over_feature_check,
+    |is_component| {
+        // Matches the ordering in production: a handoff attempted after a response has already
+        // been sent reports that, rather than reporting the feature as unsupported.
+        let resp = with_backend(
+            Test::using_fixture("handoff.wasm")
+                .adapt_component(is_component)
+                .enable_local_websocket_passthrough(false),
+        )
+        .await
+        .against(
+            Request::get("/websocket")
+                .header("send-response-first", "yes")
+                .body("")?,
+        )
+        .await?;
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(resp.into_body().read_into_string().await?, ERROR);
+
+        Ok(())
+    }
+);

--- a/cli/tests/integration/main.rs
+++ b/cli/tests/integration/main.rs
@@ -16,6 +16,7 @@ mod env_vars;
 mod fastly_key_is_valid;
 mod geolocation_lookup;
 mod grpc;
+mod handoff;
 mod http_semantics;
 mod inspect;
 mod invalid_status_code;

--- a/src/execute.rs
+++ b/src/execute.rs
@@ -149,6 +149,11 @@ pub struct ExecuteCtx {
     log_stderr: bool,
     /// The local Pushpin proxy port
     local_pushpin_proxy_port: Option<u16>,
+    /// Whether WebSocket passthrough is enabled for this service.
+    ///
+    /// Set this to `false` to simulate a service that does not have the WebSockets feature
+    /// enabled, so that guests can exercise their handling of that state locally.
+    enable_local_websocket_passthrough: bool,
     /// The ID to assign the next incoming request
     next_req_id: Arc<AtomicU64>,
     /// The ObjectStore associated with this instance of Viceroy
@@ -310,6 +315,7 @@ impl ExecuteCtx {
             log_stdout: false,
             log_stderr: false,
             local_pushpin_proxy_port: None,
+            enable_local_websocket_passthrough: true,
             next_req_id: Arc::new(AtomicU64::new(0)),
             object_store: ObjectStores::new(),
             secret_stores: SecretStores::new(),
@@ -531,6 +537,9 @@ impl ExecuteCtx {
 
                     info!("Pushpin handoff signaled to backend '{backend_name}'");
 
+                    // Defensive only: `Sandbox::redirect_downstream_to_pushpin` is the sole
+                    // producer of this handoff, and it now rejects the call with an
+                    // `unsupported` error before signaling when no proxy port is configured.
                     let local_pushpin_proxy_port = match local_pushpin_proxy_port {
                         None => {
                             error!("Pushpin handoff signaled, but Pushpin mode not enabled.");
@@ -1030,6 +1039,16 @@ impl ExecuteCtx {
         &self.shielding_sites
     }
 
+    /// The local Pushpin proxy port, if Fanout is enabled for this execution context.
+    pub fn local_pushpin_proxy_port(&self) -> Option<u16> {
+        self.local_pushpin_proxy_port
+    }
+
+    /// Whether WebSocket passthrough is enabled for this execution context.
+    pub fn enable_local_websocket_passthrough(&self) -> bool {
+        self.enable_local_websocket_passthrough
+    }
+
     /// Get the valid mock Fastly API keys for this execution context.
     pub fn fake_valid_fastly_keys(&self) -> &FakeValidFastlyKeys {
         &self.fake_valid_fastly_keys
@@ -1146,6 +1165,15 @@ impl ExecuteCtxBuilder {
     /// Set the local Pushpin proxy port
     pub fn with_local_pushpin_proxy_port(mut self, local_pushpin_proxy_port: Option<u16>) -> Self {
         self.inner.local_pushpin_proxy_port = local_pushpin_proxy_port;
+        self
+    }
+
+    /// Set whether WebSocket passthrough is enabled for this execution context.
+    pub fn with_enable_local_websocket_passthrough(
+        mut self,
+        enable_local_websocket_passthrough: bool,
+    ) -> Self {
+        self.inner.enable_local_websocket_passthrough = enable_local_websocket_passthrough;
         self
     }
 }

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -288,10 +288,10 @@ impl Sandbox {
         // state through this hostcall's `unsupported` result, so guests (and the SDKs built on
         // them) can only exercise that path if we do the same.
         if self.ctx.local_pushpin_proxy_port().is_none() {
-            return Err(Error::Unsupported {
-                msg: "Fanout is not enabled on this service \
-                      (run Viceroy with --local-pushpin-proxy-port to enable it)",
-            });
+            const MSG: &str = "Fanout is not enabled on this service \
+                               (run Viceroy with --local-pushpin-proxy-port to enable it)";
+            tracing::error!("{MSG}");
+            return Err(Error::Unsupported { msg: MSG });
         }
 
         self.downstream_resp
@@ -318,10 +318,10 @@ impl Sandbox {
 
         // As above: the guest must be able to observe the disabled state itself.
         if !self.ctx.enable_local_websocket_passthrough() {
-            return Err(Error::Unsupported {
-                msg: "WebSocket passthrough is not enabled on this service \
-                      (it was disabled with --enable-local-websocket-passthrough=false)",
-            });
+            const MSG: &str = "WebSocket passthrough is not enabled on this service \
+                               (it was disabled with --enable-local-websocket-passthrough=false)";
+            tracing::error!("{MSG}");
+            return Err(Error::Unsupported { msg: MSG });
         }
 
         self.downstream_resp

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -269,7 +269,7 @@ impl Sandbox {
 
     /// Redirect the downstream request to Pushpin.
     ///
-    /// Yield an error if a response has already been sent.
+    /// Yield an error if a response has already been sent, or if Fanout is not enabled.
     ///
     /// # Panics
     ///
@@ -279,6 +279,21 @@ impl Sandbox {
         &mut self,
         redirect_info: HandoffInfo,
     ) -> Result<(), Error> {
+        if !self.downstream_resp.is_unsent() {
+            return Err(Error::DownstreamRespSending);
+        }
+
+        // Report "not enabled" to the guest here, rather than letting the handoff proceed and
+        // failing once the guest has already returned. Deployed services signal the disabled
+        // state through this hostcall's `unsupported` result, so guests (and the SDKs built on
+        // them) can only exercise that path if we do the same.
+        if self.ctx.local_pushpin_proxy_port().is_none() {
+            return Err(Error::Unsupported {
+                msg: "Fanout is not enabled on this service \
+                      (run Viceroy with --local-pushpin-proxy-port to enable it)",
+            });
+        }
+
         self.downstream_resp
             .redirect_to_pushpin(redirect_info)
             .await
@@ -286,7 +301,8 @@ impl Sandbox {
 
     /// Redirect the downstream request to a backend.
     ///
-    /// Yield an error if a response has already been sent.
+    /// Yield an error if a response has already been sent, or if WebSocket passthrough is not
+    /// enabled.
     ///
     /// # Panics
     ///
@@ -296,6 +312,18 @@ impl Sandbox {
         &mut self,
         redirect_info: HandoffInfo,
     ) -> Result<(), Error> {
+        if !self.downstream_resp.is_unsent() {
+            return Err(Error::DownstreamRespSending);
+        }
+
+        // As above: the guest must be able to observe the disabled state itself.
+        if !self.ctx.enable_local_websocket_passthrough() {
+            return Err(Error::Unsupported {
+                msg: "WebSocket passthrough is not enabled on this service \
+                      (it was disabled with --enable-local-websocket-passthrough=false)",
+            });
+        }
+
         self.downstream_resp
             .redirect_to_backend(redirect_info)
             .await

--- a/test-fixtures/src/bin/handoff.rs
+++ b/test-fixtures/src/bin/handoff.rs
@@ -1,0 +1,58 @@
+//! A guest program that exercises the Fanout and WebSocket passthrough handoff hostcalls.
+//!
+//! Both hostcalls report `unsupported` when the corresponding feature is not enabled for the
+//! service, so this fixture reports the raw `FastlyStatus` it observed back to the test.
+
+use std::io::Write;
+
+use fastly::{Request, Response};
+use fastly_shared::FastlyStatus;
+use fastly_sys::fastly_http_req;
+
+fn main() {
+    let client_req = Request::from_client();
+    let path = client_req.get_path().to_owned();
+    let backend = client_req
+        .get_header_str("handoff-backend")
+        .unwrap_or("origin")
+        .to_owned();
+
+    // Optionally send a response before attempting the handoff, so that a test can check that
+    // the "a response was already sent" error takes precedence over the feature check. The
+    // response is streamed, so that the status can still be reported through its body once the
+    // handoff has been attempted.
+    let already_sent = client_req
+        .get_header_str("send-response-first")
+        .is_some()
+        .then(|| Response::from_status(200).stream_to_client());
+
+    let (req_handle, _body_handle) = client_req.into_handles();
+    let req = req_handle.as_u32();
+
+    let status = unsafe {
+        match path.as_str() {
+            "/fanout" => {
+                fastly_http_req::redirect_to_grip_proxy_v2(req, backend.as_ptr(), backend.len())
+            }
+            "/websocket" => fastly_http_req::redirect_to_websocket_proxy_v2(
+                req,
+                backend.as_ptr(),
+                backend.len(),
+            ),
+            other => panic!("unexpected path: {other}"),
+        }
+    };
+
+    if let Some(mut body) = already_sent {
+        write!(body, "status={}", status.code).unwrap();
+        body.finish().unwrap();
+        return;
+    }
+
+    // On success the handoff target owns the response; otherwise report what we saw.
+    if status == FastlyStatus::OK {
+        return;
+    }
+
+    Response::from_body(format!("status={}", status.code)).send_to_client();
+}


### PR DESCRIPTION
Fixes two reported bugs that share a root cause: a guest can never observe that Fanout or WebSocket passthrough is disabled, because the failure happens after the guest has already returned.

## Problem

Calling `redirect_to_grip_proxy` without `--local-pushpin-proxy-port` succeeds from the guest's point of view. Viceroy then generates a plain-text 500 (`Pushpin handoff signaled, but Pushpin mode not enabled.`) that the guest played no part in producing:

```
HTTP/1.1 500 Internal Server Error
Pushpin handoff signaled, but Pushpin mode not enabled.
```

Both WIT functions are declared `result<_, error>`, and `compute.wit` documents them as usable only on services with the corresponding product enabled. SDKs are already written against that contract — the Rust SDK checks for `FastlyStatus::Unsupported` but Viceroy never produced it, so that branch was untestable locally.

WebSocket passthrough had no concept of a disabled state at all: a handoff to a valid backend always proxied through.

## Changes

**Fanout.** The enable signal (`--local-pushpin-proxy-port`) is unchanged; only the timing and shape of the failure. The check moves into `Sandbox::redirect_downstream_to_pushpin`, before the handoff is signaled, returning `Error::Unsupported`.

**WebSocket passthrough.** New `--enable-local-websocket-passthrough=<true|false>`, default `true` so existing behavior is preserved. When `false`, `Sandbox::redirect_downstream_to_backend` reports `unsupported` the same way. A companion Fastly CLI change will set this from `fastly.toml`.

Each guard sits in the single method that funnels every entry point for its hostcall, so one guard each covers the wiggle v1 and v2 paths and the component path. Both guards run *after* the existing already-sent check.

`Error::Unsupported` already maps to `FastlyStatus::Unsupported` and `types::Error::Unsupported`, so **no WIT, witx, or adapter changes were needed**.

Before: an opaque 500. After: the guest's own response, reporting `FastlyStatus::UNSUPPORTED` (5), identically in core-wasm and component modes.

## Testing

New `test-fixtures/src/bin/handoff.rs` reports the raw `FastlyStatus` it observes. `cli/tests/integration/handoff.rs` covers, via `viceroy_test!` so each runs as both core-wasm and component:

- Fanout disabled → guest observes `UNSUPPORTED`, and gets its own response rather than the old 500
- WebSocket passthrough disabled → guest observes `UNSUPPORTED`
- WebSocket passthrough enabled → still proxies to the backend
- Response already sent, then handoff on a disabled product → the already-sent error wins, locking in the ordering that matches ExecuteD

`make ci` (174 integration, 125 lib) and `make trap-test` pass. Note that the 6 `make clippy` errors on this branch are pre-existing — verified identical on a clean `main`, and clippy is not part of `make ci` or the CI workflow.