### PR TITLE
Implement the core cache API `replace` family

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 ## Unreleased
 
+- Support the "replace" family of core cache calls, completing Viceroy's coverage of the
+  [core cache API](https://docs.rs/fastly/latest/fastly/cache/core/index.html).
+  ([#495](https://github.com/fastly/Viceroy/issues/495))
+
+  `fastly::cache::core::replace()` previously failed immediately, so read-modify-write patterns
+  such as a cached counter could not be tested locally. All three `ReplaceStrategy` variants are
+  now modeled: `Immediate` leaves the existing object visible until the replacement is provided,
+  `ImmediateForceMiss` removes it as soon as the replace begins, and `Wait` queues behind any
+  in-progress insert or replace.
+
+  As part of this, `Found::hits()` and `Found::stale_while_revalidate()` are implemented; they
+  previously reported `unsupported` for lookups as well, which made the SDK panic.
+
 ## 0.21.0 (2026-08-25)
 
 - Enable support for the wide-arithmetic feature. ([#679](https://github.com/fastly/Viceroy/pull/679))

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -240,6 +240,115 @@ impl CacheEntry {
     }
 }
 
+/// How a `replace` operation coordinates with other writers of the same object.
+///
+/// See <https://docs.rs/fastly/latest/fastly/cache/core/enum.ReplaceStrategy.html>.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum ReplaceStrategy {
+    /// Read the existing object, if any, and leave it in place. The replacement is an ordinary
+    /// last-writer-wins insert.
+    #[default]
+    Immediate,
+    /// As `Immediate`, except that the existing object immediately stops being findable by lookups.
+    ImmediateForceMiss,
+    /// Wait for any in-flight write of this object to complete, then block other writers until this
+    /// replace inserts its replacement (or is abandoned).
+    Wait,
+}
+
+impl ReplaceStrategy {
+    /// Convert from the representation used across the ABI boundary.
+    ///
+    /// Returns `None` if the value is not a recognized strategy.
+    pub fn from_abi(value: u32) -> Option<Self> {
+        match value {
+            1 => Some(Self::Immediate),
+            2 => Some(Self::ImmediateForceMiss),
+            3 => Some(Self::Wait),
+            _ => None,
+        }
+    }
+}
+
+/// An in-progress replace operation: the object currently in the cache (if any), plus the
+/// permission to write a replacement for it.
+#[derive(Debug)]
+pub struct ReplaceEntry {
+    key: CacheKey,
+
+    /// The request headers the replace was begun with.
+    ///
+    /// Used to compute the variant of the replacement, unless the guest provides its own headers at
+    /// insert time (which `Replace::header()` does).
+    request_headers: HeaderMap,
+
+    /// The object(s) under this cache key, for the insert path that doesn't hold an obligation.
+    objects: Arc<CacheKeyObjects>,
+
+    existing: Option<Found>,
+    obligation: Option<Obligation>,
+
+    /// See [`CacheEntry::always_use_requested_range`].
+    always_use_requested_range: bool,
+}
+
+impl ReplaceEntry {
+    /// Set the always_use_requested_range flag.
+    pub fn with_always_use_requested_range(self, always_use_requested_range: bool) -> Self {
+        Self {
+            always_use_requested_range,
+            ..self
+        }
+    }
+
+    /// Returns the key used to begin this replace.
+    pub fn key(&self) -> &CacheKey {
+        &self.key
+    }
+
+    /// Returns the object that was in the cache when the replace began, if any.
+    ///
+    /// This object may be stale: `replace` returns whatever is present, and leaves it to the guest
+    /// to decide what to do about freshness.
+    pub fn existing(&self) -> Option<&Found> {
+        self.existing.as_ref()
+    }
+
+    /// Returns the object that was in the cache when the replace began, if any.
+    pub fn existing_mut(&mut self) -> Option<&mut Found> {
+        self.existing.as_mut()
+    }
+
+    /// Access the body of the existing object, if there is one.
+    pub async fn body(&self, from: Option<u64>, to: Option<u64>) -> Result<Body, crate::Error> {
+        let existing = self
+            .existing
+            .as_ref()
+            .ok_or(crate::Error::CacheError(Error::Missing))?;
+        existing
+            .get_body()
+            .with_range(from, to)
+            .with_always_use_requested_range(self.always_use_requested_range)
+            .build()
+            .await
+    }
+
+    /// Write the replacement object, consuming this replace operation.
+    ///
+    /// If `request_headers` is provided it replaces the headers the operation was begun with, for
+    /// the purposes of computing the variant to insert under.
+    pub fn insert(self, request_headers: Option<HeaderMap>, options: WriteOptions, body: Body) {
+        let request_headers = request_headers.unwrap_or(self.request_headers);
+        if let Some(obligation) = self.obligation {
+            // Fulfilling the obligation also releases it, waking anyone waiting on this object.
+            obligation.insert_with_headers(request_headers, options, body);
+        } else {
+            // No obligation: a plain, racing, last-writer-wins insert.
+            self.objects.insert(request_headers, options, body, None);
+        }
+    }
+}
+
 /// A successful retrieval of an item from the cache.
 #[derive(Debug)]
 pub struct Found {
@@ -336,6 +445,29 @@ impl Cache {
             key: key.clone(),
             found: found.map(|v| Found::from((*v).clone())),
             go_get: obligation,
+            always_use_requested_range: false,
+        }
+    }
+
+    /// Begin a replace operation: read the object currently in the cache (if any), and acquire the
+    /// right to write a replacement for it.
+    pub async fn replace(
+        &self,
+        key: &CacheKey,
+        request_headers: HeaderMap,
+        strategy: ReplaceStrategy,
+    ) -> ReplaceEntry {
+        let objects = self
+            .inner
+            .get_with_by_ref(key, async { Default::default() })
+            .await;
+        let (existing, obligation) = objects.replace(&request_headers, strategy).await;
+        ReplaceEntry {
+            key: key.clone(),
+            request_headers,
+            objects,
+            existing: existing.map(|v| Found::from((*v).clone())),
+            obligation,
             always_use_requested_range: false,
         }
     }
@@ -880,5 +1012,281 @@ mod tests {
         assert!(!found.meta().is_fresh());
         assert!(found.meta().is_usable());
         assert!(result.go_get().is_some());
+    }
+
+    /// Insert `body` at `key` with a 100s TTL, non-transactionally.
+    async fn insert_fresh(cache: &Cache, key: &CacheKey, body: &str) {
+        cache
+            .insert(
+                key,
+                HeaderMap::default(),
+                WriteOptions::new(Duration::from_secs(100)),
+                body.as_bytes().into(),
+            )
+            .await;
+    }
+
+    async fn read_body(entry: &ReplaceEntry) -> String {
+        entry
+            .body(None, None)
+            .await
+            .unwrap()
+            .read_into_string()
+            .await
+            .unwrap()
+    }
+
+    async fn lookup_body(cache: &Cache, key: &CacheKey) -> Option<String> {
+        let entry = cache.lookup(key, &HeaderMap::default()).await;
+        entry.found()?;
+        Some(
+            entry
+                .body(None, None)
+                .await
+                .unwrap()
+                .read_into_string()
+                .await
+                .unwrap(),
+        )
+    }
+
+    #[tokio::test]
+    async fn replace_immediate_leaves_existing_visible() {
+        let cache = Cache::default();
+        let key: CacheKey = ([1u8].as_slice()).try_into().unwrap();
+        insert_fresh(&cache, &key, "old").await;
+
+        let entry = cache
+            .replace(&key, HeaderMap::default(), ReplaceStrategy::Immediate)
+            .await;
+        assert_eq!(read_body(&entry).await, "old");
+
+        // `Immediate` does not disturb the existing object...
+        assert_eq!(lookup_body(&cache, &key).await.as_deref(), Some("old"));
+
+        entry.insert(
+            None,
+            WriteOptions::new(Duration::from_secs(100)),
+            "new".as_bytes().into(),
+        );
+
+        // ...but the replacement wins once it's written.
+        assert_eq!(lookup_body(&cache, &key).await.as_deref(), Some("new"));
+    }
+
+    #[tokio::test]
+    async fn replace_no_existing_object() {
+        let cache = Cache::default();
+        let key: CacheKey = ([1u8].as_slice()).try_into().unwrap();
+
+        let entry = cache
+            .replace(&key, HeaderMap::default(), ReplaceStrategy::Wait)
+            .await;
+        assert!(entry.existing().is_none());
+
+        entry.insert(
+            None,
+            WriteOptions::new(Duration::from_secs(100)),
+            "new".as_bytes().into(),
+        );
+        assert_eq!(lookup_body(&cache, &key).await.as_deref(), Some("new"));
+    }
+
+    #[tokio::test]
+    async fn replace_force_miss_hides_existing() {
+        let cache = Arc::new(Cache::default());
+        let key: CacheKey = ([1u8].as_slice()).try_into().unwrap();
+        insert_fresh(&cache, &key, "old").await;
+
+        let entry = cache
+            .replace(
+                &key,
+                HeaderMap::default(),
+                ReplaceStrategy::ImmediateForceMiss,
+            )
+            .await;
+        // The replace still gets to read the object it displaced...
+        assert_eq!(read_body(&entry).await, "old");
+        // ...but nobody else can find it.
+        assert!(
+            cache
+                .lookup(&key, &HeaderMap::default())
+                .await
+                .found()
+                .is_none()
+        );
+
+        // A transactional lookup blocks on our obligation rather than missing.
+        let waiter = tokio::task::spawn({
+            let cache = Arc::clone(&cache);
+            let key = key.clone();
+            async move {
+                cache
+                    .transaction_lookup(&key, &HeaderMap::default(), true)
+                    .await
+            }
+        });
+
+        entry.insert(
+            None,
+            WriteOptions::new(Duration::from_secs(100)),
+            "new".as_bytes().into(),
+        );
+
+        let waited = tokio::time::timeout(Duration::from_secs(5), waiter)
+            .await
+            .expect("waiter should be woken by the replacement insert")
+            .unwrap();
+        assert!(waited.go_get().is_none());
+        assert_eq!(
+            waited
+                .body(None, None)
+                .await
+                .unwrap()
+                .read_into_string()
+                .await
+                .unwrap(),
+            "new"
+        );
+    }
+
+    #[tokio::test]
+    async fn replace_wait_serializes() {
+        let cache = Arc::new(Cache::default());
+        let key: CacheKey = ([1u8].as_slice()).try_into().unwrap();
+        insert_fresh(&cache, &key, "1").await;
+
+        // The read-modify-write ("counter") pattern: each task reads the current value, adds one,
+        // and writes it back. `Wait` is what makes this safe.
+        let mut set = tokio::task::JoinSet::new();
+        for _ in 0..4 {
+            set.spawn({
+                let cache = Arc::clone(&cache);
+                let key = key.clone();
+                async move {
+                    let entry = cache
+                        .replace(&key, HeaderMap::default(), ReplaceStrategy::Wait)
+                        .await;
+                    let count: u32 = read_body(&entry).await.parse().unwrap();
+                    entry.insert(
+                        None,
+                        WriteOptions::new(Duration::from_secs(100)),
+                        format!("{}", count + 1).into_bytes().into(),
+                    );
+                }
+            });
+        }
+        tokio::time::timeout(Duration::from_secs(10), set.join_all())
+            .await
+            .expect("`Wait` replaces should not deadlock");
+
+        assert_eq!(lookup_body(&cache, &key).await.as_deref(), Some("5"));
+    }
+
+    #[tokio::test]
+    async fn replace_abandoned_releases_obligation() {
+        let cache = Cache::default();
+        let key: CacheKey = ([1u8].as_slice()).try_into().unwrap();
+        insert_fresh(&cache, &key, "old").await;
+
+        let entry = cache
+            .replace(
+                &key,
+                HeaderMap::default(),
+                ReplaceStrategy::ImmediateForceMiss,
+            )
+            .await;
+        drop(entry);
+
+        // The obligation is gone, so a new transaction gets to take it on rather than waiting
+        // forever on the abandoned replace.
+        let txn = cache
+            .transaction_lookup(&key, &HeaderMap::default(), false)
+            .await;
+        assert!(txn.found().is_none());
+        assert!(txn.go_get().is_some());
+    }
+
+    #[tokio::test]
+    async fn replace_with_new_vary_rule() {
+        let cache = Cache::default();
+        let key: CacheKey = ([1u8].as_slice()).try_into().unwrap();
+
+        let header_name = HeaderName::from_static("x-viceroy-test");
+        let request_headers: HeaderMap = [(header_name.clone(), HeaderValue::from_static("test"))]
+            .into_iter()
+            .collect();
+
+        cache
+            .insert(
+                &key,
+                request_headers.clone(),
+                WriteOptions {
+                    vary_rule: VaryRule::new([&header_name].into_iter()),
+                    ..WriteOptions::new(Duration::from_secs(100))
+                },
+                "old".as_bytes().into(),
+            )
+            .await;
+
+        let entry = cache
+            .replace(&key, request_headers.clone(), ReplaceStrategy::Wait)
+            .await;
+        assert_eq!(read_body(&entry).await, "old");
+
+        // Write the replacement without a vary rule: the obligation was taken against the *old*
+        // variant, but the new object lands under a new one.
+        entry.insert(
+            None,
+            WriteOptions::new(Duration::from_secs(100)),
+            "new".as_bytes().into(),
+        );
+
+        assert_eq!(lookup_body(&cache, &key).await.as_deref(), Some("new"));
+        let matched = cache.lookup(&key, &request_headers).await;
+        assert!(matched.found().is_some());
+    }
+
+    #[tokio::test]
+    async fn hits_and_stale_while_revalidate() {
+        let cache = Cache::default();
+        let key: CacheKey = ([1u8].as_slice()).try_into().unwrap();
+
+        cache
+            .insert(
+                &key,
+                HeaderMap::default(),
+                WriteOptions {
+                    stale_while_revalidate: Duration::from_secs(10),
+                    ..WriteOptions::new(Duration::from_secs(100))
+                },
+                "old".as_bytes().into(),
+            )
+            .await;
+
+        let first = cache.lookup(&key, &HeaderMap::default()).await;
+        let found = first.found().unwrap();
+        assert_eq!(found.meta().hits(), 1);
+        assert_eq!(
+            found.meta().stale_while_revalidate(),
+            Duration::from_secs(10)
+        );
+
+        // The counter is shared with the object still in the cache, so a second delivery is visible
+        // through the first `Found` as well.
+        let second = cache.lookup(&key, &HeaderMap::default()).await;
+        assert_eq!(second.found().unwrap().meta().hits(), 2);
+        assert_eq!(found.meta().hits(), 2);
+
+        // Beginning a replace is not a delivery, so it doesn't count as a hit.
+        let entry = cache
+            .replace(&key, HeaderMap::default(), ReplaceStrategy::Immediate)
+            .await;
+        let existing = entry.existing().unwrap();
+        assert_eq!(existing.meta().hits(), 2);
+        assert_eq!(
+            existing.meta().stale_while_revalidate(),
+            Duration::from_secs(10)
+        );
     }
 }

--- a/src/cache/store.rs
+++ b/src/cache/store.rs
@@ -4,7 +4,10 @@ use crate::cache::{Error, variance::VaryRule};
 use bytes::Bytes;
 use std::{
     collections::{HashMap, VecDeque},
-    sync::{Arc, atomic::AtomicBool},
+    sync::{
+        Arc,
+        atomic::{AtomicBool, AtomicU64},
+    },
     time::{Duration, Instant},
 };
 use tokio::sync::watch;
@@ -13,7 +16,7 @@ use http::HeaderMap;
 
 use crate::{body::Body, collecting_body::CollectingBody};
 
-use super::{Found, SurrogateKeySet, WriteOptions, variance::Variant};
+use super::{Found, ReplaceStrategy, SurrogateKeySet, WriteOptions, variance::Variant};
 
 /// Metadata associated with a particular object on insert.
 #[derive(Debug)]
@@ -45,6 +48,12 @@ pub struct ObjectMeta {
     // Soft-purge bit: atomic so we don't have to wrap the whole thing in a lock.
     // This can only transition false -> true.
     soft_purge: AtomicBool,
+
+    /// The number of times this object has been served from the cache.
+    ///
+    /// Shared (rather than copied) between clones of this metadata, so that a `Found` handed to the
+    /// guest observes the same counter as the object still sitting in the cache.
+    hits: Arc<AtomicU64>,
 }
 impl ObjectMeta {
     /// Retrieve the current age of this object.
@@ -56,6 +65,21 @@ impl ObjectMeta {
     /// Maximum fresh age of this object.
     pub fn max_age(&self) -> Duration {
         self.max_age
+    }
+
+    /// The stale-while-revalidate period of this object, which begins after `max_age`.
+    pub fn stale_while_revalidate(&self) -> Duration {
+        self.stale_while_revalidate
+    }
+
+    /// The number of times this object has been served from the cache.
+    pub fn hits(&self) -> u64 {
+        self.hits.load(std::sync::atomic::Ordering::SeqCst)
+    }
+
+    /// Count a delivery of this object from the cache.
+    fn record_hit(&self) {
+        self.hits.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
     }
 
     /// Return true if the entry is fresh at the current time.
@@ -121,6 +145,7 @@ impl ObjectMeta {
             length,
             surrogate_keys,
             soft_purge: AtomicBool::new(false),
+            hits: Arc::new(AtomicU64::new(0)),
         }
     }
 }
@@ -137,6 +162,10 @@ impl Clone for ObjectMeta {
             length: self.length,
             surrogate_keys: self.surrogate_keys.clone(),
             soft_purge: AtomicBool::new(self.soft_purge.load(std::sync::atomic::Ordering::SeqCst)),
+            // Unlike the other fields, the hit counter is *shared* with the clone: a `Found`
+            // handed to the guest must observe the same counter as the object still sitting in
+            // the cache.
+            hits: Arc::clone(&self.hits),
         }
     }
 }
