### PR TITLE
Map a truncated body read to `http-incomplete` on the component ABI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Unreleased
 
+- Map a body read that ends early to `error.http-incomplete` on the component ABI, which previously
+  answered `error.generic-error` even though the witx ABI mapped it. A truncated body does not
+  satisfy `hyper::Error::is_incomplete_message`, so the cause needs a downcast, and the component
+  mapping had no equivalent of the one in `src/error.rs`. See [#289](https://github.com/fastly/Viceroy/issues/289).
+
 - Enable support for the wide-arithmetic feature. ([#679](https://github.com/fastly/Viceroy/pull/679))
 
 - Implement `backend.get-host` on the component ABI, which previously always returned

--- a/src/component/compute/error.rs
+++ b/src/component/compute/error.rs
@@ -15,6 +15,7 @@ use {
         status::InvalidStatusCode,
         uri::InvalidUri,
     },
+    std::{error::Error as StdError, io},
     wasmtime_wasi::ResourceTableError,
 };
 
@@ -218,6 +219,16 @@ impl From<error::Error> for types::Error {
             Error::HyperError(e) if e.is_parse() => types::Error::HttpInvalid,
             Error::HyperError(e) if e.is_user() => types::Error::HttpUser,
             Error::HyperError(e) if e.is_incomplete_message() => types::Error::HttpIncomplete,
+            // A body that ends early does not satisfy `is_incomplete_message`. Hyper reports kind
+            // `Body`, with an `io::Error` cause of `UnexpectedEof`, so the cause needs a downcast.
+            Error::HyperError(e)
+                if e.source()
+                    .and_then(|e| e.downcast_ref::<io::Error>())
+                    .map(|ioe| ioe.kind())
+                    == Some(io::ErrorKind::UnexpectedEof) =>
+            {
+                types::Error::HttpIncomplete
+            }
             Error::HyperError(_) => types::Error::GenericError,
             // BackendConnectionError wraps hyper::Error with context
             Error::BackendConnectionError { source, .. } if source.is_parse() => {
@@ -227,6 +238,15 @@ impl From<error::Error> for types::Error {
                 types::Error::HttpUser
             }
             Error::BackendConnectionError { source, .. } if source.is_incomplete_message() => {
+                types::Error::HttpIncomplete
+            }
+            Error::BackendConnectionError { source, .. }
+                if source
+                    .source()
+                    .and_then(|e| e.downcast_ref::<io::Error>())
+                    .map(|ioe| ioe.kind())
+                    == Some(io::ErrorKind::UnexpectedEof) =>
+            {
                 types::Error::HttpIncomplete
             }
             Error::BackendConnectionError { .. } => types::Error::GenericError,


### PR DESCRIPTION
A body read that ends early answers `error.generic-error` on the component ABI, where the witx ABI answers `Httpincomplete`. A component guest therefore cannot tell a truncated response from any other failure.

The reason is that a truncated body does not satisfy `hyper::Error::is_incomplete_message()`. Hyper reports kind `Body`, with an `io::Error` cause of `UnexpectedEof`. The witx mapping in `src/error.rs` handles that: beside each `is_incomplete_message()` arm it has an arm that downcasts the cause to `io::Error` and tests for `ErrorKind::UnexpectedEof`. The mapping in `src/component/compute/error.rs` has the `is_incomplete_message()` arms and no equivalent of the downcast, so it falls through to `generic-error`.

This adds the two missing arms, for `HyperError` and for `BackendConnectionError`, matching the witx mapping.

This looks like the remainder of #289, whose fix landed on the witx mapping only.

## Verification

Measured with a component guest, on an origin that promises 4 bytes, sends 3, and closes. The guest receives `http-incomplete` with this change and `generic-error` without it. A chunked origin that sends one whole chunk and then a partial chunk length gives the same result. Four cases in total: both framings, each with a close and with a half-close.

The guest has to read the body with no readiness call first. A guest that calls `select` on the body before it reads gets no error at all, whichever way this mapping goes. That is a separate defect, filed as #690: `Body::await_ready` discards a read error.

`cargo fmt --check` is clean. `cargo clippy` reports six warnings, all of them in other files and all present before this change.

## Note on tests

No test accompanies this change, and I would value your view on what you would want.

A unit test on the `From<error::Error> for types::Error` impl is not reachable, because a `hyper::Error` carrying an `UnexpectedEof` cause cannot be constructed from outside hyper. An integration test needs an origin that truncates a body and a component guest that reports the error it received. I am happy to write one if you can point me at the shape you would prefer for a component-ABI fixture.
