### PR TITLE
Update to the latest WITs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 - Avoid using bindings::sync functions in WASI implementations. ([#700](https://github.com/fastly/Viceroy/pull/700))
 - Implement cache_override_v3_set in the component adapter. ([#703](https://github.com/fastly/Viceroy/pull/703))
+- Update to the latest WITs. ([#701](https://github.com/fastly/Viceroy/pull/701))
 
 ## 0.21.0 (2026-08-25)
 

--- a/src/component.rs
+++ b/src/component.rs
@@ -76,6 +76,7 @@ pub(crate) mod bindings {
             "fastly:compute/kv-store.[method]store.lookup-async": async | tracing,
             "fastly:compute/http-downstream.next-request": async | tracing,
             "fastly:compute/http-body.read": async | tracing,
+            "fastly:compute/backend.[method]backend.clone": tracing | trappable,
             "fastly:compute/backend.register-dynamic-backend": async | tracing,
             "fastly:compute/async-io.select": async | tracing | trappable,
             "fastly:compute/async-io.select-with-timeout": async | tracing,
@@ -90,6 +91,7 @@ pub(crate) mod bindings {
             "fastly:compute/cache.[static]entry.transaction-lookup-async": async | tracing,
             "fastly:compute/http-body.write": async | tracing,
             "fastly:compute/http-body.write-front": async | tracing,
+            "fastly:compute/log.[method]endpoint.clone": tracing | trappable,
 
             // Match the `wasmtime-wasi` crate's bindings.
             "wasi:io/streams.[method]output-stream.write": tracing | trappable,

--- a/src/component/compute/backend.rs
+++ b/src/component/compute/backend.rs
@@ -39,6 +39,17 @@ impl backend::HostBackend for ComponentCtx {
         Ok(res)
     }
 
+    fn clone(
+        &mut self,
+        backend_res: Resource<String>,
+    ) -> Result<Resource<String>, wasmtime::Error> {
+        let backend = self.wasi_table.get(&backend_res)?;
+
+        let res = self.wasi_table.push(backend.clone())?;
+
+        Ok(res)
+    }
+
     fn get_name(&mut self, name: Resource<String>) -> String {
         self.wasi_table.get(&name).unwrap().to_owned()
     }

--- a/src/component/compute/log.rs
+++ b/src/component/compute/log.rs
@@ -30,6 +30,13 @@ impl log::HostEndpoint for ComponentCtx {
         Ok(self.sandbox_mut().log_endpoint_handle(name).into())
     }
 
+    fn clone(
+        &mut self,
+        h: Resource<log::Endpoint>,
+    ) -> Result<Resource<log::Endpoint>, wasmtime::Error> {
+        Ok(h)
+    }
+
     fn write(&mut self, h: Resource<log::Endpoint>, msg: Vec<u8>) {
         let endpoint = self.sandbox().log_endpoint(h.into()).unwrap();
 

--- a/wasm_abi/wit/deps/fastly/compute.wit
+++ b/wasm_abi/wit/deps/fastly/compute.wit
@@ -355,6 +355,9 @@ interface log {
     /// events.
     open: static func(name: string) -> result<endpoint, open-error>;
 
+    /// Returns a new owned handle to the same endpoint.
+    clone: func() -> endpoint;
+
     /// Writes a data to the given endpoint.
     ///
     /// Each call to `write` with a non-empty message produces a single log event.
@@ -1925,7 +1928,7 @@ interface backend {
     ///
     /// For more information, see [the Fastly documentation on override hosts].
     ///
-    /// [the Fastly documentation on override hosts]: https://docs.fastly.com/en/guides/specifying-an-override-host>
+    /// [the Fastly documentation on override hosts]: https://docs.fastly.com/en/guides/specifying-an-override-host
     override-host: func(value: string);
 
     /// Sets the connection timeout, in milliseconds, for this backend.
@@ -2154,6 +2157,9 @@ interface backend {
       /// Attempts to open the named static backend.
       open: static func(name: string) -> result<backend, open-error>;
 
+      /// Returns a new owned handle to the same backend.
+      clone: func() -> backend;
+
       /// Returns the name of this backend.
       get-name: func() -> string;
 
@@ -2318,6 +2324,8 @@ interface purge {
   /// A surrogate key can be a max of 1024 characters.
   /// A surrogate key must contain only printable ASCII characters (those between `0x21` and `0x7E`,
   /// inclusive).
+  ///
+  /// Despite the name, the `surrogate-keys` argument only holds one key.
   purge-surrogate-key: func(
     surrogate-keys: string,
     purge-options: purge-options,
@@ -2328,6 +2336,8 @@ interface purge {
   /// This is similar to `purge-surrogate-key`, but on success, returns a
   /// [JSON purge response] containing an ASCII alphanumeric string identifying
   /// a purging.
+  ///
+  /// Despite the name, the `surrogate-keys` argument only holds one key.
   ///
   /// [JSON purge response]: https://developer.fastly.com/reference/api/purging/#purge-tag
   purge-surrogate-key-verbose: func(
@@ -2629,7 +2639,10 @@ interface cache {
   ) -> result<body, error>;
 
   /// Continues the lookup transaction from which the given busy handle was returned,
-  /// waiting for the leader transaction if request collapsed, and returns a cache handle.
+  /// as a cache handle instead of a busy handle.
+  ///
+  /// Note that cache handles also proceed asynchronously; the returned cache handle may not be ready
+  /// to read.
   await-entry: func(
     handle: pending-entry,
   ) -> result<entry, error>;


### PR DESCRIPTION
Changes:
 - `clone` methods on log endpoints and backends.
 - The `set-lookup-timeout` method on `extra-cache-override-details`.