@@ -145,8 +174,20 @@ impl Clone for ObjectMeta {
 pub struct CacheKeyObjects(watch::Sender<CacheKeyObjectsInner>);
 
 impl CacheKeyObjects {
-    /// Get the applicable CacheData, if available.
+    /// Get the applicable CacheData, if available, counting a hit against it.
     pub fn get(&self, request_headers: &HeaderMap) -> Option<Arc<CacheData>> {
+        let object = self.peek(request_headers);
+        if let Some(object) = &object {
+            object.meta.record_hit();
+        }
+        object
+    }
+
+    /// Get the applicable CacheData, if available, *without* counting a hit against it.
+    ///
+    /// This is what the `replace` API uses to read the existing object: on Compute, starting a
+    /// replace is not a delivery of the cached object, so it does not bump the hit count.
+    pub fn peek(&self, request_headers: &HeaderMap) -> Option<Arc<CacheData>> {
         let key_objects = self.0.borrow();
 
         for vary_rule in key_objects.vary_rules.iter() {
@@ -197,6 +238,7 @@ impl CacheKeyObjects {
                     if let Some(data) = &cache_value.present {
                         if data.meta.is_fresh() {
                             // We have fresh data; no need to generate an obligation.
+                            data.meta.record_hit();
                             return (Some(Arc::clone(data)), None);
                         }
                         if data.meta.is_usable() && cache_value.obligated {
@@ -204,6 +246,7 @@ impl CacheKeyObjects {
                             // obligated to freshen it.
                             // So we can go ahead and use the current data, without generating an
                             // obligation.
+                            data.meta.record_hit();
                             return (Some(Arc::clone(data)), None);
                         }
                     }
@@ -337,11 +380,176 @@ impl CacheKeyObjects {
 
             // Now outside of the lock: return what we have.
             if data.is_some() || obligated.is_some() || !ok_to_wait {
+                if let Some(data) = &data {
+                    data.meta.record_hit();
+                }
                 return (data, obligated);
             }
 
             // Return back to the top of the loop: look for the obligation we missed in the first
             // read pass.
+        }
+    }
+
+    /// Begin a replace operation.
+    ///
+    /// Returns the existing CacheData, if any (even if stale, and without counting a hit), and an
+    /// Obligation if this replace took ownership of the entry's obligation slot.
+    ///
+    /// The three strategies differ only in how they interact with that slot:
+    ///
+    /// - `Immediate` never takes it, and leaves the existing object visible to lookups. The
+    ///   eventual insert is an ordinary last-writer-wins insert.
+    /// - `ImmediateForceMiss` clears the existing object so that subsequent lookups miss, and takes
+    ///   the slot if it is free.
+    /// - `Wait` blocks until the slot is free, then takes it. Holding the slot is what serializes
+    ///   concurrent replaces of the same object, which is what makes read-modify-write ("counter")
+    ///   patterns work.
+    pub async fn replace(
+        self: &Arc<Self>,
+        request_headers: &HeaderMap,
+        strategy: ReplaceStrategy,
+    ) -> (Option<Arc<CacheData>>, Option<Obligation>) {
+        if matches!(strategy, ReplaceStrategy::Immediate) {
+            // Nothing to coordinate: read the current object and get out of the way.
+            return (self.peek(request_headers), None);
+        }
+
+        let force_miss = matches!(strategy, ReplaceStrategy::ImmediateForceMiss);
+        let mut sub = self.0.subscribe();
+
+        loop {
+            if !force_miss {
+                // `Wait`: don't attempt to take the obligation slot until nobody else holds it.
+                //
+                // Note that a guest which begins a `Wait` replace while *itself* holding an
+                // unfulfilled obligation on the same key will block here indefinitely; on Compute
+                // the request would eventually time out. We deliberately don't impose a timeout of
+                // our own.
+                let awaitable = {
+                    let key_objects = sub.borrow_and_update();
+                    key_objects
+                        .vary_rules
+                        .iter()
+                        .map(|v| v.variant(request_headers))
+                        .filter_map(|key| key_objects.objects.get(&key))
+                        .any(|value| value.obligated)
+                };
+                if awaitable {
+                    let _ = sub.changed().await;
+                    continue;
+                }
+            }
+
+            let mut data: Option<Arc<CacheData>> = None;
+            let mut obligation: Option<Obligation> = None;
+            // Set if, between the read above and the write below, someone else took the obligation
+            // slot out from under us; a `Wait` replace goes back around and waits on them instead.
+            let mut lost_race = false;
+
+            self.0.send_if_modified(|key_objects| {
+                // The variants that could serve this request, most-recent vary rule first.
+                let response_keys: Vec<Variant> = key_objects
+                    .vary_rules
+                    .iter()
+                    .map(|v| v.variant(request_headers))
+                    .collect();
+
+                // The existing object we'll hand to the guest: the same one a lookup would find.
+                let found = response_keys
+                    .iter()
+                    .find(|key| {
+                        key_objects
+                            .objects
+                            .get(key)
+                            .is_some_and(|value| value.present.is_some())
+                    })
+                    .cloned();
+                data = found.as_ref().and_then(|key| {
+                    key_objects
+                        .objects
+                        .get(key)
+                        .and_then(|value| value.present.clone())
+                });
+
+                // Hold the obligation against the variant we read from if there was one; failing
+                // that, any existing matching variant; failing that, a new variant derived from the
+                // most recent vary rule.
+                let variant = found
+                    .or_else(|| {
+                        response_keys
+                            .iter()
+                            .find(|key| key_objects.objects.contains_key(*key))
+                            .cloned()
+                    })
+                    .unwrap_or_else(|| {
+                        response_keys.into_iter().next().unwrap_or_else(|| {
+                            key_objects.vary_rules.push_front(VaryRule::default());
+                            VaryRule::default().variant(request_headers)
+                        })
+                    });
+
+                let already_obligated = key_objects
+                    .objects
+                    .get(&variant)
+                    .is_some_and(|value| value.obligated);
+
+                if already_obligated && !force_miss {
+                    // Raced with another obligation-taker; wait for them instead.
+                    lost_race = true;
+                    data = None;
+                    return false;
+                }
+
+                if force_miss {
+                    // Make subsequent lookups miss, for every variant that could have served this
+                    // request. As in `purge`, we keep obligated `CacheValue`s around (minus their
+                    // data) so we don't confuse whoever holds the obligation.
+                    for key in key_objects
+                        .vary_rules
+                        .iter()
+                        .map(|v| v.variant(request_headers))
+                        .collect::<Vec<_>>()
+                    {
+                        if let Some(value) = key_objects.objects.get_mut(&key) {
+                            value.present = None;
+                        }
+                    }
+                }
+
+                if already_obligated {
+                    // `ImmediateForceMiss` with an obligation already outstanding. The store's
+                    // invariant is one `Obligation` per obligated `CacheValue`, so we can't take a
+                    // second one; we fall back to a racing plain insert. (Deviation from Compute,
+                    // which would collapse these.)
+                    return false;
+                }
+
+                key_objects
+                    .objects
+                    .entry(variant.clone())
+                    .or_default()
+                    .obligated = true;
+                obligation = Some(Obligation {
+                    object: Arc::clone(self),
+                    variant,
+                    request_headers: request_headers.clone(),
+                    // A replace always inserts a fresh body, so this is only ever used to decide
+                    // that a revalidating `update` is possible -- which, for a force-miss, it
+                    // isn't, since we just dropped the data.
+                    present: if force_miss { None } else { data.clone() },
+                    completed: false,
+                });
+
+                // No notification: waiters wait on obligations being *fulfilled* or abandoned,
+                // neither of which happened here.
+                false
+            });
+
+            if lost_race {
+                continue;
+            }
+            return (data, obligation);
         }
     }
 
@@ -510,6 +718,20 @@ impl Obligation {
     /// Returns a Found for the entry inserted.
     pub fn insert(mut self, options: WriteOptions, body: Body) -> Found {
         let request_headers = std::mem::take(&mut self.request_headers);
+        self.insert_with_headers(request_headers, options, body)
+    }
+
+    /// Fulfill the obligation, computing the inserted variant from the given request headers rather
+    /// than the ones the obligation was created with.
+    ///
+    /// The `replace` API needs this: the guest may set request headers on the replacement that
+    /// differ from the ones it looked up with.
+    pub fn insert_with_headers(
+        mut self,
+        request_headers: HeaderMap,
+        options: WriteOptions,
+        body: Body,
+    ) -> Found {
         let variant = std::mem::take(&mut self.variant);
         let data = self
             .object

--- a/src/component/compute/cache.rs
+++ b/src/component/compute/cache.rs
@@ -2,11 +2,11 @@ use {
     crate::component::bindings::fastly::compute::{cache as api, http_body, types},
     crate::{
         body::Body,
-        cache::{self, CacheKey, SurrogateKeySet, VaryRule, WriteOptions},
+        cache::{self, CacheKey, ReplaceStrategy, SurrogateKeySet, VaryRule, WriteOptions},
         error::Error,
         linking::{ComponentCtx, SandboxView},
-        sandbox::{PeekableTask, PendingCacheTask, Sandbox},
-        wiggle_abi::types::{AsyncItemHandle, CacheBusyHandle, CacheHandle},
+        sandbox::{PeekableTask, PendingCacheReplaceTask, PendingCacheTask, Sandbox},
+        wiggle_abi::types::{AsyncItemHandle, CacheBusyHandle, CacheHandle, CacheReplaceHandle},
     },
     bytes::Bytes,
     http::HeaderMap,
@@ -115,6 +115,58 @@ fn load_lookup_options(
     })
 }
 
+struct ReplaceOptions {
+    headers: HeaderMap,
+    strategy: ReplaceStrategy,
+    always_use_requested_range: bool,
+}
+
+fn load_replace_options(
+    sandbox: &Sandbox,
+    options: api::ReplaceOptions,
+) -> Result<ReplaceOptions, Error> {
+    let headers = if let Some(request_headers) = options.request_headers {
+        let parts = sandbox.request_parts(request_headers.into())?;
+        parts.headers.clone()
+    } else {
+        HeaderMap::default()
+    };
+
+    let strategy = match options.replace_strategy {
+        None | Some(api::ReplaceStrategy::Immediate) => ReplaceStrategy::Immediate,
+        Some(api::ReplaceStrategy::ImmediateForceMiss) => ReplaceStrategy::ImmediateForceMiss,
+        Some(api::ReplaceStrategy::Wait) => ReplaceStrategy::Wait,
+    };
+
+    Ok(ReplaceOptions {
+        headers,
+        strategy,
+        always_use_requested_range: options.always_use_requested_range,
+    })
+}
+
+/// The lookup state to report for an in-progress replace operation.
+///
+/// Unlike a lookup, a replace always carries the obligation to insert, and the state is always
+/// well-defined -- even with no existing object, in which case the state is just
+/// `MUST_INSERT_OR_UPDATE`. Note that the SDK panics if this is reported as absent.
+fn replace_lookup_state(entry: &cache::ReplaceEntry) -> api::LookupState {
+    let mut state = api::LookupState::MUST_INSERT_OR_UPDATE;
+    if let Some(existing) = entry.existing() {
+        // As in `get_state`: Compute reports FOUND only for usable objects, and SDKs (including old
+        // versions) do not check the USABLE bit.
+        if existing.meta().is_usable() {
+            state |= api::LookupState::USABLE;
+            state |= api::LookupState::FOUND;
+
+            if !existing.meta().is_fresh() {
+                state |= api::LookupState::STALE;
+            }
+        }
+    }
+    state
+}
+
 impl api::Host for ComponentCtx {
     async fn insert(
         &mut self,
@@ -142,13 +194,34 @@ impl api::Host for ComponentCtx {
 
     async fn replace_insert(
         &mut self,
-        _handle: Resource<api::ReplaceEntry>,
-        _options: api::WriteOptions,
+        handle: Resource<api::ReplaceEntry>,
+        mut options: api::WriteOptions,
     ) -> Result<Resource<api::Body>, types::Error> {
-        Err(Error::Unsupported {
-            msg: "Cache API primitives not yet supported",
-        }
-        .into())
+        // Unlike `transaction_insert`, the replace API lets the guest set the request headers of the
+        // replacement -- that's what `Replace::header()` does. If they're absent, we fall back to
+        // the headers the replace was begun with.
+        let request_headers = if let Some(handle) = options.request_headers.take() {
+            let parts = self.sandbox().request_parts(handle.into())?;
+            Some(parts.headers.clone())
+        } else {
+            None
+        };
+        let options = load_write_options(&options)?;
+
+        // Optimistically start a body, so we don't have to reborrow self.sandbox_mut()
+        let body_handle = self.sandbox_mut().insert_body(Body::empty());
+        let read_body = self.sandbox_mut().begin_streaming(body_handle)?;
+
+        // `replace_insert` consumes the replace handle.
+        let entry = self
+            .sandbox_mut()
+            .take_cache_replace_entry(handle.into())?
+            .task()
+            .recv()
+            .await?;
+        entry.insert(request_headers, options, read_body);
+
+        Ok(body_handle.into())
     }
 
     async fn await_entry(
@@ -190,12 +263,12 @@ impl api::Host for ComponentCtx {
 
     async fn close_replace_entry(
         &mut self,
-        _handle: Resource<api::ReplaceEntry>,
+        handle: Resource<api::ReplaceEntry>,
     ) -> Result<(), types::Error> {
-        Err(Error::Unsupported {
-            msg: "Cache API primitives not yet supported",
-        }
-        .into())
+        // Dropping the entry drops its obligation, if it took one, which releases any writer waiting
+        // on this object.
+        let _ = self.sandbox_mut().take_cache_replace_entry(handle.into())?;
+        Ok(())
     }
 }
 
@@ -203,95 +276,181 @@ impl api::HostReplaceEntry for ComponentCtx {
     async fn replace(
         &mut self,
         key: Vec<u8>,
-        _options: api::ReplaceOptions,
+        options: api::ReplaceOptions,
     ) -> Result<Resource<api::ReplaceEntry>, types::Error> {
-        let _key: CacheKey = get_key(key)?;
-        Err(Error::Unsupported {
-            msg: "Cache API primitives not yet supported",
-        }
-        .into())
+        let ReplaceOptions {
+            headers,
+            strategy,
+            always_use_requested_range,
+        } = load_replace_options(self.sandbox(), options)?;
+        let key: CacheKey = get_key(key)?;
+        let cache = Arc::clone(self.sandbox().cache());
+
+        let task = match strategy {
+            // These strategies never block, so we can resolve the operation right now.
+            ReplaceStrategy::Immediate | ReplaceStrategy::ImmediateForceMiss => {
+                PeekableTask::complete(
+                    cache
+                        .replace(&key, headers, strategy)
+                        .await
+                        .with_always_use_requested_range(always_use_requested_range),
+                )
+            }
+            // `Wait` may block on another writer; let it do so in the background, so that the guest
+            // can use `step` to poll for completion.
+            ReplaceStrategy::Wait => {
+                PeekableTask::spawn(Box::pin(async move {
+                    Ok(cache
+                        .replace(&key, headers, strategy)
+                        .await
+                        .with_always_use_requested_range(always_use_requested_range))
+                }))
+                .await
+            }
+        };
+
+        let handle: CacheReplaceHandle = self
+            .sandbox_mut()
+            .insert_cache_replace_op(PendingCacheReplaceTask::new(task))
+            .into();
+        Ok(handle.into())
     }
 
     async fn get_age_ns(
         &mut self,
-        _handle: Resource<api::ReplaceEntry>,
+        handle: Resource<api::ReplaceEntry>,
     ) -> Result<Option<api::DurationNs>, types::Error> {
-        Err(Error::Unsupported {
-            msg: "Cache API primitives not yet supported",
-        }
-        .into())
+        let entry = self
+            .sandbox_mut()
+            .cache_replace_entry(handle.into())
+            .await?;
+        Ok(entry
+            .existing()
+            .map(|existing| existing.meta().age().as_nanos().try_into().unwrap()))
     }
 
     async fn get_body(
         &mut self,
-        _handle: Resource<api::ReplaceEntry>,
-        _options: api::GetBodyOptions,
+        handle: Resource<api::ReplaceEntry>,
+        options: api::GetBodyOptions,
     ) -> Result<Option<Resource<http_body::Body>>, types::Error> {
-        Err(Error::Unsupported {
-            msg: "Cache API primitives not yet supported",
+        let handle: CacheReplaceHandle = handle.into();
+
+        // See the comments in `HostEntry::get_body`: we deliberately re-borrow rather than hold both
+        // a borrow of the entry and of the handle tables at once.
+        let entry = self.sandbox_mut().cache_replace_entry(handle).await?;
+        if entry.existing().is_none() {
+            return Ok(None);
         }
-        .into())
+        let body = entry.body(options.from, options.to).await?;
+
+        let existing = entry
+            .existing()
+            .ok_or(Error::CacheError(cache::Error::Missing))?;
+        if let Some(prev_handle) = existing.last_body_handle {
+            // Check if they're still reading the previous handle.
+            if self.sandbox().body(prev_handle).is_ok() {
+                return Err(Error::CacheError(cache::Error::HandleBodyUsed).into());
+            }
+        };
+
+        let body_handle = self.sandbox_mut().insert_body(body);
+        self.sandbox_mut()
+            .cache_replace_entry_mut(handle)
+            .await?
+            .existing_mut()
+            .unwrap()
+            .last_body_handle = Some(body_handle);
+
+        Ok(Some(body_handle.into()))
     }
 
     async fn get_hits(
         &mut self,
-        _handle: Resource<api::ReplaceEntry>,
+        handle: Resource<api::ReplaceEntry>,
     ) -> Result<Option<u64>, types::Error> {
-        Err(Error::Unsupported {
-            msg: "Cache API primitives not yet supported",
-        }
-        .into())
+        let entry = self
+            .sandbox_mut()
+            .cache_replace_entry(handle.into())
+            .await?;
+        Ok(entry.existing().map(|existing| existing.meta().hits()))
     }
 
     async fn get_length(
         &mut self,
-        _handle: Resource<api::ReplaceEntry>,
+        handle: Resource<api::ReplaceEntry>,
     ) -> Result<Option<u64>, types::Error> {
-        Err(Error::Unsupported {
-            msg: "Cache API primitives not yet supported",
-        }
-        .into())
+        let entry = self
+            .sandbox_mut()
+            .cache_replace_entry(handle.into())
+            .await?;
+        Ok(entry.existing().and_then(|existing| existing.length()))
     }
 
     async fn get_max_age_ns(
         &mut self,
-        _handle: Resource<api::ReplaceEntry>,
+        handle: Resource<api::ReplaceEntry>,
     ) -> Result<Option<api::DurationNs>, types::Error> {
-        Err(Error::Unsupported {
-            msg: "Cache API primitives not yet supported",
-        }
-        .into())
+        let entry = self
+            .sandbox_mut()
+            .cache_replace_entry(handle.into())
+            .await?;
+        Ok(entry
+            .existing()
+            .map(|existing| existing.meta().max_age().as_nanos().try_into().unwrap()))
     }
 
     async fn get_stale_while_revalidate_ns(
         &mut self,
-        _handle: Resource<api::ReplaceEntry>,
+        handle: Resource<api::ReplaceEntry>,
     ) -> Result<Option<api::DurationNs>, types::Error> {
-        Err(Error::Unsupported {
-            msg: "Cache API primitives not yet supported",
-        }
-        .into())
+        let entry = self
+            .sandbox_mut()
+            .cache_replace_entry(handle.into())
+            .await?;
+        Ok(entry.existing().map(|existing| {
+            existing
+                .meta()
+                .stale_while_revalidate()
+                .as_nanos()
+                .try_into()
+                .unwrap()
+        }))
     }
 
     async fn get_state(
         &mut self,
-        _handle: Resource<api::ReplaceEntry>,
+        handle: Resource<api::ReplaceEntry>,
     ) -> Result<Option<api::LookupState>, types::Error> {
-        Err(Error::Unsupported {
-            msg: "Cache API primitives not yet supported",
-        }
-        .into())
+        // NOTE: this must always report a state, even with no existing object: the SDK
+        // unconditionally calls this from `ReplaceBuilder::begin()` and panics on `none`.
+        let entry = self
+            .sandbox_mut()
+            .cache_replace_entry(handle.into())
+            .await?;
+        Ok(Some(replace_lookup_state(entry)))
     }
 
     async fn get_user_metadata(
         &mut self,
-        _handle: Resource<api::ReplaceEntry>,
-        _max_len: u64,
+        handle: Resource<api::ReplaceEntry>,
+        max_len: u64,
     ) -> Result<Option<Vec<u8>>, types::Error> {
-        Err(Error::Unsupported {
-            msg: "Cache API primitives not yet supported",
+        let entry = self
+            .sandbox_mut()
+            .cache_replace_entry(handle.into())
+            .await?;
+        let Some(md_bytes) = entry
+            .existing()
+            .map(|existing| existing.meta().user_metadata())
+        else {
+            return Ok(None);
+        };
+        let len = md_bytes.len() as u64;
+        if len > max_len {
+            return Err(types::Error::BufferLen(len));
         }
-        .into())
+        Ok(Some(md_bytes.into()))
     }
 
     fn drop(&mut self, _entry: Resource<api::ReplaceEntry>) -> wasmtime::Result<()> {
@@ -300,12 +459,17 @@ impl api::HostReplaceEntry for ComponentCtx {
 
     fn step(
         &mut self,
-        _handle: Resource<api::ReplaceEntry>,
+        handle: Resource<api::ReplaceEntry>,
     ) -> wasmtime::Result<Option<Resource<api::Pollable>>> {
-        Err(Error::Unsupported {
-            msg: "Cache API primitives not yet supported",
+        let replace_handle = CacheReplaceHandle::from(handle);
+        let async_handle = replace_handle.into();
+        let is_ready = self.sandbox_mut().async_item_mut(async_handle)?.is_ready();
+
+        if is_ready {
+            Ok(None)
+        } else {
+            Ok(Some(AsyncItemHandle::from(async_handle).into()))
         }
-        .into())
     }
 }
 
@@ -574,12 +738,17 @@ impl api::HostEntry for ComponentCtx {
 
     async fn get_stale_while_revalidate_ns(
         &mut self,
-        _handle: Resource<api::Entry>,
+        handle: Resource<api::Entry>,
     ) -> Result<Option<u64>, types::Error> {
-        Err(Error::Unsupported {
-            msg: "Cache API primitives not yet supported",
-        }
-        .into())
+        let entry = self.sandbox_mut().cache_entry_mut(handle.into()).await?;
+        Ok(entry.found().map(|found| {
+            found
+                .meta()
+                .stale_while_revalidate()
+                .as_nanos()
+                .try_into()
+                .unwrap()
+        }))
     }
 
     async fn get_age_ns(
@@ -596,12 +765,10 @@ impl api::HostEntry for ComponentCtx {
 
     async fn get_hits(
         &mut self,
-        _handle: Resource<api::Entry>,
+        handle: Resource<api::Entry>,
     ) -> Result<Option<u64>, types::Error> {
-        Err(Error::Unsupported {
-            msg: "Cache API primitives not yet supported",
-        }
-        .into())
+        let entry = self.sandbox_mut().cache_entry_mut(handle.into()).await?;
+        Ok(entry.found().map(|found| found.meta().hits()))
     }
 
     fn drop(&mut self, _entry: Resource<api::Entry>) -> wasmtime::Result<()> {

--- a/src/error.rs
+++ b/src/error.rs
@@ -422,6 +422,10 @@ pub enum HandleError {
     /// A cache handle was not valid.
     #[error("Invalid cache handle: {0}")]
     InvalidCacheHandle(crate::wiggle_abi::types::CacheHandle),
+
+    /// A cache replace handle was not valid.
+    #[error("Invalid cache replace handle: {0}")]
+    InvalidCacheReplaceHandle(crate::wiggle_abi::types::CacheReplaceHandle),
 }
 
 /// Errors that can occur in a worker thread running a guest module.

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -4,8 +4,9 @@ mod async_item;
 mod downstream;
 
 pub use async_item::{
-    AsyncItem, PeekableTask, PendingCacheTask, PendingDownstreamReqTask, PendingKvDeleteTask,
-    PendingKvInsertTask, PendingKvListTask, PendingKvLookupTask, PendingResponse,
+    AsyncItem, PeekableTask, PendingCacheReplaceTask, PendingCacheTask, PendingDownstreamReqTask,
+    PendingKvDeleteTask, PendingKvInsertTask, PendingKvListTask, PendingKvLookupTask,
+    PendingResponse,
 };
 
 use std::collections::HashMap;
@@ -17,10 +18,12 @@ use std::sync::atomic::AtomicU64;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-use crate::cache::{Cache, CacheEntry};
+use crate::cache::{Cache, CacheEntry, ReplaceEntry};
 use crate::linking::Limiter;
 use crate::object_store::KvStoreError;
-use crate::wiggle_abi::types::{CacheBusyHandle, CacheHandle, FramingHeadersMode};
+use crate::wiggle_abi::types::{
+    CacheBusyHandle, CacheHandle, CacheReplaceHandle, FramingHeadersMode,
+};
 
 use {
     self::downstream::DownstreamResponseState,
@@ -1183,6 +1186,77 @@ impl Sandbox {
             .ok_or(HandleError::InvalidCacheHandle(handle))
     }
 
+    /// Insert a pending cache replace operation.
+    pub fn insert_cache_replace_op(&mut self, task: PendingCacheReplaceTask) -> AsyncItemHandle {
+        self.async_items
+            .push(Some(AsyncItem::PendingCacheReplace(task)))
+    }
+
+    /// Returns true if the handle refers to a pending cache replace operation.
+    ///
+    /// The witx `close` hostcall is shared between cache entries and replace entries, so it has to
+    /// figure out which kind of handle it was given.
+    pub(crate) fn is_cache_replace(&self, handle: AsyncItemHandle) -> bool {
+        self.async_items
+            .get(handle)
+            .and_then(Option::as_ref)
+            .is_some_and(AsyncItem::is_pending_cache_replace)
+    }
+
+    /// Get mutable access to a replace entry, which may require blocking until the operation has
+    /// begun.
+    pub(crate) async fn cache_replace_entry_mut(
+        &mut self,
+        handle: CacheReplaceHandle,
+    ) -> Result<&mut ReplaceEntry, HandleError> {
+        self.async_items
+            .get_mut(handle.into())
+            .and_then(Option::as_mut)
+            .and_then(AsyncItem::as_pending_cache_replace_mut)
+            .map(PendingCacheReplaceTask::as_mut)
+            .ok_or(HandleError::InvalidCacheReplaceHandle(handle))?
+            .await
+            .as_mut()
+            .map_err(|e| {
+                tracing::error!("in completion of cache replace: {e}");
+                HandleError::InvalidCacheReplaceHandle(handle)
+            })
+    }
+
+    /// Get immutable access to a replace entry, which may require blocking until the operation has
+    /// begun.
+    pub(crate) async fn cache_replace_entry(
+        &mut self,
+        handle: CacheReplaceHandle,
+    ) -> Result<&ReplaceEntry, HandleError> {
+        self.async_items
+            .get_mut(handle.into())
+            .and_then(Option::as_mut)
+            .and_then(AsyncItem::as_pending_cache_replace_mut)
+            .map(PendingCacheReplaceTask::as_mut)
+            .ok_or(HandleError::InvalidCacheReplaceHandle(handle))?
+            .await
+            .as_ref()
+            .map_err(|e| {
+                tracing::error!("in completion of cache replace: {e}");
+                HandleError::InvalidCacheReplaceHandle(handle)
+            })
+    }
+
+    /// Take ownership of a `ReplaceEntry` given its handle.
+    ///
+    /// Returns a `HandleError` if the handle is not associated with a cache replace.
+    pub(crate) fn take_cache_replace_entry(
+        &mut self,
+        handle: CacheReplaceHandle,
+    ) -> Result<PendingCacheReplaceTask, HandleError> {
+        self.async_items
+            .get_mut(handle.into())
+            .and_then(Option::take)
+            .and_then(AsyncItem::into_pending_cache_replace)
+            .ok_or(HandleError::InvalidCacheReplaceHandle(handle))
+    }
+
     /// Access the cache.
     pub fn cache(&self) -> &Arc<Cache> {
         self.ctx.cache()
@@ -1657,6 +1731,18 @@ impl From<AsyncItemHandle> for CacheBusyHandle {
 
 impl From<CacheBusyHandle> for AsyncItemHandle {
     fn from(h: CacheBusyHandle) -> AsyncItemHandle {
+        AsyncItemHandle::from_u32(h.into())
+    }
+}
+
+impl From<AsyncItemHandle> for CacheReplaceHandle {
+    fn from(h: AsyncItemHandle) -> CacheReplaceHandle {
+        CacheReplaceHandle::from(h.as_u32())
+    }
+}
+
+impl From<CacheReplaceHandle> for AsyncItemHandle {
+    fn from(h: CacheReplaceHandle) -> AsyncItemHandle {
         AsyncItemHandle::from_u32(h.into())
     }
 }

--- a/src/sandbox/async_item.rs
+++ b/src/sandbox/async_item.rs
@@ -1,6 +1,6 @@
 use std::time::{Duration, Instant};
 
-use crate::cache::CacheEntry;
+use crate::cache::{CacheEntry, ReplaceEntry};
 use crate::downstream::DownstreamRequest;
 use crate::execute::NextRequest;
 use crate::http::PendingHeaders;
@@ -145,6 +145,26 @@ impl PendingCacheTask {
     }
 }
 
+/// An async item, waiting for a cache replace operation to begin.
+#[derive(Debug)]
+pub struct PendingCacheReplaceTask(PeekableTask<ReplaceEntry>);
+impl PendingCacheReplaceTask {
+    pub fn new(t: PeekableTask<ReplaceEntry>) -> PendingCacheReplaceTask {
+        PendingCacheReplaceTask(t)
+    }
+    pub fn task(self) -> PeekableTask<ReplaceEntry> {
+        self.0
+    }
+
+    /// Get a mutable reference to the ReplaceEntry, possibly blocking until it becomes available.
+    pub async fn as_mut(&mut self) -> &mut Result<ReplaceEntry, Error> {
+        self.0.await_ready().await;
+        self.0
+            .get_mut()
+            .expect("internal error: PeekableTask was not ready after AwaitReady")
+    }
+}
+
 /// Represents either a full body, or the write end of a streaming body.
 ///
 /// This enum is needed because we reuse the handle for a body when it is transformed into a streaming
@@ -160,6 +180,7 @@ pub enum AsyncItem {
     PendingKvDelete(PendingKvDeleteTask),
     PendingKvList(PendingKvListTask),
     PendingCache(PendingCacheTask),
+    PendingCacheReplace(PendingCacheReplaceTask),
     Ready,
 }
 
@@ -311,6 +332,31 @@ impl AsyncItem {
         }
     }
 
+    pub fn is_pending_cache_replace(&self) -> bool {
+        matches!(self, Self::PendingCacheReplace(_))
+    }
+
+    pub fn as_pending_cache_replace(&self) -> Option<&PendingCacheReplaceTask> {
+        match self {
+            Self::PendingCacheReplace(op) => Some(op),
+            _ => None,
+        }
+    }
+
+    pub fn as_pending_cache_replace_mut(&mut self) -> Option<&mut PendingCacheReplaceTask> {
+        match self {
+            Self::PendingCacheReplace(op) => Some(op),
+            _ => None,
+        }
+    }
+
+    pub fn into_pending_cache_replace(self) -> Option<PendingCacheReplaceTask> {
+        match self {
+            Self::PendingCacheReplace(op) => Some(op),
+            _ => None,
+        }
+    }
+
     pub fn into_pending_req(self) -> Option<PendingResponse> {
         match self {
             Self::PendingReq(req) => Some(req),
@@ -343,6 +389,7 @@ impl AsyncItem {
             Self::PendingKvDelete(req) => req.0.await_ready().await,
             Self::PendingKvList(req) => req.0.await_ready().await,
             Self::PendingCache(req) => req.0.await_ready().await,
+            Self::PendingCacheReplace(req) => req.0.await_ready().await,
             Self::Ready => (),
         }
     }
@@ -388,6 +435,12 @@ impl From<PendingKvListTask> for AsyncItem {
 impl From<PendingCacheTask> for AsyncItem {
     fn from(task: PendingCacheTask) -> Self {
         Self::PendingCache(task)
+    }
+}
+
+impl From<PendingCacheReplaceTask> for AsyncItem {
+    fn from(task: PendingCacheReplaceTask) -> Self {
+        Self::PendingCacheReplace(task)
     }
 }
 

--- a/src/wiggle_abi/cache.rs
+++ b/src/wiggle_abi/cache.rs
@@ -6,8 +6,10 @@ use bytes::Bytes;
 use http::HeaderMap;
 
 use crate::body::Body;
-use crate::cache::{CacheKey, SurrogateKeySet, VaryRule, WriteOptions};
-use crate::sandbox::{PeekableTask, PendingCacheTask, Sandbox};
+use crate::cache::{
+    CacheKey, ReplaceEntry, ReplaceStrategy, SurrogateKeySet, VaryRule, WriteOptions,
+};
+use crate::sandbox::{PeekableTask, PendingCacheReplaceTask, PendingCacheTask, Sandbox};
 use crate::wiggle_abi::types::CacheWriteOptionsMask;
 
 use super::fastly_cache::FastlyCache;
@@ -177,6 +179,137 @@ fn load_lookup_options(
     })
 }
 
+struct ReplaceOptions {
+    headers: HeaderMap,
+    strategy: ReplaceStrategy,
+    always_use_requested_range: bool,
+}
+
+fn load_replace_options(
+    sandbox: &Sandbox,
+    memory: &wiggle::GuestMemory<'_>,
+    mut options_mask: types::CacheReplaceOptionsMask,
+    options: wiggle::GuestPtr<types::CacheReplaceOptions>,
+) -> Result<ReplaceOptions, Error> {
+    let options = memory.read(options)?;
+
+    let headers = if options_mask.contains(types::CacheReplaceOptionsMask::REQUEST_HEADERS) {
+        let parts = sandbox.request_parts(options.request_headers)?;
+        parts.headers.clone()
+    } else {
+        HeaderMap::default()
+    };
+    options_mask &= !types::CacheReplaceOptionsMask::REQUEST_HEADERS;
+
+    let strategy = if options_mask.contains(types::CacheReplaceOptionsMask::REPLACE_STRATEGY) {
+        ReplaceStrategy::from_abi(options.replace_strategy).ok_or(Error::InvalidArgument)?
+    } else {
+        ReplaceStrategy::default()
+    };
+    options_mask &= !types::CacheReplaceOptionsMask::REPLACE_STRATEGY;
+
+    if options_mask.contains(types::CacheReplaceOptionsMask::SERVICE_ID) {
+        // TODO: Support service-ID-keyed hashes, for testing internal services at Fastly
+        return Err(Error::Unsupported {
+            msg: "service ID in cache replace is not supported in Viceroy",
+        });
+    }
+    options_mask &= !types::CacheReplaceOptionsMask::SERVICE_ID;
+
+    let always_use_requested_range =
+        options_mask.contains(types::CacheReplaceOptionsMask::ALWAYS_USE_REQUESTED_RANGE);
+    options_mask &= !types::CacheReplaceOptionsMask::ALWAYS_USE_REQUESTED_RANGE;
+
+    if !options_mask.is_empty() {
+        return Err(Error::NotAvailable("unknown cache replace option"));
+    }
+
+    Ok(ReplaceOptions {
+        headers,
+        strategy,
+        always_use_requested_range,
+    })
+}
+
+struct GetBodyOptions {
+    from: Option<u64>,
+    to: Option<u64>,
+}
+
+fn load_get_body_options(
+    mut options_mask: types::CacheGetBodyOptionsMask,
+    options: &types::CacheGetBodyOptions,
+) -> Result<GetBodyOptions, Error> {
+    let from = if options_mask.contains(types::CacheGetBodyOptionsMask::FROM) {
+        Some(options.from)
+    } else {
+        None
+    };
+    options_mask &= !types::CacheGetBodyOptionsMask::FROM;
+    let to = if options_mask.contains(types::CacheGetBodyOptionsMask::TO) {
+        Some(options.to)
+    } else {
+        None
+    };
+    options_mask &= !types::CacheGetBodyOptionsMask::TO;
+
+    if !options_mask.is_empty() {
+        return Err(Error::NotAvailable("unknown cache get_body option"));
+    }
+
+    Ok(GetBodyOptions { from, to })
+}
+
+/// Copy user metadata out to the guest, reporting the required length if the buffer is too small.
+fn write_user_metadata(
+    memory: &mut wiggle::GuestMemory<'_>,
+    md_bytes: &[u8],
+    out_ptr: wiggle::GuestPtr<u8>,
+    out_len: u32,
+    nwritten_out: wiggle::GuestPtr<u32>,
+) -> Result<(), Error> {
+    let len: u32 = md_bytes
+        .len()
+        .try_into()
+        .expect("user metadata must be shorter than u32 can indicate");
+    if len > out_len {
+        memory.write(nwritten_out, len)?;
+        return Err(Error::BufferLengthError {
+            buf: "user_metadata_out_ptr",
+            len: "user_metadata_out_len",
+        });
+    }
+    let user_metadata = memory
+        .as_slice_mut(out_ptr.as_array(out_len))?
+        .ok_or(Error::SharedMemory)?;
+    user_metadata[..(len as usize)].copy_from_slice(md_bytes);
+    memory.write(nwritten_out, len)?;
+
+    Ok(())
+}
+
+/// The lookup state to report for an in-progress replace operation.
+///
+/// Unlike a lookup, a replace always carries the obligation to insert, and the state is always
+/// well-defined -- even with no existing object, in which case the state is just
+/// `MUST_INSERT_OR_UPDATE`.
+fn replace_lookup_state(entry: &ReplaceEntry) -> types::CacheLookupState {
+    let mut state = types::CacheLookupState::MUST_INSERT_OR_UPDATE;
+    if let Some(existing) = entry.existing() {
+        // As in `get_state`: Compute reports FOUND only for usable objects, and SDKs (including old
+        // versions) don't check the USABLE bit.
+        if existing.meta().is_usable() {
+            state |= types::CacheLookupState::USABLE;
+            state |= types::CacheLookupState::FOUND;
+
+            if !existing.meta().is_fresh() {
+                state |= types::CacheLookupState::STALE;
+            }
+        }
+    }
+    state
+}
+
 #[allow(unused_variables)]
 impl FastlyCache for Sandbox {
     async fn lookup(
@@ -245,7 +378,39 @@ impl FastlyCache for Sandbox {
         options_mask: types::CacheReplaceOptionsMask,
         abi_options: wiggle::GuestPtr<types::CacheReplaceOptions>,
     ) -> Result<types::CacheReplaceHandle, Error> {
-        Err(Error::NotAvailable("Cache API primitives"))
+        let ReplaceOptions {
+            headers,
+            strategy,
+            always_use_requested_range,
+        } = load_replace_options(self, memory, options_mask, abi_options)?;
+        let key = load_cache_key(memory, cache_key)?;
+        let cache = Arc::clone(self.cache());
+
+        let task = match strategy {
+            // These strategies never block, so we can resolve the operation right now.
+            ReplaceStrategy::Immediate | ReplaceStrategy::ImmediateForceMiss => {
+                PeekableTask::complete(
+                    cache
+                        .replace(&key, headers, strategy)
+                        .await
+                        .with_always_use_requested_range(always_use_requested_range),
+                )
+            }
+            // `Wait` may block on another writer; let it do so in the background, so that the guest
+            // can use `step` to poll for completion.
+            ReplaceStrategy::Wait => {
+                PeekableTask::spawn(Box::pin(async move {
+                    Ok(cache
+                        .replace(&key, headers, strategy)
+                        .await
+                        .with_always_use_requested_range(always_use_requested_range))
+                }))
+                .await
+            }
+        };
+
+        let handle = self.insert_cache_replace_op(PendingCacheReplaceTask::new(task));
+        Ok(handle.into())
     }
 
     async fn replace_get_age_ns(
@@ -253,7 +418,12 @@ impl FastlyCache for Sandbox {
         memory: &mut wiggle::GuestMemory<'_>,
         cache_handle: types::CacheReplaceHandle,
     ) -> Result<types::CacheDurationNs, Error> {
-        Err(Error::NotAvailable("Cache API primitives"))
+        let existing = self
+            .cache_replace_entry(cache_handle)
+            .await?
+            .existing()
+            .ok_or(Error::CacheError(crate::cache::Error::Missing))?;
+        Ok(existing.meta().age().as_nanos().try_into().unwrap())
     }
 
     async fn replace_get_body(
@@ -263,7 +433,32 @@ impl FastlyCache for Sandbox {
         options_mask: types::CacheGetBodyOptionsMask,
         options: &types::CacheGetBodyOptions,
     ) -> Result<types::BodyHandle, Error> {
-        Err(Error::NotAvailable("Cache API primitives"))
+        let GetBodyOptions { from, to } = load_get_body_options(options_mask, options)?;
+
+        // See the comments in `get_body`: we deliberately re-borrow rather than hold both a borrow
+        // of the entry and of the handle tables at once.
+        let entry = self.cache_replace_entry(cache_handle).await?;
+        let body = entry.body(from, to).await?;
+
+        let existing = entry
+            .existing()
+            .ok_or(Error::CacheError(crate::cache::Error::Missing))?;
+
+        if let Some(prev_handle) = existing.last_body_handle {
+            // Check if they're still reading the previous handle.
+            if self.body(prev_handle).is_ok() {
+                return Err(Error::CacheError(crate::cache::Error::HandleBodyUsed));
+            }
+        };
+
+        let body_handle = self.insert_body(body);
+        self.cache_replace_entry_mut(cache_handle)
+            .await?
+            .existing_mut()
+            .unwrap()
+            .last_body_handle = Some(body_handle);
+
+        Ok(body_handle)
     }
 
     async fn replace_get_hits(
@@ -271,7 +466,12 @@ impl FastlyCache for Sandbox {
         memory: &mut wiggle::GuestMemory<'_>,
         cache_handle: types::CacheReplaceHandle,
     ) -> Result<u64, Error> {
-        Err(Error::NotAvailable("Cache API primitives"))
+        let existing = self
+            .cache_replace_entry(cache_handle)
+            .await?
+            .existing()
+            .ok_or(Error::CacheError(crate::cache::Error::Missing))?;
+        Ok(existing.meta().hits())
     }
 
     async fn replace_get_length(
@@ -279,7 +479,11 @@ impl FastlyCache for Sandbox {
         memory: &mut wiggle::GuestMemory<'_>,
         cache_handle: types::CacheReplaceHandle,
     ) -> Result<u64, Error> {
-        Err(Error::NotAvailable("Cache API primitives"))
+        self.cache_replace_entry(cache_handle)
+            .await?
+            .existing()
+            .and_then(|existing| existing.length())
+            .ok_or(Error::CacheError(crate::cache::Error::Missing))
     }
 
     async fn replace_get_max_age_ns(
@@ -287,7 +491,12 @@ impl FastlyCache for Sandbox {
         memory: &mut wiggle::GuestMemory<'_>,
         cache_handle: types::CacheReplaceHandle,
     ) -> Result<types::CacheDurationNs, Error> {
-        Err(Error::NotAvailable("Cache API primitives"))
+        let existing = self
+            .cache_replace_entry(cache_handle)
+            .await?
+            .existing()
+            .ok_or(Error::CacheError(crate::cache::Error::Missing))?;
+        Ok(existing.meta().max_age().as_nanos().try_into().unwrap())
     }
 
     async fn replace_get_stale_while_revalidate_ns(
@@ -295,7 +504,17 @@ impl FastlyCache for Sandbox {
         memory: &mut wiggle::GuestMemory<'_>,
         cache_handle: types::CacheReplaceHandle,
     ) -> Result<types::CacheDurationNs, Error> {
-        Err(Error::NotAvailable("Cache API primitives"))
+        let existing = self
+            .cache_replace_entry(cache_handle)
+            .await?
+            .existing()
+            .ok_or(Error::CacheError(crate::cache::Error::Missing))?;
+        Ok(existing
+            .meta()
+            .stale_while_revalidate()
+            .as_nanos()
+            .try_into()
+            .unwrap())
     }
 
     async fn replace_get_state(
@@ -303,7 +522,10 @@ impl FastlyCache for Sandbox {
         memory: &mut wiggle::GuestMemory<'_>,
         cache_handle: types::CacheReplaceHandle,
     ) -> Result<types::CacheLookupState, Error> {
-        Err(Error::NotAvailable("Cache API primitives"))
+        // NOTE: this must never fail when there is no existing object: the SDK unconditionally
+        // calls this hostcall from `ReplaceBuilder::begin()` and panics on any non-OK status.
+        let entry = self.cache_replace_entry(cache_handle).await?;
+        Ok(replace_lookup_state(entry))
     }
 
     async fn replace_get_user_metadata(
@@ -314,7 +536,13 @@ impl FastlyCache for Sandbox {
         out_len: u32,
         nwritten_out: wiggle::GuestPtr<u32>,
     ) -> Result<(), Error> {
-        Err(Error::NotAvailable("Cache API primitives"))
+        let md_bytes = self
+            .cache_replace_entry(cache_handle)
+            .await?
+            .existing()
+            .map(|existing| existing.meta().user_metadata())
+            .ok_or(Error::CacheError(crate::cache::Error::Missing))?;
+        write_user_metadata(memory, &md_bytes, out_ptr, out_len, nwritten_out)
     }
 
     async fn replace_insert(
@@ -324,7 +552,36 @@ impl FastlyCache for Sandbox {
         options_mask: types::CacheWriteOptionsMask,
         abi_options: wiggle::GuestPtr<types::CacheWriteOptions>,
     ) -> Result<types::BodyHandle, Error> {
-        Err(Error::NotAvailable("Cache API primitives"))
+        let guest_options = memory.read(abi_options)?;
+
+        // Unlike `transaction_insert`, the replace API lets the guest set the request headers of the
+        // replacement -- that's what `Replace::header()` does. If they're absent, we fall back to
+        // the headers the replace was begun with.
+        let request_headers = if options_mask.contains(CacheWriteOptionsMask::REQUEST_HEADERS) {
+            let handle = guest_options.request_headers;
+            Some(self.request_parts(handle)?.headers.clone())
+        } else {
+            None
+        };
+        let options = load_write_options(
+            memory,
+            options_mask & !CacheWriteOptionsMask::REQUEST_HEADERS,
+            &guest_options,
+        )?;
+
+        // Optimistically start a body, so we don't have to reborrow &mut self.
+        let body_handle = self.insert_body(Body::empty());
+        let read_body = self.begin_streaming(body_handle)?;
+
+        // `replace_insert` consumes the replace handle.
+        let entry = self
+            .take_cache_replace_entry(cache_handle)?
+            .task()
+            .recv()
+            .await?;
+        entry.insert(request_headers, options, read_body);
+
+        Ok(body_handle)
     }
 
     async fn transaction_lookup(
@@ -488,6 +745,17 @@ impl FastlyCache for Sandbox {
         memory: &mut wiggle::GuestMemory<'_>,
         handle: types::CacheHandle,
     ) -> Result<(), Error> {
+        // `close` is shared between cache entries and replace entries: the SDK's
+        // `CacheReplaceHandle` closes itself through this hostcall, so dispatch on what the handle
+        // actually refers to.
+        //
+        // Dropping a replace entry drops its obligation, if it took one, which releases any writer
+        // waiting on this object.
+        let async_handle: crate::sandbox::AsyncItemHandle = handle.into();
+        if self.is_cache_replace(async_handle) {
+            let _ = self.take_cache_replace_entry(async_handle.into())?;
+            return Ok(());
+        }
         let _ = self.take_cache_entry(handle)?.task().recv().await?;
         Ok(())
     }
@@ -534,49 +802,23 @@ impl FastlyCache for Sandbox {
             .found()
             .map(|found| found.meta().user_metadata())
             .ok_or(crate::Error::CacheError(crate::cache::Error::Missing))?;
-        let len: u32 = md_bytes
-            .len()
-            .try_into()
-            .expect("user metadata must be shorter than u32 can indicate");
-        if len > user_metadata_out_len {
-            memory.write(nwritten_out, len)?;
-            return Err(Error::BufferLengthError {
-                buf: "user_metadata_out_ptr",
-                len: "user_metadata_out_len",
-            });
-        }
-        let user_metadata = memory
-            .as_slice_mut(user_metadata_out_ptr.as_array(user_metadata_out_len))?
-            .ok_or(Error::SharedMemory)?;
-        user_metadata[..(len as usize)].copy_from_slice(&md_bytes);
-        memory.write(nwritten_out, len)?;
-
-        Ok(())
+        write_user_metadata(
+            memory,
+            &md_bytes,
+            user_metadata_out_ptr,
+            user_metadata_out_len,
+            nwritten_out,
+        )
     }
 
     async fn get_body(
         &mut self,
         memory: &mut wiggle::GuestMemory<'_>,
         handle: types::CacheHandle,
-        mut options_mask: types::CacheGetBodyOptionsMask,
+        options_mask: types::CacheGetBodyOptionsMask,
         options: &types::CacheGetBodyOptions,
     ) -> Result<types::BodyHandle, Error> {
-        let from = if options_mask.contains(types::CacheGetBodyOptionsMask::FROM) {
-            Some(options.from)
-        } else {
-            None
-        };
-        options_mask &= !types::CacheGetBodyOptionsMask::FROM;
-        let to = if options_mask.contains(types::CacheGetBodyOptionsMask::TO) {
-            Some(options.to)
-        } else {
-            None
-        };
-        options_mask &= !types::CacheGetBodyOptionsMask::TO;
-
-        if !options_mask.is_empty() {
-            return Err(Error::NotAvailable("unknown cache get_body option"));
-        }
+        let GetBodyOptions { from, to } = load_get_body_options(options_mask, options)?;
 
         // We wind up re-borrowing `found` and `self.sandbox` several times here, to avoid
         // borrowing the both of them at once.
@@ -650,7 +892,17 @@ impl FastlyCache for Sandbox {
         memory: &mut wiggle::GuestMemory<'_>,
         handle: types::CacheHandle,
     ) -> Result<types::CacheDurationNs, Error> {
-        Err(Error::NotAvailable("Cache API primitives"))
+        let entry = self.cache_entry_mut(handle).await?;
+        if let Some(found) = entry.found() {
+            Ok(found
+                .meta()
+                .stale_while_revalidate()
+                .as_nanos()
+                .try_into()
+                .unwrap())
+        } else {
+            Err(Error::CacheError(crate::cache::Error::Missing))
+        }
     }
 
     async fn get_age_ns(
@@ -671,6 +923,11 @@ impl FastlyCache for Sandbox {
         memory: &mut wiggle::GuestMemory<'_>,
         handle: types::CacheHandle,
     ) -> Result<types::CacheHitCount, Error> {
-        Err(Error::NotAvailable("Cache API primitives"))
+        let entry = self.cache_entry_mut(handle).await?;
+        if let Some(found) = entry.found() {
+            Ok(found.meta().hits())
+        } else {
+            Err(Error::CacheError(crate::cache::Error::Missing))
+        }
     }
 }

--- a/test-fixtures/src/bin/cache.rs
+++ b/test-fixtures/src/bin/cache.rs
@@ -70,6 +70,15 @@ fn main() {
     run_test!(test_stream_back);
     run_test!(test_stream_back_fixed);
 
+    run_test!(test_hits_and_stale_while_revalidate);
+    run_test!(test_replace_no_existing);
+    run_test!(test_replace_existing);
+    run_test!(test_replace_counter);
+    run_test!(test_replace_force_miss);
+    run_test!(test_replace_dropped);
+    run_test!(test_replace_vary);
+    run_test!(test_replace_surrogate_keys);
+
     eprintln!("Completed all tests for version {service}")
 }
 
@@ -123,6 +132,27 @@ fn poll_known_length(key: &CacheKey) -> Found {
         "did not arrive at known-length after {} seconds",
         TIMEOUT.as_secs()
     );
+}
+
+/// Insert an object with a known length, and wait for the write to complete.
+fn write_object(key: &CacheKey, body: &str, max_age: Duration) {
+    let mut writer = insert(key.clone(), max_age)
+        .known_length(body.len() as u64)
+        .execute()
+        .unwrap();
+    writer.write_all(body.as_bytes()).unwrap();
+    writer.finish().unwrap();
+}
+
+/// Read a cached object's body, asserting that the object is present.
+fn read_object(key: &CacheKey) -> String {
+    lookup(key.clone())
+        .execute()
+        .unwrap()
+        .expect("object should be cached")
+        .to_stream()
+        .unwrap()
+        .into_string()
 }
 
 fn test_non_concurrent() {
@@ -1356,6 +1386,317 @@ fn test_stream_back_fixed() {
     let got = got.into_string();
 
     assert_eq!(&got, &body[6..=14]);
+}
+
+fn test_hits_and_stale_while_revalidate() {
+    let key = new_key();
+
+    {
+        let mut writer = insert(key.clone(), Duration::from_secs(140))
+            .stale_while_revalidate(Duration::from_secs(60))
+            .execute()
+            .unwrap();
+        write!(writer, "hello").unwrap();
+        writer.finish().unwrap();
+    }
+
+    let first = lookup(key.clone()).execute().unwrap().expect("is found");
+    assert_eq!(first.stale_while_revalidate(), Duration::from_secs(60));
+
+    // We can't assert an exact hit count -- the platform counts hits per cache node -- but the
+    // count must not go backwards as we keep reading the same object.
+    let first_hits = first.hits();
+    let second = lookup(key.clone()).execute().unwrap().expect("is found");
+    let second_hits = second.hits();
+    assert!(
+        second_hits >= first_hits,
+        "hit count went backwards: {first_hits} then {second_hits}"
+    );
+}
+
+fn test_replace_no_existing() {
+    let key = new_key();
+
+    let current = replace(key.clone()).begin().expect("failed to begin replace");
+    assert!(current.existing_object().is_none());
+
+    let body = "hello replacement";
+    let mut writer = current
+        .known_length(body.len() as u64)
+        .execute(Duration::from_secs(141))
+        .unwrap();
+    writer.write_all(body.as_bytes()).unwrap();
+    writer.finish().unwrap();
+
+    let found = lookup(key).execute().unwrap().expect("is found");
+    assert_eq!(found.max_age(), Duration::from_secs(141));
+    assert_eq!(&found.to_stream().unwrap().into_string(), body);
+}
+
+fn test_replace_existing() {
+    let key = new_key();
+
+    let original = "the original object";
+    {
+        let mut writer = insert(key.clone(), Duration::from_secs(142))
+            .initial_age(Duration::from_secs(3))
+            .stale_while_revalidate(Duration::from_secs(60))
+            .known_length(original.len() as u64)
+            .user_metadata(Bytes::from_static(b"version 1"))
+            .execute()
+            .unwrap();
+        writer.write_all(original.as_bytes()).unwrap();
+        writer.finish().unwrap();
+    }
+
+    let current = replace(key.clone()).begin().expect("failed to begin replace");
+    {
+        let existing = current.existing_object().expect("existing object");
+        assert_eq!(existing.max_age(), Duration::from_secs(142));
+        assert!(existing.age() >= Duration::from_secs(3));
+        assert_eq!(existing.stale_while_revalidate(), Duration::from_secs(60));
+        assert_eq!(existing.known_length(), Some(original.len() as u64));
+        assert_eq!(existing.user_metadata().iter().as_slice(), b"version 1");
+        assert!(existing.is_usable());
+        assert!(!existing.is_stale());
+        // Just check that reading the hit count works; how a replace affects it is unspecified.
+        let _ = existing.hits();
+        assert_eq!(&existing.to_stream().unwrap().into_string(), original);
+    }
+
+    let replacement = "the replacement object";
+    let mut writer = current
+        .known_length(replacement.len() as u64)
+        .user_metadata(Bytes::from_static(b"version 2"))
+        .execute(Duration::from_secs(143))
+        .unwrap();
+    writer.write_all(replacement.as_bytes()).unwrap();
+    writer.finish().unwrap();
+
+    let found = lookup(key).execute().unwrap().expect("is found");
+    assert_eq!(found.max_age(), Duration::from_secs(143));
+    assert_eq!(found.user_metadata().iter().as_slice(), b"version 2");
+    assert_eq!(&found.to_stream().unwrap().into_string(), replacement);
+}
+
+fn test_replace_counter() {
+    let key = new_key();
+
+    // The read-modify-write pattern: each `Wait` replace waits for any in-progress update, so it
+    // observes the value written by the previous one.
+    for expected in 0..4u32 {
+        let current = replace(key.clone())
+            .replace_strategy(ReplaceStrategy::Wait)
+            .begin()
+            .expect("failed to begin replace");
+
+        let count = match current.existing_object() {
+            None => 0,
+            Some(existing) => existing
+                .to_stream()
+                .unwrap()
+                .into_string()
+                .parse::<u32>()
+                .expect("cached object should be a count"),
+        };
+        assert_eq!(count, expected);
+
+        let next = (count + 1).to_string();
+        let mut writer = current
+            .known_length(next.len() as u64)
+            .execute(Duration::from_secs(144))
+            .unwrap();
+        writer.write_all(next.as_bytes()).unwrap();
+        writer.finish().unwrap();
+    }
+
+    assert_eq!(read_object(&key), "4");
+}
+
+fn test_replace_force_miss() {
+    // The default `Immediate` strategy leaves the existing object in place until the replacement
+    // is provided.
+    {
+        let key = new_key();
+        write_object(&key, "original", Duration::from_secs(145));
+
+        let current = replace(key.clone()).begin().expect("failed to begin replace");
+        assert!(current.existing_object().is_some());
+        assert_eq!(
+            read_object(&key),
+            "original",
+            "an Immediate replace should leave the existing object visible"
+        );
+
+        let replacement = "replacement";
+        let mut writer = current
+            .known_length(replacement.len() as u64)
+            .execute(Duration::from_secs(146))
+            .unwrap();
+        writer.write_all(replacement.as_bytes()).unwrap();
+        writer.finish().unwrap();
+
+        assert_eq!(read_object(&key), replacement);
+    }
+
+    // `ImmediateForceMiss` removes the existing object right away, so other requests for it wait
+    // for the replacement instead of being served the old object.
+    {
+        let key = new_key();
+        write_object(&key, "original", Duration::from_secs(147));
+
+        let current = replace(key.clone())
+            .replace_strategy(ReplaceStrategy::ImmediateForceMiss)
+            .begin()
+            .expect("failed to begin replace");
+        // The replace itself still has access to the object it is replacing.
+        let existing = current.existing_object().expect("existing object");
+        assert_eq!(existing.to_stream().unwrap().into_string(), "original");
+
+        let pending = Transaction::lookup(key.clone()).execute_async().unwrap();
+        assert!(
+            pending.pending().expect("error checking status"),
+            "a lookup during a force-miss replace should wait for the replacement"
+        );
+
+        let replacement = "replacement";
+        let mut writer = current
+            .known_length(replacement.len() as u64)
+            .execute(Duration::from_secs(148))
+            .unwrap();
+        writer.write_all(replacement.as_bytes()).unwrap();
+        writer.finish().unwrap();
+
+        let txn = pending.wait().unwrap();
+        let found = txn.found().expect("the waiting lookup should be satisfied");
+        assert_eq!(found.to_stream().unwrap().into_string(), replacement);
+    }
+}
+
+fn test_replace_dropped() {
+    let key = new_key();
+    write_object(&key, "original", Duration::from_secs(149));
+
+    // Dropping a replace without calling execute() leaves the existing object alone.
+    {
+        let current = replace(key.clone()).begin().expect("failed to begin replace");
+        assert!(current.existing_object().is_some());
+    }
+    assert_eq!(read_object(&key), "original");
+
+    // The same is true of a `Wait` replace, and abandoning it must not block the next one: if the
+    // abandoned replace kept other updates waiting, the replace below would never begin.
+    {
+        let current = replace(key.clone())
+            .replace_strategy(ReplaceStrategy::Wait)
+            .begin()
+            .expect("failed to begin replace");
+        assert!(current.existing_object().is_some());
+    }
+    assert_eq!(read_object(&key), "original");
+
+    let replacement = "replacement";
+    let mut writer = replace(key.clone())
+        .replace_strategy(ReplaceStrategy::Wait)
+        .begin()
+        .expect("failed to begin replace")
+        .known_length(replacement.len() as u64)
+        .execute(Duration::from_secs(150))
+        .unwrap();
+    writer.write_all(replacement.as_bytes()).unwrap();
+    writer.finish().unwrap();
+
+    assert_eq!(read_object(&key), replacement);
+}
+
+fn test_replace_vary() {
+    let key = new_key();
+    let header_name = HeaderName::from_static("x-viceroy-test");
+
+    let original = "original foo";
+    {
+        let mut writer = insert(key.clone(), Duration::from_secs(151))
+            .header(&header_name, "foo")
+            .vary_by([&header_name])
+            .known_length(original.len() as u64)
+            .execute()
+            .unwrap();
+        writer.write_all(original.as_bytes()).unwrap();
+        writer.finish().unwrap();
+    }
+
+    // Without the header, the replace doesn't find the varied object -- just like a lookup.
+    {
+        let current = replace(key.clone()).begin().expect("failed to begin replace");
+        assert!(current.existing_object().is_none());
+    }
+
+    // With the matching header it does. The replacement repeats the header and the vary rule, so
+    // that later lookups can still find it.
+    let replacement = "replacement foo";
+    {
+        let current = replace(key.clone())
+            .header(&header_name, "foo")
+            .begin()
+            .expect("failed to begin replace");
+        {
+            let existing = current.existing_object().expect("existing object");
+            assert_eq!(&existing.to_stream().unwrap().into_string(), original);
+        }
+
+        let mut writer = current
+            .header(&header_name, "foo")
+            .vary_by([&header_name])
+            .known_length(replacement.len() as u64)
+            .execute(Duration::from_secs(152))
+            .unwrap();
+        writer.write_all(replacement.as_bytes()).unwrap();
+        writer.finish().unwrap();
+    }
+
+    let found = lookup(key.clone())
+        .header(&header_name, "foo")
+        .execute()
+        .unwrap()
+        .expect("is found");
+    assert_eq!(&found.to_stream().unwrap().into_string(), replacement);
+
+    // The variant without the header still doesn't exist.
+    assert!(lookup(key).execute().unwrap().is_none());
+}
+
+fn test_replace_surrogate_keys() {
+    let key = new_key();
+
+    {
+        let mut writer = insert(key.clone(), Duration::from_secs(153))
+            .surrogate_keys(["replace-key-old"])
+            .known_length(8)
+            .execute()
+            .unwrap();
+        writer.write_all(b"original").unwrap();
+        writer.finish().unwrap();
+    }
+
+    let replacement = "replacement";
+    let mut writer = replace(key.clone())
+        .begin()
+        .expect("failed to begin replace")
+        .surrogate_keys(["replace-key-new"])
+        .known_length(replacement.len() as u64)
+        .execute(Duration::from_secs(154))
+        .unwrap();
+    writer.write_all(replacement.as_bytes()).unwrap();
+    writer.finish().unwrap();
+
+    // The replacement only carries the surrogate keys it was given, so the original's key no
+    // longer purges it...
+    fastly::http::purge::purge_surrogate_key("replace-key-old").unwrap();
+    assert_eq!(read_object(&key), replacement);
+
+    // ...but the replacement's own key does.
+    fastly::http::purge::purge_surrogate_key("replace-key-new").unwrap();
+    assert!(lookup(key).execute().unwrap().is_none());
 }
 
 fn test_simple_cache_expires() {


### PR DESCRIPTION
This addresses https://github.com/fastly/Viceroy/issues/495, and closes it.

`fastly::cache::core::replace()` was the last unimplemented piece of the core cache API. Every `replace*` hostcall returned `NotAvailable("Cache API primitives")` (witx) or `Unsupported` (component), so [`ReplaceBuilder::begin()`](https://docs.rs/fastly/latest/fastly/cache/core/struct.ReplaceBuilder.html#method.begin) failed immediately and read-modify-write patterns such as a cached counter could not be tested locally at all.

This implements the whole family in both host paths. No `.witx`, `.wit`, or adapter changes were needed — that surface was already declared and adapted.

## Semantics

A replace reads the current object for the request's variant and then writes a new one, which maps onto the existing `CacheValue`/`Obligation` machinery. The strategy decides how it interacts with the obligation slot:

| Strategy | At `replace()` | At `replace_insert()` |
| --- | --- | --- |
| `Immediate` (default) | Read the matching variant; don't wait, don't take the obligation. The existing object stays visible to lookups. | Plain insert — last writer wins, like non-transactional `insert`. |
| `ImmediateForceMiss` | Same read, then clear `present` for the matching variants under the write lock and take the obligation, so concurrent lookups wait for the replacement instead of being served the old object. | Fulfill the obligation, waking waiters. |
| `Wait` | Block until no matching variant is obligated, then take the slot. This serialization is what makes the counter pattern correct. | Fulfill the obligation. |

The existing object is returned regardless of freshness (the docs note it "may be stale"); freshness only shows up in the lookup state, where `MUST_INSERT_OR_UPDATE` is always set. `Obligation`'s existing `Drop` impl already gives the right "replace abandoned" behavior, so closing or dropping a replace handle needs nothing new.

Two SDK behaviors worth calling out, since they turn host-side "not supported" into guest panics rather than errors:

- `ReplaceBuilder::begin()` calls `replace_get_state` unconditionally and panics on any status other than OK, **including `NONE`** — so `replace_get_state` always succeeds, returning empty flags when there is no existing object.
- `Found::hits()` and `Found::stale_while_revalidate()` panic when the host reports `unsupported`, and `Replace::existing_object()` returns exactly that `Found`. Both were unimplemented for plain lookups too, so this closes those gaps as well. Hits are counted on delivery through a counter shared between the cached object and the `Found` handed to the guest; a replace reading the object it is about to replace does not count as a hit.

## Known deviations

Both are commented at their definitions:

- With `ImmediateForceMiss`, if another party already holds the obligation we clear `present` but cannot take a second one (the store's invariant is one `Obligation` per obligated `CacheValue`), so we fall back to a racing plain insert.
- A guest that starts a `Wait` replace while itself holding an unfulfilled obligation blocks forever, where Compute would eventually time out. No timeout was added.

## Tests

Rust unit tests in `src/cache.rs` cover each strategy, an abandoned replace releasing its obligation, a replacement inserted under a different vary rule, and the hits/`stale_while_revalidate` round-trip. Four concurrent `Wait` replaces starting from "1" produce "5", which is the property the counter pattern depends on.

Eight guest tests were added to `test-fixtures/src/bin/cache.rs`, so they run against both ABI paths via the existing `viceroy_test!` configurations. Since this fixture is also meant to pass on real Compute, assertions stick to documented behavior — e.g. hit counts are asserted monotonic rather than exact, and the force-miss test uses a transactional lookup, because "requests wait for the replacement" is the documented behavior and is well-defined on both.

`cargo test --all` passes (176 integration + 132 lib tests). `cargo clippy --all-targets --all-features` reports only pre-existing warnings in `http_downstream.rs`/`backend.rs`. The only `Unsupported` returns left in the cache hostcalls are the deliberate `on_behalf_of`/service-ID ones, matching the existing lookup and insert paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
