### PR TITLE
Enable support for the wide-arithmetic feature.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- Enable support for the wide-arithmetic feature. ([#679](https://github.com/fastly/Viceroy/pull/679))
+
 ## 0.20.1 (2026-07-16)
 
 - Fix wiggle abi implementation for bot detection mocking. ([#664](https://github.com/fastly/Viceroy/pull/664))

--- a/src/execute.rs
+++ b/src/execute.rs
@@ -1249,6 +1249,10 @@ fn configure_wasmtime(
     // different host architecture.
     config.relaxed_simd_deterministic(true);
 
+    // Enable the wide-arithmetic feature, which has now been voted
+    // to phase-4.
+    config.wasm_wide_arithmetic(true);
+
     config
 }
 


### PR DESCRIPTION
wide-arithmetic has recently been voted to stage 4, so we can now enable it.