### PR TITLE
Allow debugging integration tests in editor

### DIFF
--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -1,0 +1,14 @@
+{
+  "lsp": {
+    "rust-analyzer": {
+      "initialization_options": {
+        "linkedProjects": [
+          "Cargo.toml",
+          "test-fixtures/Cargo.toml",
+          "wasm_abi/adapter/Cargo.toml",
+          "cli/tests/trap-test/Cargo.toml"
+        ]
+      }
+    }
+  }
+}

--- a/cli/tests/integration/common.rs
+++ b/cli/tests/integration/common.rs
@@ -59,7 +59,13 @@ macro_rules! viceroy_test {
 /// ```
 /// let module_path = format!("{}/guest.wasm", RUST_FIXTURE_PATH);
 /// ```
-pub static RUST_FIXTURE_PATH: &str = "../test-fixtures/target/wasm32-wasip1/debug/";
+///
+/// Anchored on `CARGO_MANIFEST_DIR` so it resolves regardless of the process's current
+/// working directory, e.g. when launched directly by an editor/debugger.
+pub static RUST_FIXTURE_PATH: &str = concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../test-fixtures/target/wasm32-wasip1/debug/"
+);
 
 /// A shorthand for the path to our test fixtures' build artifacts for WAT tests.
 ///
@@ -69,7 +75,10 @@ pub static RUST_FIXTURE_PATH: &str = "../test-fixtures/target/wasm32-wasip1/debu
 /// ```
 /// let module_path = format!("{}/guest.wat", WAT_FIXTURE_PATH);
 /// ```
-pub static WAT_FIXTURE_PATH: &str = "../test-fixtures/";
+///
+/// Anchored on `CARGO_MANIFEST_DIR` so it resolves regardless of the process's current
+/// working directory, e.g. when launched directly by an editor/debugger.
+pub static WAT_FIXTURE_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../test-fixtures/");
 
 /// A catch-all error, so we can easily use `?` in test cases.
 pub type Error = Box<dyn std::error::Error + Send + Sync>;

--- a/cli/tests/trap-test/src/main.rs
+++ b/cli/tests/trap-test/src/main.rs
@@ -5,7 +5,13 @@ use {
 };
 
 /// A shorthand for the path to our test fixtures' build artifacts for Rust tests.
-const RUST_FIXTURE_PATH: &str = "../../../test-fixtures/target/wasm32-wasip1/debug/";
+///
+/// Anchored on `CARGO_MANIFEST_DIR` so it resolves regardless of the process's current
+/// working directory, e.g. when launched directly by an editor/debugger.
+const RUST_FIXTURE_PATH: &str = concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../../../test-fixtures/target/wasm32-wasip1/debug/"
+);
 
 /// A catch-all error, so we can easily use `?` in test cases.
 pub type Error = Box<dyn std::error::Error + Send + Sync>;
@@ -39,7 +45,10 @@ async fn fatal_error_traps_impl(adapt_core_wasm: bool) -> TestResult {
 
     let body = resp.into_body().read_into_string().await?;
     let needle = "Fatal error: [A fatal error occurred in the test-only implementation of header_values_get]";
-    assert!(body.contains(needle), "body missing expected string: {body}");
+    assert!(
+        body.contains(needle),
+        "body missing expected string: {body}"
+    );
 
     Ok(())
 }


### PR DESCRIPTION
Paths were dependent on current working directory, which broke debugging in Zed because it launched the process from within the target dir. Also adds configuration so rust-analyzer detects the extra crates.